### PR TITLE
fix(ui): JS code executed before document is ready

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -440,8 +440,7 @@ class PluginFormcreatorForm extends CommonDBTM
       echo '</select>';
       echo '</div>';
 
-      echo '<script type="text/javascript">
-               function changeValidators(value) {
+      $script = 'function changeValidators(value) {
                   if (value == 1) {
                      document.getElementById("validators_users").style.display  = "block";
                      document.getElementById("validators_groups").style.display = "none";
@@ -454,8 +453,9 @@ class PluginFormcreatorForm extends CommonDBTM
                   }
                   fcInitMultiSelect();
                }
-               changeValidators(' . $this->fields["validation_required"] . ');
-            </script>';
+               $(document).ready(function() {changeValidators(' . $this->fields["validation_required"] . ');});';
+      echo Html::scriptBlock($script);
+
       echo '</td>';
       echo '</tr>';
 


### PR DESCRIPTION
before the fix, default form in service catalog has wrong design, caused by a JS error

![image](https://user-images.githubusercontent.com/14139801/31126215-464b3642-a84b-11e7-959c-6b7e26ee4a19.png)

JS console: 
```
VM9383:13 Uncaught ReferenceError: fcInitMultiSelect is not defined
    at changeValidators (eval at <anonymous> (jquery-1.10.2.js?v=9.2:612), <anonymous>:13:19)
    at eval (eval at <anonymous> (jquery-1.10.2.js?v=9.2:612), <anonymous>:15:16)
    at eval (<anonymous>)
    at jquery-1.10.2.js?v=9.2:612
    at Function.globalEval (jquery-1.10.2.js?v=9.2:613)
    at init.domManip (jquery-1.10.2.js?v=9.2:6281)
    at init.append (jquery-1.10.2.js?v=9.2:6047)
    at init.<anonymous> (jquery-1.10.2.js?v=9.2:6174)
    at Function.access (jquery-1.10.2.js?v=9.2:861)
    at init.html (jquery-1.10.2.js?v=9.2:6138)
```

in form.class.php
```php
      echo '<script type="text/javascript">
               function changeValidators(value) {
                  if (value == 1) {
                     document.getElementById("validators_users").style.display  = "block";
                     document.getElementById("validators_groups").style.display = "none";
                  } else if (value == 2) {
                     document.getElementById("validators_users").style.display  = "none";
                     document.getElementById("validators_groups").style.display = "block";
                  } else {
                     document.getElementById("validators_users").style.display  = "none";
                     document.getElementById("validators_groups").style.display = "none";
                  }
                  fcInitMultiSelect();
               }
               changeValidators(' . $this->fields["validation_required"] . ');
            </script>';
```