### PR TITLE
don't die without logging a backtrace when an upgrade error occurs

### DIFF
--- a/inc/answer.class.php
+++ b/inc/answer.class.php
@@ -63,11 +63,11 @@ class PluginFormcreatorAnswer extends CommonDBChild
                   ENGINE = MyISAM
                   DEFAULT CHARACTER SET = utf8
                   COLLATE = utf8_unicode_ci";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       } else {
          // Update field type from previous version (Need answer to be text since text can be WYSIWING).
          $query = "ALTER TABLE  `$table` CHANGE  `answer`  `answer` text;";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
          /**
           * Migration of special chars from previous versions
@@ -81,7 +81,7 @@ class PluginFormcreatorAnswer extends CommonDBChild
             $query_update = "UPDATE `$table` SET
                                `answer` = '".plugin_formcreator_encode($line['answer'])."'
                              WHERE `id` = ".$line['id'];
-            $DB->query($query_update) or die ($DB->error());
+            $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
          }
 
          //rename foreign key, to match table plugin_formcreator_forms_answers name

--- a/inc/category.class.php
+++ b/inc/category.class.php
@@ -149,7 +149,7 @@ class PluginFormcreatorCategory extends CommonTreeDropdown
                      INDEX `knowbaseitemcategories_id` (`knowbaseitemcategories_id`),
                      INDEX `name` (`name`)
                   ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-         $DB->query($query) or die($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       }
 
       // Migration from previous version
@@ -173,7 +173,7 @@ class PluginFormcreatorCategory extends CommonTreeDropdown
                             `name`    = '".plugin_formcreator_encode($line['name'])."',
                             `comment` = '".plugin_formcreator_encode($line['comment'])."'
                           WHERE `id` = ".$line['id'];
-         $DB->query($query_update) or die ($DB->error());
+         $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
       }
 
       /**
@@ -204,6 +204,6 @@ class PluginFormcreatorCategory extends CommonTreeDropdown
       global $DB;
 
       $query = "DROP TABLE IF EXISTS `".getTableForItemType(__CLASS__)."`";
-      return $DB->query($query) or die($DB->error());
+      return $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
    }
 }

--- a/inc/entityconfig.class.php
+++ b/inc/entityconfig.class.php
@@ -181,7 +181,7 @@ class PluginFormcreatorEntityconfig extends CommonDBTM {
                   ENGINE = MyISAM
                   DEFAULT CHARACTER SET = utf8
                   COLLATE = utf8_unicode_ci;";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       } else {
 
       }
@@ -191,7 +191,7 @@ class PluginFormcreatorEntityconfig extends CommonDBTM {
             WHERE `id` NOT IN (
                SELECT `id` FROM `$table`
             )";
-      $result = $DB->query($query) or die ($DB->error());
+      $result = $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       while ($row = $DB->fetch_assoc($result)) {
          $entityConfig = new self();
          $entityConfig->add([

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1153,12 +1153,12 @@ class PluginFormcreatorForm extends CommonDBTM
 
       // Create default request type
       $query  = "SELECT id FROM `glpi_requesttypes` WHERE `name` LIKE 'Formcreator';";
-      $result = $DB->query($query) or die ($DB->error());
+      $result = $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       if ($DB->numrows($result) > 0) {
          list($requesttype) = $DB->fetch_array($result);
       } else {
          $query = "INSERT INTO `glpi_requesttypes` SET `name` = 'Formcreator';";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          $requesttype = $DB->insert_id();
       }
 
@@ -1191,7 +1191,7 @@ class PluginFormcreatorForm extends CommonDBTM
                   ENGINE = MyISAM
                   DEFAULT CHARACTER SET = utf8
                   COLLATE = utf8_unicode_ci;";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       }
 
       // Migration from previous version
@@ -1230,7 +1230,7 @@ class PluginFormcreatorForm extends CommonDBTM
                             `description` = '" . plugin_formcreator_encode($line['description']) . "',
                             `content`     = '" . plugin_formcreator_encode($line['content']) . "'
                           WHERE `id` = " . (int) $line['id'];
-         $DB->query($query_update) or die ($DB->error());
+         $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
       }
 
       /**
@@ -1248,7 +1248,7 @@ class PluginFormcreatorForm extends CommonDBTM
 
       // Re-add FULLTEXT index
       $query = "ALTER TABLE `glpi_plugin_formcreator_forms` ADD FULLTEXT INDEX `Search` (`name`, `description`)";
-      $DB->query($query) or die ($DB->error());
+      $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
       $migration->addField($table, 'usage_count', 'integer', array('after' => 'validation_required',
                                                                    'value' => '0'));
@@ -1269,7 +1269,7 @@ class PluginFormcreatorForm extends CommonDBTM
                   (NULL, '" . __CLASS__ . "', 7, 4, 0),
                   (NULL, '" . __CLASS__ . "', 8, 5, 0),
                   (NULL, '" . __CLASS__ . "', 9, 6, 0);";
-      $DB->query($query) or die ($DB->error());
+      $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
 
       // add uuid to forms

--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -841,7 +841,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
          $itemTicket_table = Item_Ticket::getTable();
          $itemtype = __CLASS__;
          $query = "UPDATE `$itemTicket_table` SET `itemtype` = '$itemtype' WHERE `itemtype` = 'PluginFormcreatorFormanswer'";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       }
 
       if (!TableExists($table)) {
@@ -865,7 +865,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
                   ENGINE = MyISAM
                   DEFAULT CHARACTER SET = utf8
                   COLLATE = utf8_unicode_ci";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       } else {
          /**
           * Migration of special chars from previous versions
@@ -879,18 +879,18 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
             $query_update = "UPDATE `$table` SET
                                `comment` = '" . plugin_formcreator_encode($line['comment']) . "'
                              WHERE `id` = " . $line['id'];
-            $DB->query($query_update) or die ($DB->error());
+            $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
          }
 
          if (!FieldExists($table, 'name')) {
             $query_update = 'ALTER TABLE `$table` ADD `name` VARCHAR(255) NOT NULL AFTER `id`;';
-            $DB->query($query_update) or die ($DB->error());
+            $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
          }
 
          // valdiator_id should not be set for waiting form answers
          $query = "UPDATE $table
                SET `validator_id` = '0' WHERE `status`='waiting'";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       }
 
       // Create standard search options
@@ -900,7 +900,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
                (NULL, '" . __CLASS__ . "', 4, 4, 0),
                (NULL, '" . __CLASS__ . "', 5, 5, 0),
                (NULL, '" . __CLASS__ . "', 6, 6, 0);";
-      $DB->query($query) or die ($DB->error());
+      $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
       $migration->addKey($table, 'plugin_formcreator_forms_id');
 

--- a/inc/form_profile.class.php
+++ b/inc/form_profile.class.php
@@ -107,7 +107,7 @@ class PluginFormcreatorForm_Profile extends CommonDBRelation
                      UNIQUE KEY `unicity` (`plugin_formcreator_forms_id`,
                                            `profiles_id`)
                   ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-         $DB->query($query) or die($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       }
 
       // change fk for profiles
@@ -147,7 +147,7 @@ class PluginFormcreatorForm_Profile extends CommonDBRelation
       global $DB;
 
       $query = "DROP TABLE IF EXISTS `".getTableForItemType(__CLASS__)."`";
-      return $DB->query($query) or die($DB->error());
+      return $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
    }
 
    /**

--- a/inc/form_validator.class.php
+++ b/inc/form_validator.class.php
@@ -52,7 +52,7 @@ class PluginFormcreatorForm_Validator extends CommonDBRelation {
                      UNIQUE KEY `unicity` (`plugin_formcreator_forms_id`, `itemtype`, `items_id`)
                   )
                   ENGINE = MyISAM DEFAULT CHARACTER SET = utf8 COLLATE = utf8_unicode_ci;";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       }
 
       // Convert the old relation in glpi_plugin_formcreator_formvalidators table
@@ -67,7 +67,7 @@ class PluginFormcreatorForm_Validator extends CommonDBRelation {
                FROM `$old_table`
                LEFT JOIN `$table_form` ON (`$table_form`.`id` = `$old_table`.`forms_id`)
                WHERE `validation_required` > 1";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          $migration->displayMessage('Backing up table glpi_plugin_formcreator_formvalidators');
          $migration->renameTable('glpi_plugin_formcreator_formvalidators', 'glpi_plugin_formcreator_formvalidators_backup');
       }
@@ -92,7 +92,7 @@ class PluginFormcreatorForm_Validator extends CommonDBRelation {
 
       $table = self::getTable();
       $query = "DROP TABLE IF EXISTS `$table`";
-      return $DB->query($query) or die($DB->error());
+      return $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
    }
 
    /**

--- a/inc/header.class.php
+++ b/inc/header.class.php
@@ -129,7 +129,7 @@ class PluginFormcreatorHeader extends CommonDropdown
                      PRIMARY KEY (`id`),
                      KEY `name` (`name`)
                      ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-         $DB->query($query) or die($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       }
 
       // Migration from previous version
@@ -150,6 +150,6 @@ class PluginFormcreatorHeader extends CommonDropdown
       global $DB;
 
       $query = "DROP TABLE IF EXISTS `".getTableForItemType(__CLASS__)."`";
-      return $DB->query($query) or die($DB->error());
+      return $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
    }
 }

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -25,7 +25,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
                      (NULL, '$cls', 7, 6, 0),
                      (NULL, '$cls', 8, 7, 0)
                      ";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       }
 
       // create view who merge tickets and formanswers
@@ -75,7 +75,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
          WHERE `tic`.`is_deleted` = 0
          GROUP BY `original_id`
          HAVING COUNT(`itic`.`items_id`) <= 1";
-      $DB->query($query) or die ($DB->error());
+      $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
    }
 
    /**

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -655,7 +655,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
                   ENGINE = MyISAM
                   DEFAULT CHARACTER SET = utf8
                   COLLATE = utf8_unicode_ci";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
          // Create questions conditions table (since 0.85-1.1)
          $query = "CREATE TABLE IF NOT EXISTS `glpi_plugin_formcreator_questions_conditions` (
@@ -672,7 +672,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
                   ENGINE = MyISAM
                   DEFAULT CHARACTER SET = utf8
                   COLLATE = utf8_unicode_ci";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
       } else {
          // Migration 0.83-1.0 => 0.85-1.0
@@ -693,10 +693,10 @@ class PluginFormcreatorQuestion extends CommonDBChild
                       ADD `regex` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
                       CHANGE `content` `description` text COLLATE utf8_unicode_ci NOT NULL,
                       CHANGE `position` `order` int(11) NOT NULL DEFAULT '0';";
-            $DB->query($query) or die ($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
             // order start from 1 instead of 0
-            $DB->query("UPDATE `$table` SET `order` = `order` + 1;") or die ($DB->error());
+            $DB->query("UPDATE `$table` SET `order` = `order` + 1;") or plugin_formcrerator_upgrade_error($migration);
 
             // Match new type
             $query  = "SELECT `id`, `type`, `data`, `option`
@@ -800,7 +800,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
                                   `regex`          = '" . $regex . "',
                                   `required`       = " . (int) $required . "
                                WHERE `id` = " . $line['id'];
-               $DB->query($query_udate) or die ($DB->error());
+               $DB->query($query_udate) or plugin_formcrerator_upgrade_error($migration);
             }
 
             $query = "ALTER TABLE `$table`
@@ -808,7 +808,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
                       DROP `data`,
                       DROP `option`,
                       DROP `plugin_formcreator_forms_id`;";
-            $DB->query($query) or die ($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          }
 
          // Migration 0.85-1.0 => 0.85-1.1
@@ -819,7 +819,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
                $query = "ALTER TABLE  `glpi_plugin_formcreator_questions`
                          CHANGE `plugin_formcreator_sections_id` `plugin_formcreator_sections_id` INT NOT NULL,
                          ADD `show_rule` enum('always','hidden','shown') NOT NULL DEFAULT 'always'";
-               $DB->query($query) or die ($DB->error());
+               $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
             }
 
             // Create new table for conditionnal show of questions
@@ -837,7 +837,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
                   ENGINE = MyISAM
                   DEFAULT CHARACTER SET = utf8
                   COLLATE = utf8_unicode_ci";
-            $DB->query($query) or die ($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
             // Migrate date from "questions" table to "questions_conditions" table
             $query  = "SELECT `id`, `show_type`, `show_field`, `show_condition`, `show_value`
@@ -870,14 +870,14 @@ class PluginFormcreatorQuestion extends CommonDBChild
                $query_udate = "UPDATE `glpi_plugin_formcreator_questions` SET
                                  `show_rule` = '$show_rule'
                                WHERE `id` = " . $line['id'];
-               $DB->query($query_udate) or die ($DB->error());
+               $DB->query($query_udate) or plugin_formcrerator_upgrade_error($migration);
 
                $query_udate = "INSERT INTO `glpi_plugin_formcreator_questions_conditions` SET
                                   `plugin_formcreator_questions_id` = {$line['id']},
                                   `show_field`     = $show_field,
                                   `show_condition` = '$show_condition',
                                   `show_value`     = '" . Toolbox::addslashes_deep($line['show_value']) . "'";
-               $DB->query($query_udate) or die ($DB->error());
+               $DB->query($query_udate) or plugin_formcrerator_upgrade_error($migration);
             }
 
             // Delete old fields
@@ -886,7 +886,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
                       DROP `show_field`,
                       DROP `show_condition`,
                       DROP `show_value`;";
-            $DB->query($query) or die ($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          }
 
          /**
@@ -905,7 +905,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
                                `default_values` = '" . addslashes(plugin_formcreator_encode($line['default_values'])) . "',
                                `description`    = '" . addslashes(plugin_formcreator_encode($line['description'])) . "'
                              WHERE `id` = " . $line['id'];
-            $DB->query($query_update) or die ($DB->error());
+            $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
          }
 
          // Migrate "question_conditions" table
@@ -916,7 +916,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
             $query_update = "UPDATE `glpi_plugin_formcreator_questions_conditions` SET
                                `show_value` = '" . plugin_formcreator_encode($line['show_value']) . "'
                              WHERE `id` = " . (int) $line['id'];
-            $DB->query($query_update) or die ($DB->error());
+            $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
          }
 
          /**
@@ -933,7 +933,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
 
          // Re-add FULLTEXT index
          $query = "ALTER TABLE `$table` ADD FULLTEXT INDEX `Search` (`name`, `description`)";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
          // add uuid to questions
          if (!FieldExists($table, 'uuid', false)) {

--- a/inc/section.class.php
+++ b/inc/section.class.php
@@ -64,7 +64,7 @@ class PluginFormcreatorSection extends CommonDBChild
                   ENGINE = MyISAM
                   DEFAULT CHARACTER SET = utf8
                   COLLATE = utf8_unicode_ci;";
-         $DB->query($query) or die ($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       } else {
          /**
           * Migration of special chars from previous versions
@@ -78,7 +78,7 @@ class PluginFormcreatorSection extends CommonDBChild
             $query_update = "UPDATE `$table` SET
                                `name` = '".plugin_formcreator_encode($line['name'])."'
                              WHERE `id` = ".$line['id'];
-            $DB->query($query_update) or die ($DB->error());
+            $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
          }
       }
 

--- a/inc/target.class.php
+++ b/inc/target.class.php
@@ -210,7 +210,7 @@ class PluginFormcreatorTarget extends CommonDBTM
                      PRIMARY KEY (`id`),
                      INDEX `plugin_formcreator_forms_id` (`plugin_formcreator_forms_id`)
                   ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-         $DB->query($query) or die($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
       // Migration from previous version
       } else{
@@ -240,7 +240,7 @@ class PluginFormcreatorTarget extends CommonDBTM
                       FROM `glpi_plugin_formcreator_targets` t, `glpi_plugin_formcreator_forms` f
                       WHERE f.`id` = t.`plugin_formcreator_forms_id`
                       GROUP BY t.`urgency`, t.`priority`, t.`itilcategories_id`, t.`type`, f.`entities_id`";
-            $result = $DB->query($query) or die($DB->error());
+            $result = $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
             $i = 0;
             while ($ligne = $DB->fetch_array($result)) {
@@ -347,7 +347,7 @@ class PluginFormcreatorTarget extends CommonDBTM
                   $query_update = "UPDATE `$table_targetticket` SET
                                      `comment` = '".plugin_formcreator_encode($line['comment'])."'
                                    WHERE `id` = ".$line['id'];
-                  $DB->query($query_update) or die ($DB->error());
+                  $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
                }
             }
          }
@@ -376,7 +376,7 @@ class PluginFormcreatorTarget extends CommonDBTM
       global $DB;
 
       $query = "DROP TABLE IF EXISTS `".getTableForItemType(__CLASS__)."`";
-      return $DB->query($query) or die($DB->error());
+      return $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
    }
 
    /**

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -1155,7 +1155,7 @@ EOS;
 
       // Get default request type
       $query   = "SELECT id FROM `glpi_requesttypes` WHERE `name` LIKE 'Formcreator';";
-      $result  = $DB->query($query) or die ($DB->error());
+      $result  = $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       list($requesttypes_id) = $DB->fetch_array($result);
 
       $datas['requesttypes_id'] = $requesttypes_id;
@@ -1612,7 +1612,7 @@ EOS;
                      PRIMARY KEY (`id`),
                      INDEX `tickettemplates_id` (`tickettemplates_id`)
                   ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
-         $DB->query($query) or die($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       } else {
          if(!FieldExists($table, 'due_date_rule', false)) {
             $query = "ALTER TABLE `$table`
@@ -1621,7 +1621,7 @@ EOS;
                         ADD `due_date_value` TINYINT NULL DEFAULT NULL,
                         ADD `due_date_period` ENUM('minute', 'hour', 'day', 'month') NULL DEFAULT NULL,
                         ADD `validation_followup` BOOLEAN NOT NULL DEFAULT TRUE;";
-            $DB->query($query) or die($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          }
 
          // Migration to Formcreator 0.90-1.4
@@ -1629,7 +1629,7 @@ EOS;
             $query = "ALTER TABLE `$table`
                         ADD `destination_entity` ENUM($enum_destination_entity) NOT NULL DEFAULT 'requester',
                         ADD `destination_entity_value` int(11) NULL DEFAULT NULL;";
-            $DB->query($query) or die($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          } else {
             $current_enum_destination_entity = PluginFormcreatorCommon::getEnumValues($table, 'destination_entity');
             if (count($current_enum_destination_entity) != count(self::getEnumDestinationEntity())) {
@@ -1637,7 +1637,7 @@ EOS;
                            CHANGE COLUMN `destination_entity` `destination_entity`
                            ENUM($enum_destination_entity)
                            NOT NULL DEFAULT 'requester'";
-               $DB->query($query) or die($DB->error());
+               $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
             }
          }
 
@@ -1646,13 +1646,13 @@ EOS;
                          ADD `tag_type` ENUM($enum_tag_type) NOT NULL DEFAULT 'none',
                          ADD `tag_questions` VARCHAR(255) NOT NULL,
                          ADD `tag_specifics` VARCHAR(255) NOT NULL;";
-            $DB->query($query) or die($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          }
 
          if (!FieldExists($table, 'urgency_rule', false)) {
             $query = "ALTER TABLE `$table`
             ADD `urgency_rule` ENUM($enum_urgency_rule) NOT NULL DEFAULT 'none' AFTER `due_date_period`;";
-            $DB->query($query) or die($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
 
          } else {
             $current_enum_destination_entity = PluginFormcreatorCommon::getEnumValues($table, 'urgency_rule');
@@ -1661,7 +1661,7 @@ EOS;
                CHANGE COLUMN `urgency_rule` `urgency_rule`
                ENUM($enum_urgency_rule)
                NOT NULL DEFAULT 'none'";
-               $DB->query($query) or die($DB->error());
+               $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
             }
          }
          $migration->addField($table, 'urgency_question', 'integer', array('after' => 'urgency_rule'));
@@ -1677,7 +1677,7 @@ EOS;
       global $DB;
 
       $query = "DROP TABLE IF EXISTS `" . getTableForItemType(__CLASS__) . "`";
-      return $DB->query($query) or die($DB->error());
+      return $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
    }
 
    /**

--- a/inc/targetticket_actor.class.php
+++ b/inc/targetticket_actor.class.php
@@ -44,7 +44,7 @@ class PluginFormcreatorTargetTicket_Actor extends CommonDBTM
                     PRIMARY KEY (`id`),
                     INDEX `plugin_formcreator_targettickets_id` (`plugin_formcreator_targettickets_id`)
                   ) ENGINE=MyISAM DEFAULT CHARSET=utf8  COLLATE=utf8_unicode_ci";
-         $DB->query($query) or die($DB->error());
+         $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
       } else {
          $current_enum_actor_type = PluginFormcreatorCommon::getEnumValues($table, 'actor_type');
          if (count($current_enum_actor_type) != count(self::getEnumActorType())) {
@@ -52,7 +52,7 @@ class PluginFormcreatorTargetTicket_Actor extends CommonDBTM
             CHANGE COLUMN `actor_type` `actor_type`
             ENUM($enum_actor_type)
             NOT NULL";
-            $DB->query($query) or die($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          }
 
          $current_enum_role = PluginFormcreatorCommon::getEnumValues($table, 'actor_role');
@@ -61,7 +61,7 @@ class PluginFormcreatorTargetTicket_Actor extends CommonDBTM
             CHANGE COLUMN `actor_role` `actor_role`
             ENUM($enum_actor_role)
             NOT NULL";
-            $DB->query($query) or die($DB->error());
+            $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
          }
       }
 
@@ -97,7 +97,7 @@ class PluginFormcreatorTargetTicket_Actor extends CommonDBTM
 
       $table = self::getTable();
       $query = "DROP TABLE IF EXISTS `$table`";
-      return $DB->query($query) or die($DB->error());
+      return $DB->query($query) or plugin_formcrerator_upgrade_error($migration);
    }
 
    /**

--- a/setup.php
+++ b/setup.php
@@ -274,3 +274,11 @@ function plugin_formcreator_getFromDBByField(CommonDBTM $item, $field = "", $val
       return false;
    }
 }
+
+function plugin_formcrerator_upgrade_error(Migration $migration) {
+   global $DB;
+
+   $error = $DB->error();
+   $migration->log($error . "\n" . Toolbox::backtrace(false, '', array('Toolbox::backtrace()')));
+   die($error . "<br><br> Please, check migration log");
+}


### PR DESCRIPTION
suggestion to ensure we have a backtrace when an unrecoverable upgrade error occurs.

I wish to add this in the hotfix 2.4.1 that's why this PR is based on it.

