### PR TITLE
compatibility with GLPI 0.90.x

### DIFF
--- a/inc/fields/actor-field.class.php
+++ b/inc/fields/actor-field.class.php
@@ -33,6 +33,11 @@ class actorField extends PluginFormcreatorField
                name="formcreator_field_' . $this->fields['id'] . '"
                id="actor_formcreator_field_' . $this->fields['id'] . '"
                value=" " />';
+      if (version_compare(GLPI_VERSION, '9.1') < 0) {
+         $method = 'GET';
+      } else {
+         $method = 'POST';
+      }
       echo '<script type="text/javascript">
                jQuery(document).ready(function() {
                   $("#actor_formcreator_field_' . $this->fields['id'] . '").select2({
@@ -52,7 +57,7 @@ class actorField extends PluginFormcreatorField
                                  page_limit: 20,
                                  page: query.page
                               },
-                              type: "POST",
+                              type: "' . $method . '",
                               dataType: "json"
                            }).done(function(response) { query.callback(response) });
                         } else {


### PR DESCRIPTION
In GLPI 0.90.x : ajax/getDropdownUsers.php uses GET to retrieve parameters, but this changed to POST in GLPI 9.1

