### PR TITLE
fix #414 : slash lost problem in form tiles (service catalog)

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -648,14 +648,13 @@ class PluginFormcreatorForm extends CommonDBTM
       $formList = array();
       if ($DB->numrows($result_forms) > 0) {
          while ($form = $DB->fetch_array($result_forms)) {
-            $formDescription = plugin_formcreator_encode($form['description']);
             $formList[] = [
                   'id'           => $form['id'],
                   'name'         => $form['name'],
-                  'description'  => $formDescription,
+                  'description'  => $form['description'],
                   'type'         => 'form',
                   'usage_count'  => $form['usage_count'],
-                  'is_default'   => $form['is_default']?"true":"false"
+                  'is_default'   => $form['is_default'] ? "true" : "false"
             ];
          }
       }


### PR DESCRIPTION
see #414 

Now a form time renders like this

![image](https://cloud.githubusercontent.com/assets/14139801/21638527/003524c0-d26c-11e6-9e61-cc6b6da69efc.png)

![image](https://cloud.githubusercontent.com/assets/14139801/21761761/7ec8caf2-d655-11e6-8a7a-aae8abced2a4.png)
