### PR TITLE
display form answers in forms admin

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -121,7 +121,13 @@ function plugin_formcreator_addDefaultWhere($itemtype)
          break;
 
       case "PluginFormcreatorForm_Answer" :
-         $condition = plugin_formcreator_getCondition($itemtype);
+         if (isset($_SESSION['formcreator']['form_search_answers'])
+             && $_SESSION['formcreator']['form_search_answers']) {
+            $condition = "`$table`.`".PluginFormcreatorForm_Answer::$items_id."` = ".
+                         $_SESSION['formcreator']['form_search_answers'];
+         } else {
+            $condition = plugin_formcreator_getCondition($itemtype);
+         }
          break;
    }
    return $condition;
@@ -252,4 +258,26 @@ function plugin_formcreator_giveItem($itemtype, $ID, $data, $num) {
    }
 
    return "";
+}
+
+
+function plugin_formcreator_dynamicReport($params) {
+   switch ($params['item_type']) {
+      case "PluginFormcreatorForm_Answer";
+         if ($url = parse_url($_SERVER['HTTP_REFERER'])) {
+            if (strpos($url['path'],
+                       Toolbox::getItemTypeFormURL("PluginFormcreatorForm")) !== false) {
+               parse_str($url['query'], $query);
+               if (isset($query['id'])) {
+                  $item = new PluginFormcreatorForm;
+                  $item->getFromDB($query['id']);
+                  PluginFormcreatorForm_Answer::showForForm($item, $params);
+                  return true;
+               }
+            }
+         }
+         break;
+   }
+
+   return false;
 }

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -493,6 +493,7 @@ class PluginFormcreatorForm extends CommonDBTM
       $this->addStandardTab('PluginFormcreatorForm_Profile', $ong, $options);
       $this->addStandardTab('PluginFormcreatorTarget', $ong, $options);
       $this->addStandardTab(__CLASS__, $ong, $options);
+      $this->addStandardTab('PluginFormcreatorForm_Answer', $ong, $options);
       return $ong;
    }
 


### PR DESCRIPTION
This PR adds:
- A new tab in form administration which displays the relative answer
- use Search engine for that
- use a Session var to tweak the display

A screenshot: 
![image](https://cloud.githubusercontent.com/assets/418844/21104260/22d2947e-c086-11e6-9411-d26bbc805494.png)


Some things to add before merge
- [ ] manage answers values in searchoptions
- [ ] check pagination