### PR TITLE
fix: rich description encoding in ticket

### DIFF
--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -981,7 +981,7 @@ EOS;
     * @return Ticket|null Generated ticket if success, null otherwise
     */
    public function save(PluginFormcreatorForm_Answer $formanswer) {
-      global $DB;
+      global $DB, $CFG_GLPI;
 
       // Prepare actors structures for creation of the ticket
       $this->requesters = [
@@ -1084,7 +1084,9 @@ EOS;
          $data['content'] = str_replace('##FULLFORM##', $formanswer->getFullForm(), $data['content']);
       }
       $data['content'] = addslashes($this->parseTags($data['content'], $formanswer));
-
+      if ($CFG_GLPI['use_rich_text']) {
+         $data['content'] = htmlentities($data['content']);
+      }
       $data['_users_id_recipient'] = $_SESSION['glpiID'];
       $data['_tickettemplates_id'] = $this->fields['tickettemplates_id'];
 


### PR DESCRIPTION
GLPI saves rich text as html-entities-ized content i.e <p> tag is saved as &lt;p&gt;
Formcreator shall do the same even if it seems to not have impact anywhere saving <p> as is.