### PR TITLE
repair class name consistency for notifications

### DIFF
--- a/inc/notificationtargetform_answer.class.php
+++ b/inc/notificationtargetform_answer.class.php
@@ -1,6 +1,6 @@
 <?php
 
-class PluginFormcreatorNotificationTargetFormanswer extends NotificationTarget
+class PluginFormcreatorNotificationTargetForm_answer extends NotificationTarget
 {
    const AUTHOR   = 101;
    const APPROVER = 102;


### PR DESCRIPTION
renaming PluginFormcreatorFormanswer to PluginFormcreatorForm_answer broke notification setup.

Note the filename change

see #392 