### PR TITLE
fix added actors with ID = 0

### DIFF
--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -1415,6 +1415,10 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorTargetBase
       } else {
          $userId = intval($user);
          $alternativeEmail = '';
+         if ($userId == '0') {
+            // there is no actor
+            return;
+         }
       }
 
       switch ($role) {


### PR DESCRIPTION
On GLPI < 9.1.2 only 

If a form contains several questions of type **GLPI Object**, subtype **User**, and these questions are used to add an actor in a ticket.

Leaving at least one of them without answer adds an actor with users_id = 0. The ticket contains a "ghost" actor, and it is impossible to remove it from the ticket.

This PR fixes it.