### PR TITLE
make column not clickable

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -309,7 +309,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
             'table'         => self::getTable(),
             'field'         => 'display_id',
             'name'          => __('ID'),
-            'datatype'      => 'itemlink',
+            'datatype'      => 'string',
             'forcegroupby'  => true,
             'massiveaction' => false,
          ),


### PR DESCRIPTION
between 2.4.0 and 2.4.1 id becomes display_id, and is no longer a key.