### PR TITLE
Fix error in validation for hidden fields with min/max length requirement

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -103,8 +103,7 @@ abstract class PluginFormcreatorField implements Field
 
    public function isRequired()
    {
-      $is_visible = PluginFormcreatorFields::isVisible($this->fields['id'], $this->fields['answer']);
-      return ($is_visible && $this->fields['required']);
+      return $this->fields['required'];
    }
 
 }

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -88,10 +88,6 @@ abstract class PluginFormcreatorField implements Field
 
    public function isValid($value)
    {
-      // If the field is not visible, don't check it's value
-      if (!PluginFormcreatorFields::isVisible($this->fields['id'], $this->fields['answer']))
-         return true;
-
       // If the field is required it can't be empty
       if ($this->isRequired() && empty($value)) {
          Session::addMessageAfterRedirect(

--- a/inc/fields/date-field.class.php
+++ b/inc/fields/date-field.class.php
@@ -44,10 +44,6 @@ class dateField extends PluginFormcreatorField
 
    public function isValid($value)
    {
-      // If the field is not visible, don't check it's value
-      if (!PluginFormcreatorFields::isVisible($this->fields['id'], $this->fields['answer']))
-         return true;
-
       // If the field is required it can't be empty
       if ($this->isRequired() && (strtotime($value) == '')) {
          Session::addMessageAfterRedirect(

--- a/inc/fields/datetime-field.class.php
+++ b/inc/fields/datetime-field.class.php
@@ -44,10 +44,6 @@ class datetimeField extends PluginFormcreatorField
 
    public function isValid($value)
    {
-      // If the field is not visible, don't check it's value
-      if (!PluginFormcreatorFields::isVisible($this->fields['id'], $this->fields['answer']))
-         return true;
-
       // If the field is required it can't be empty
       if ($this->isRequired() && (strtotime($value) == '')) {
          Session::addMessageAfterRedirect(

--- a/inc/fields/file-field.class.php
+++ b/inc/fields/file-field.class.php
@@ -23,9 +23,6 @@ class fileField extends PluginFormcreatorField
 
    public function isValid($value)
    {
-      // If the field is not visible, don't check it's value
-      if (!PluginFormcreatorFields::isVisible($this->fields['id'], $this->fields['answer'])) return true;
-
       // If the field is required it can't be empty
       if ($this->isRequired() && (empty($_FILES['formcreator_field_' . $this->fields['id']]['tmp_name'])
                                  || !is_file($_FILES['formcreator_field_' . $this->fields['id']]['tmp_name']))) {

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -930,7 +930,7 @@ class PluginFormcreatorForm extends CommonDBTM
             include_once ($filePath);
             if (class_exists($className)) {
                $obj = new $className($fields, $datas);
-               if (!$obj->isValid($datas[$id])) {
+               if (PluginFormcreatorFields::isVisible($id, $datas) && !$obj->isValid($datas[$id])) {
                   $valid = false;
                }
             }


### PR DESCRIPTION
Hello,

When submitting a form, if a hidden field has a min/max length requirement, the validation shouldn't check its length.

Example :

Take that form with two fields "chp 1" always visible, and "chp 2" always hidden unless "chp 1" equals a certain value.

![2016-04-22-113447_987x241_scrot](https://cloud.githubusercontent.com/assets/18532366/14741313/a4962c7c-0895-11e6-8b45-f334f974320f.png)

When you submit the empty form you get these errors :

![2016-04-22-113500_326x129_scrot](https://cloud.githubusercontent.com/assets/18532366/14741337/cf1e57da-0895-11e6-809b-de9c3ce97ade.png)

The first is correct, but the second shouldn't be here because the field "chp 2" is hidden.
This pull request correct that behaviour.