### PR TITLE
WIP : Hotfix/import export question condition

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1748,6 +1748,8 @@ class PluginFormcreatorForm extends CommonDBTM
             PluginFormcreatorSection::import($forms_id, $section);
          }
       }
+      // Save all question conditions stored in memory
+      PluginFormcreatorQuestion_Condition::import(0, array(), false);
 
       // import form's validators
       if ($forms_id

--- a/inc/question_condition.class.php
+++ b/inc/question_condition.class.php
@@ -12,23 +12,37 @@ class PluginFormcreatorQuestion_Condition extends CommonDBChild
     * @param  array   $condition the condition data (match the condition table)
     * @return integer the condition's id
     */
-   public static function import($questions_id = 0, $condition = array()) {
-      $item = new self;
+   public static function import($questions_id = 0, $condition = array(), $storeOnly = true) {
+      static $conditionsToImport = array();
 
-      $condition['plugin_formcreator_questions_id'] = $questions_id;
+      if ($storeOnly) {
+         $condition['plugin_formcreator_questions_id'] = $questions_id;
 
-      if ($conditions_id = plugin_formcreator_getFromDBByField($item, 'uuid', $condition['uuid'])) {
-         // add id key
-         $condition['id'] = $conditions_id;
+         $item = new static();
+         if ($conditions_id = plugin_formcreator_getFromDBByField($item, 'uuid', $condition['uuid'])) {
+            // add id key
+            $condition['id'] = $conditions_id;
 
-         // update condition
-         $item->update($condition);
+            // prepare update condition
+            $conditionsToImport[] = $condition;
+         } else {
+            // prepare create condition
+            $conditionsToImport[] = $condition;
+         }
       } else {
-         //create condition
-         $conditions_id = $item->add($condition);
+         // Assumes all questions needed for the stored conditions exist
+         foreach ($conditionsToImport as $condition) {
+            $item = new static();
+            $question = new PluginFormcreatorQuestion();
+            $condition['show_field'] = plugin_formcreator_getFromDBByField($question, 'uuid', $condition['show_field']);
+            if (isset($condition['id'])) {
+               $item->update($condition);
+            } else {
+               $item->add($condition);
+            }
+         }
+         $conditionsToImport = array();
       }
-
-      return $conditions_id;
    }
 
    /**
@@ -40,7 +54,10 @@ class PluginFormcreatorQuestion_Condition extends CommonDBChild
          return false;
       }
 
+      $question = new PluginFormcreatorQuestion();
+      $question->getFromDB($this->fields['show_field']);
       $condition = $this->fields;
+      $condition['show_field'] = $question->getField('uuid');
 
       unset($condition['id'],
             $condition['plugin_formcreator_questions_id']);

--- a/inc/section.class.php
+++ b/inc/section.class.php
@@ -261,6 +261,13 @@ class PluginFormcreatorSection extends CommonDBChild
 
       if ($sections_id
           && isset($section['_questions'])) {
+         // sort questions by order
+         usort($section['_questions'], function ($a, $b) {
+            if ($a['order'] == $b['order']) return 0;
+               return ($a['order'] < $b['order']) ? -1 : 1;
+            }
+         );
+
          foreach($section['_questions'] as $question) {
             PluginFormcreatorQuestion::import($sections_id, $question);
          }


### PR DESCRIPTION
- replace question Id in question condition by its uuid (column show_field)
- keep in memory question conditions instead of storing them in DB
- add a call to save them in DB after processing of all questions of a form

Also fix order of questions in import process (observed import in reverse order, making them displayed in reverse order).

I found the value returned by question_conditoin::import() is never used. If this also occurs for import() in other itemtypes, I think we should remove it too (cor consistency).

