### PR TITLE
fix search option

### DIFF
--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -106,7 +106,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
          $questions = $question->getQuestionsFromForm($_SESSION['formcreator']['form_search_answers']);
 
          foreach ($questions as $current_question) {
-            $questions_id = $question->getID();
+            $questions_id = $current_question->getID();
             $tab[$optindex] = [
                'table'         => PluginFormcreatorAnswer::getTable(),
                'field'         => 'answer',


### PR DESCRIPTION
@flegastelois  said 

> $questions_id dans la condition vaut toujours -1
> la ligne 112 devrait être $questions_id = $current_question->getID();
> du coup, on a aucune réponse affichée dans la liste des réponses d'un formulaire
