### PR TITLE
Rewrite form validator relation

### DIFF
--- a/inc/fields/ldapselect-field.class.php
+++ b/inc/fields/ldapselect-field.class.php
@@ -53,7 +53,7 @@ class ldapselectField extends selectField
                   ldap_control_paged_result_response($ds, $result, $cookie);
                }
 
-           } while($cookie !== null && $cookie != '');
+            } while($cookie !== null && $cookie != '');
 
             asort($tab_values);
             return $tab_values;

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1003,10 +1003,10 @@ class PluginFormcreatorForm extends CommonDBTM
                         : $this->input['_validator_groups'];
          switch ($this->input['validation_required']) {
             case '1':
-               $validatorItemtype = 'user';
+               $validatorItemtype = 'User';
                break;
             case '2':
-               $validatorItemtype = 'group';
+               $validatorItemtype = 'Group';
                break;
          }
          foreach ($validators as $itemId) {

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -995,17 +995,18 @@ class PluginFormcreatorForm extends CommonDBTM
       $form_validator = new PluginFormcreatorForm_Validator();
       $form_validator->deleteByCriteria(array('plugin_formcreator_forms_id' => $this->getID()));
 
-      if ( (($this->input['validation_required'] == 1) && (!empty($this->input['_validator_users'])))
-            || (($this->input['validation_required'] == 2) && (!empty($this->input['_validator_groups']))) ) {
+      if ($this->input['validation_required'] == PluginFormcreatorForm_Validator::VALIDATION_USER
+          && !empty($this->input['_validator_users'])
+          || $this->input['validation_required'] == PluginFormcreatorForm_Validator::VALIDATION_GROUP
+          && !empty($this->input['_validator_groups'])) {
 
-         $validators = ($this->input['validation_required'] == 1)
-                        ? $this->input['_validator_users']
-                        : $this->input['_validator_groups'];
          switch ($this->input['validation_required']) {
-            case '1':
+            case PluginFormcreatorForm_Validator::VALIDATION_USER:
+               $validators = $this->input['_validator_users'];
                $validatorItemtype = 'User';
                break;
-            case '2':
+            case PluginFormcreatorForm_Validator::VALIDATION_GROUP:
+               $validators = $this->input['_validator_groups'];
                $validatorItemtype = 'Group';
                break;
          }
@@ -1279,11 +1280,12 @@ class PluginFormcreatorForm extends CommonDBTM
    {
       global $DB;
 
-      $section       = new PluginFormcreatorSection();
-      $question      = new PluginFormcreatorQuestion();
-      $target        = new PluginFormcreatorTarget();
-      $target_ticket = new PluginFormcreatorTargetTicket();
-      $tab_questions = array();
+      $section        = new PluginFormcreatorSection();
+      $question       = new PluginFormcreatorQuestion();
+      $target         = new PluginFormcreatorTarget();
+      $target_ticket  = new PluginFormcreatorTargetTicket();
+      $form_validator = new PluginFormcreatorForm_Validator();
+      $tab_questions  = array();
 
       // From datas
       $form_datas              = $this->fields;
@@ -1305,12 +1307,10 @@ class PluginFormcreatorForm extends CommonDBTM
       if (!$DB->query($query)) return false;
 
       // Form validators
-      $form_validator = new PluginFormcreatorForm_Validator();
       $rows = $form_validator->find("forms_id = $old_form_id");
       foreach($rows as $rowId => $row) {
          unset($row['id']);
          $row['plugin_formcreator_forms_id'] = $new_form_id;
-         $form_validator = new PluginFormcreatorForm_Validator();
          if (!$form_validator->add($row)) {
             return false;
          }

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1030,9 +1030,12 @@ class PluginFormcreatorForm extends CommonDBTM
       $found_sections = $sections->find('`plugin_formcreator_forms_id` = ' . $this->getID());
       foreach ($found_sections as $id => $fields) $tab_section[] = $id;
 
-      $questions         = new PluginFormcreatorQuestion();
-      $found_questions = $questions->find('`plugin_formcreator_sections_id` IN (' . implode(',', $tab_section) .')');
-
+      if (count($tab_section) < 1) {
+         $found_questions = array();
+      } else {
+         $questions         = new PluginFormcreatorQuestion();
+         $found_questions = $questions->find('`plugin_formcreator_sections_id` IN (' . implode(',', $tab_section) .')');
+      }
       // Validate form fields
       foreach ($found_questions as $id => $fields) {
          // If field was not post, it's value is empty

--- a/inc/form_validator.class.php
+++ b/inc/form_validator.class.php
@@ -1,0 +1,64 @@
+<?php
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+/**
+ * @since 0.90-1.5
+ */
+class PluginFormcreatorForm_Validator extends CommonDBRelation {
+
+      // From CommonDBRelation
+   static public $itemtype_1          = 'PluginFormcreatorForm';
+   static public $items_id_1          = 'plugin_formcreator_forms_id';
+
+   static public $itemtype_2          = 'itemtype';
+   static public $items_id_2          = 'items_id';
+   static public $checkItem_2_Rights  = self::HAVE_VIEW_RIGHT_ON_ITEM;
+
+   public static function install(Migration $migration)
+   {
+      global $DB;
+
+      $table = self::getTable();
+      if (!TableExists($table)) {
+         $query = "CREATE TABLE IF NOT EXISTS `$table` (
+                     `id`                          int(11) NOT NULL AUTO_INCREMENT,
+                     `plugin_formcreator_forms_id` int(11) NOT NULL,
+                     `itemtype`                    varchar(255) NOT NULL DEFAULT '',
+                     `items_id`                    int(11) NOT NULL,
+                     PRIMARY KEY (`id`),
+                     UNIQUE KEY `unicity` (`plugin_formcreator_forms_id`, `itemtype`, `items_id`)
+                  )
+                  ENGINE = MyISAM DEFAULT CHARACTER SET = utf8 COLLATE = utf8_unicode_ci;";
+         $DB->query($query) or die ($DB->error());
+      }
+
+      // Convert the old relation in glpi_plugin_formcreator_formvalidators table
+      if (TableExists('glpi_plugin_formcreator_formvalidators')) {
+         $table_form = PluginFormcreatorForm::getTable();
+         $old_table = 'glpi_plugin_formcreator_formvalidators';
+         $query = "INSERT INTO `$table` (`plugin_formcreator_forms_id`, `itemtype`, `items_id`)
+               SELECT
+                  `$old_table`.`forms_id`,
+                  IF(`validation_required` = '1', 'User', 'Group'),
+                  `$old_table`.`users_id`
+               FROM `$old_table`
+               LEFT JOIN `$table_form` ON (`$table_form`.`id` = `$old_table`.`forms_id`)
+               WHERE `validation_required` = '1' OR `validation_required` = '2'";
+         $DB->query($query) or die ($DB->error());
+         $migration->displayMessage('Backing up table glpi_plugin_formcreator_formvalidators');
+         $migration->renameTable('glpi_plugin_formcreator_formvalidators', 'glpi_plugin_formcreator_formvalidators_backup');
+      }
+   }
+
+   public static function uninstall()
+   {
+      global $DB;
+
+      $table = self::getTable();
+      $query = "DROP TABLE IF EXISTS `$table`";
+      return $DB->query($query) or die($DB->error());
+   }
+
+}

--- a/inc/form_validator.class.php
+++ b/inc/form_validator.class.php
@@ -16,6 +16,9 @@ class PluginFormcreatorForm_Validator extends CommonDBRelation {
    static public $items_id_2          = 'items_id';
    static public $checkItem_2_Rights  = self::HAVE_VIEW_RIGHT_ON_ITEM;
 
+   const VALIDATION_USER  = 1;
+   const VALIDATION_GROUP = 2;
+
    public static function install(Migration $migration)
    {
       global $DB;
@@ -41,11 +44,11 @@ class PluginFormcreatorForm_Validator extends CommonDBRelation {
          $query = "INSERT INTO `$table` (`plugin_formcreator_forms_id`, `itemtype`, `items_id`)
                SELECT
                   `$old_table`.`forms_id`,
-                  IF(`validation_required` = '1', 'User', 'Group'),
+                  IF(`validation_required` = '".self::VALIDATION_USER."', 'User', 'Group'),
                   `$old_table`.`users_id`
                FROM `$old_table`
                LEFT JOIN `$table_form` ON (`$table_form`.`id` = `$old_table`.`forms_id`)
-               WHERE `validation_required` = '1' OR `validation_required` = '2'";
+               WHERE `validation_required` > 1";
          $DB->query($query) or die ($DB->error());
          $migration->displayMessage('Backing up table glpi_plugin_formcreator_formvalidators');
          $migration->renameTable('glpi_plugin_formcreator_formvalidators', 'glpi_plugin_formcreator_formvalidators_backup');

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -232,7 +232,7 @@ class PluginFormcreatorFormanswer extends CommonDBChild
       if ($form->fields['validation_required'] == 1) {
          // Check the user is one of the users able to validate this form answer
          $form_validator = new PluginFormcreatorForm_Validator();
-         $rows = $form_validator->find("`forms_id` = '$formId' AND `itemtype = 'User' AND `items_id` = '$userId'", "", "1");
+         $rows = $form_validator->find("`plugin_formcreator_forms_id` = '$formId' AND `itemtype` = 'User' AND `items_id` = '$userId'", "", "1");
          $canValidate = (count($rows) > 0);
       } else if(($form->fields['validation_required'] == 2)) {
          // Check the user is member of at least one validator group for the form answers

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -243,7 +243,7 @@ class PluginFormcreatorFormanswer extends CommonDBChild
             $condition = "`glpi_groups`.`id` IN (
                SELECT `items_id`
                FROM `$table_form_validator`
-               WHERE `itemtype` = 'Group' AND forms_id` = '$formId'
+               WHERE `itemtype` = 'Group' AND `plugin_formcreator_forms_id` = '$formId'
             )";
             $groupList = Group_User::getUserGroups($userId, $condition);
             $canValidate = (count($groupList) > 0);

--- a/setup.php
+++ b/setup.php
@@ -1,7 +1,7 @@
 <?php
 global $CFG_GLPI;
 // Version of the plugin
-define('PLUGIN_FORMCREATOR_VERSION', "0.90-1.4-beta4");
+define('PLUGIN_FORMCREATOR_VERSION', "0.90-1.4-beta5");
 // Minimal GLPI version, inclusive
 define ("PLUGIN_FORMCREATOR_GLPI_MIN_VERSION", "0.85");
 // Maximum GLPI version, exclusive

--- a/tests/0010_Integration/Form_ValidatorTest.php
+++ b/tests/0010_Integration/Form_ValidatorTest.php
@@ -1,0 +1,55 @@
+<?php
+class Form_ValidatorTest extends SuperAdminTestCase {
+
+   public function setUp() {
+      parent::setUp();
+
+      $this->formData = array(
+            'entities_id'           => $_SESSION['glpiactive_entity'],
+            'name'                  => 'a form',
+            'description'           => 'form description',
+            'content'               => 'a content',
+            'is_active'             => 1,
+            'validation_required'   => 0
+      );
+
+      $this->groupData = array(
+            'entities_id'           => $_SESSION['glpiactive_entity'],
+            'completename'          => 'a group',
+      );
+   }
+
+   public function testInitCreateForm() {
+      $form = new PluginFormcreatorForm();
+      $formId = $form->add($this->formData);
+      $this->assertFalse($form->isNewItem());
+
+      return $form;
+   }
+
+   public function testInitCreateGroup() {
+      $group = new Group();
+      $group->import($this->groupData);
+
+      $this->assertFalse($group->isNewItem());
+
+      return $group;
+   }
+
+   /**
+    * @depends testInitCreateForm
+    * @depends testInitCreateGroup
+    * @param PluginFormcreatorForm $form
+    * @param Group $group
+    */
+   public function testCreateFormValidator(PluginFormcreatorForm $form, Group $group) {
+      $form_validator = new PluginFormcreatorForm_Validator();
+      $form_validator->add(array(
+            'itemtype'                    => $group::getType(),
+            'items_id'                    => $group->getID(),
+            'plugin_formcreator_forms_id' => $form->getID(),
+      ));
+
+      $this->assertFalse($form_validator->isNewItem());
+   }
+}

--- a/tests/0010_Integration/Form_ValidatorTest.php
+++ b/tests/0010_Integration/Form_ValidatorTest.php
@@ -10,7 +10,7 @@ class Form_ValidatorTest extends SuperAdminTestCase {
             'description'           => 'form description',
             'content'               => 'a content',
             'is_active'             => 1,
-            'validation_required'   => 2
+            'validation_required'   => PluginFormcreatorForm_Validator::VALIDATION_GROUP
       );
 
       $this->formDataForUser = array(
@@ -19,7 +19,7 @@ class Form_ValidatorTest extends SuperAdminTestCase {
             'description'           => 'form description',
             'content'               => 'a content',
             'is_active'             => 1,
-            'validation_required'   => 1
+            'validation_required'   => PluginFormcreatorForm_Validator::VALIDATION_USER
       );
       $this->groupData = array(
             'entities_id'           => $_SESSION['glpiactive_entity'],

--- a/tests/0010_Integration/Form_ValidatorTest.php
+++ b/tests/0010_Integration/Form_ValidatorTest.php
@@ -4,27 +4,27 @@ class Form_ValidatorTest extends SuperAdminTestCase {
    public function setUp() {
       parent::setUp();
 
-      $this->formData = array(
+      $this->formDataForGroup = array(
             'entities_id'           => $_SESSION['glpiactive_entity'],
-            'name'                  => 'a form',
+            'name'                  => 'a form for group validator',
             'description'           => 'form description',
             'content'               => 'a content',
             'is_active'             => 1,
-            'validation_required'   => 0
+            'validation_required'   => 2
       );
 
+      $this->formDataForUser = array(
+            'entities_id'           => $_SESSION['glpiactive_entity'],
+            'name'                  => 'a form for user validator',
+            'description'           => 'form description',
+            'content'               => 'a content',
+            'is_active'             => 1,
+            'validation_required'   => 1
+      );
       $this->groupData = array(
             'entities_id'           => $_SESSION['glpiactive_entity'],
             'completename'          => 'a group',
       );
-   }
-
-   public function testInitCreateForm() {
-      $form = new PluginFormcreatorForm();
-      $formId = $form->add($this->formData);
-      $this->assertFalse($form->isNewItem());
-
-      return $form;
    }
 
    public function testInitCreateGroup() {
@@ -37,19 +37,43 @@ class Form_ValidatorTest extends SuperAdminTestCase {
    }
 
    /**
-    * @depends testInitCreateForm
     * @depends testInitCreateGroup
-    * @param PluginFormcreatorForm $form
-    * @param Group $group
+    * @return PluginFormcreatorForm
     */
-   public function testCreateFormValidator(PluginFormcreatorForm $form, Group $group) {
-      $form_validator = new PluginFormcreatorForm_Validator();
-      $form_validator->add(array(
-            'itemtype'                    => $group::getType(),
-            'items_id'                    => $group->getID(),
-            'plugin_formcreator_forms_id' => $form->getID(),
-      ));
+   public function testCreateFormForGroup(Group $group) {
+      $this->formDataForGroup = $this->formDataForGroup + array(
+            '_validator_groups'     => array($group->getID())
+      );
+      $form = new PluginFormcreatorForm();
+      $formId = $form->add($this->formDataForGroup);
+      $this->assertFalse($form->isNewItem());
 
+      $form_validator = new PluginFormcreatorForm_Validator();
+      $form_validator->getFromDBForItems($form, $group);
       $this->assertFalse($form_validator->isNewItem());
+
+      return $form;
+   }
+
+   /**
+    * @return PluginFormcreatorForm
+    */
+   public function testCreateFormForUser() {
+      $user = new User;
+      $user->getFromDBbyName('tech');
+      $this->assertFalse($user->isNewItem());
+
+      $this->formDataForUser = $this->formDataForUser + array(
+            '_validator_users'     => array($user->getID())
+      );
+      $form = new PluginFormcreatorForm();
+      $formId = $form->add($this->formDataForUser);
+      $this->assertFalse($form->isNewItem());
+
+      $form_validator = new PluginFormcreatorForm_Validator();
+      $form_validator->getFromDBForItems($form, $user);
+      $this->assertFalse($form_validator->isNewItem());
+
+      return $form;
    }
 }


### PR DESCRIPTION
A table in the plugin is a relation, but is managed by hardcoded requests only.

- change name of the table to follow GLPi's naming conventions
- Create a class and use it in the whole plugin
- migrate data from the old table to the new one backup the old table)
- add some unit  tests

TODO Add more unit tests before merge