### PR TITLE
lower compatibility constraint

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -3,7 +3,7 @@ global $CFG_GLPI;
 // Version of the plugin
 define('PLUGIN_FORMCREATOR_VERSION', "0.90-1.4-beta7");
 // Minimal GLPI version, inclusive
-define ("PLUGIN_FORMCREATOR_GLPI_MIN_VERSION", "9.1");
+define ("PLUGIN_FORMCREATOR_GLPI_MIN_VERSION", "0.85");
 // Maximum GLPI version, exclusive
 define ("PLUGIN_FORMCREATOR_GLPI_MAX_VERSION", "9.2");
 


### PR DESCRIPTION
compatibility code added, then no longer need to force GLPi 9.1 yet