### PR TITLE
fix(ui): back to home generates overlap when continuing browsing categories

### DIFF
--- a/lib/slinky/assets/js/jquery.slinky.js
+++ b/lib/slinky/assets/js/jquery.slinky.js
@@ -158,6 +158,11 @@
 				count = active.parentsUntil(menu, 'li').length;
 
 			if (count > 0) {
+			   $.each(active.parentsUntil(menu, 'li'), function(index, val) {
+			      var $this = $(this);
+			      $this.find('ul').hide();
+			   });
+			
 				move(-count, function() {
 					active.removeClass(settings.activeClass);
 				});


### PR DESCRIPTION
see https://github.com/alizahid/slinky/pull/22