### PR TITLE
0.90/fix.encode title

### DIFF
--- a/inc/answer.class.php
+++ b/inc/answer.class.php
@@ -49,12 +49,12 @@ class PluginFormcreatorAnswer extends CommonDBChild
       foreach ($input as $key => $value) {
          if (is_array($value)) {
             foreach($value as $key2 => $value2) {
-               $input[$key][$key2] = plugin_formcreator_encode($value2);
+               $input[$key][$key2] = plugin_formcreator_encode($value2, false);
             }
          } elseif(is_array(json_decode($value))) {
             $value = json_decode($value);
             foreach($value as $key2 => $value2) {
-               $value[$key2] = plugin_formcreator_encode($value2);
+               $value[$key2] = plugin_formcreator_encode($value2, false);
             }
             // Verify the constant exits (included in PHP 5.4+)
             if (defined('JSON_UNESCAPED_UNICODE')) {
@@ -64,7 +64,7 @@ class PluginFormcreatorAnswer extends CommonDBChild
                $input[$key] = json_encode($value);
             }
          } else {
-            $input[$key] = plugin_formcreator_encode($value);
+            $input[$key] = plugin_formcreator_encode($value, false);
          }
       }
 

--- a/setup.php
+++ b/setup.php
@@ -155,10 +155,13 @@ function plugin_init_formcreator ()
  */
 function plugin_formcreator_encode($string)
 {
-   $string = stripcslashes($string);
-   $string = html_entity_decode($string, ENT_QUOTES, 'UTF-8');
-   $string = str_replace('&apos;', "'", $string);
-   $string = htmlentities($string, ENT_QUOTES, 'UTF-8');
+   $string = Html::clean(Html::entity_decode_deep($string));
+   $string = preg_replace('/\\r\\n/',' ',$string);
+   $string = preg_replace('/\\n/',' ',$string);
+   $string = preg_replace('/\\\\r\\\\n/',' ',$string);
+   $string = preg_replace('/\\\\n/',' ',$string);
+   $string = Toolbox::stripslashes_deep($string);
+   $string = Toolbox::addslashes_deep($string);
    return $string;
 }
 

--- a/setup.php
+++ b/setup.php
@@ -153,15 +153,22 @@ function plugin_init_formcreator ()
  * @param  String    $string  The string to encode
  * @return String             The encoded string
  */
-function plugin_formcreator_encode($string)
+function plugin_formcreator_encode($string, $mode_legacy=true)
 {
-   $string = Html::clean(Html::entity_decode_deep($string));
-   $string = preg_replace('/\\r\\n/',' ',$string);
-   $string = preg_replace('/\\n/',' ',$string);
-   $string = preg_replace('/\\\\r\\\\n/',' ',$string);
-   $string = preg_replace('/\\\\n/',' ',$string);
-   $string = Toolbox::stripslashes_deep($string);
-   $string = Toolbox::addslashes_deep($string);
+   if (!$mode_legacy) {
+      $string = Html::clean(Html::entity_decode_deep($string));
+      $string = preg_replace('/\\r\\n/',' ',$string);
+      $string = preg_replace('/\\n/',' ',$string);
+      $string = preg_replace('/\\\\r\\\\n/',' ',$string);
+      $string = preg_replace('/\\\\n/',' ',$string);
+      $string = Toolbox::stripslashes_deep($string);
+      $string = Toolbox::addslashes_deep($string);
+   } else {
+      $string = stripcslashes($string);
+      $string = html_entity_decode($string, ENT_QUOTES, 'UTF-8');
+      $string = str_replace('&apos;', "'", $string);
+      $string = htmlentities($string, ENT_QUOTES, 'UTF-8');
+   }
    return $string;
 }
 


### PR DESCRIPTION
Problem : 
Impossible to use specialchars (ie: é,à,è,ç, etc...) in business rules criterias after save answer and generate ticket.

Example of business rule : 
* Criteria : **Title** contents **Matériel**
* Action : **Category** assigned **Hardware**

Before fix : 
* answer value in DB for title : "Mat\&eacute;riel" (in UTF8)
* result of criteria, false ! ( **Mat\&eacute;riel** != **Matériel**)

After fix : 
* answer value in DB for title : "Matériel" (in UTF8)
* result of criteria, true ! ( **Matériel** == **Matériel**)

