### PR TITLE
Fix warnings when using FusionInventory

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -63,8 +63,10 @@ function plugin_init_formcreator ()
       $PLUGIN_HOOKS['add_javascript']['formcreator'][] = 'scripts/homepage.js';
    }
 
-   if ($_SESSION['glpiactiveprofile']['interface'] == 'helpdesk') {
-      $PLUGIN_HOOKS['add_javascript']['formcreator'][] = 'scripts/helpdesk-menu.js';
+   if (isset($_SESSION['glpiactiveprofile'])) {
+      if ($_SESSION['glpiactiveprofile']['interface'] == 'helpdesk') {
+         $PLUGIN_HOOKS['add_javascript']['formcreator'][] = 'scripts/helpdesk-menu.js';
+      }
    }
    $PLUGIN_HOOKS['add_javascript']['formcreator'][] = 'scripts/forms-validation.js.php';
 


### PR DESCRIPTION
requests from FusionInventory agents seems to not have $_SESSION['glpiactiveprofile']
