### PR TITLE
missing link to wiki / documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Features
 13. Preview form created directly in the configuration.
 14. An optional service catalog to browse for forms and FAQ in an unified interface.
 
+For more information you can visit the [documentation](http://glpi-plugins.readthedocs.io/en/latest/formcreator/)
+
 Translations
 ------------
 


### PR DESCRIPTION
in english the link to the wiki / new documentation is missing.

I think you could delete old wiki on github - all information are in readthedocs