### PR TITLE
fix use of questions from others forms when editing a destination ticket

### DIFF
--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -538,9 +538,9 @@ EOS;
                    INNER JOIN glpi_plugin_formcreator_sections s
                      ON s.id = q.plugin_formcreator_sections_id
                    WHERE s.id = {$section['id']}
-                   AND (q.fieldtype = 'glpiselect'
+                   AND ((q.fieldtype = 'glpiselect'
                      AND q.values IN ('User', 'Group', 'Supplier'))
-                   OR (q.fieldtype = 'actor')";
+                     OR (q.fieldtype = 'actor'))";
          $result2 = $DB->query($query2);
          $section_questions_user       = array();
          $section_questions_group      = array();


### PR DESCRIPTION
When several forms have an actor field, the actors of all forms were displayed in the dropdown to choose an actor field for requiester, observer or technician