### PR TITLE
change escaping mode

### DIFF
--- a/inc/category.class.php
+++ b/inc/category.class.php
@@ -171,8 +171,8 @@ class PluginFormcreatorCategory extends CommonTreeDropdown
       $result = $DB->query($query);
       while ($line = $DB->fetch_array($result)) {
          $query_update = "UPDATE `$table` SET
-                            `name`    = '".plugin_formcreator_encode($line['name'])."',
-                            `comment` = '".plugin_formcreator_encode($line['comment'])."'
+                            `name`    = '".plugin_formcreator_encode($line['name'], false)."',
+                            `comment` = '".plugin_formcreator_encode($line['comment'], false)."'
                           WHERE `id` = ".$line['id'];
          $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
       }

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -914,7 +914,7 @@ class PluginFormcreatorQuestion extends CommonDBChild
          $result = $DB->query($query);
          while ($line = $DB->fetch_array($result)) {
             $query_update = "UPDATE `glpi_plugin_formcreator_questions_conditions` SET
-                               `show_value` = '" . plugin_formcreator_encode($line['show_value']) . "'
+                               `show_value` = '" . plugin_formcreator_encode($line['show_value'], false) . "'
                              WHERE `id` = " . (int) $line['id'];
             $DB->query($query_update) or plugin_formcrerator_upgrade_error($migration);
          }


### PR DESCRIPTION
htmlentities no longer used to save some data, previously saved data needs to follow the change

cannot cherry-pick in 2.5.0 due to changes in installer