### PR TITLE
Feature/fix targetchange bugs

### DIFF
--- a/inc/target.class.php
+++ b/inc/target.class.php
@@ -122,7 +122,7 @@ class PluginFormcreatorTarget extends CommonDBTM
          }
 
          switch ($input['itemtype']) {
-            case 'PluginFormcreatorTargetTicket':
+            case PluginFormcreatorTargetTicket::class:
                $targetticket      = new PluginFormcreatorTargetTicket();
                $id_targetticket   = $targetticket->add([
                   'name'    => $input['name'],
@@ -148,7 +148,7 @@ class PluginFormcreatorTarget extends CommonDBTM
                   ]);
                }
                break;
-            case 'PluginFormcreatorTargetChange':
+            case PluginFormcreatorTargetChange::class:
                $targetchange      = new PluginFormcreatorTargetChange();
                $id_targetchange   = $targetchange->add([
                   'name'    => $input['name'],

--- a/inc/targetbase.class.php
+++ b/inc/targetbase.class.php
@@ -38,6 +38,8 @@ abstract class PluginFormcreatorTargetBase extends CommonDBTM
 
    abstract public function getItem_Actor();
 
+   abstract protected function getCategoryFilter();
+
    static function getEnumDestinationEntity() {
       return [
          'current'   => __("Current active entity", 'formcreator'),
@@ -93,7 +95,6 @@ abstract class PluginFormcreatorTargetBase extends CommonDBTM
          'answer'    => __('Equals to the answer to the question', 'formcreator'),
       ];
    }
-
 
    /**
     * Check if current user have the right to create and modify requests
@@ -543,8 +544,9 @@ EOS;
       echo '</div>';
       echo '<div id="category_specific_value" style="display: none">';
       ITILCategory::dropdown([
-         'name'   => '_category_specific',
-         'value'  => $this->fields["category_question"],
+         'name'      => '_category_specific',
+         'value'     => $this->fields["category_question"],
+         'condition' => $this->getCategoryFilter(),
       ]);
       echo '</div>';
       echo '</td>';

--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -42,11 +42,15 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
    }
 
    protected function getTargetItemtypeName() {
-      return 'Change';
+      return Change::class;
    }
 
    public function getItem_Actor() {
       return new PluginFormcreatorTargetChange_Actor();
+   }
+
+   protected function getCategoryFilter() {
+      return "`is_change` = '1'";
    }
 
    /**

--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -948,8 +948,6 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
       $data['requesttypes_id'] = $requesttypes_id;
 
       // Parse datas
-      $fullform = $formanswer->getFullForm();
-
       $changeFields = [
          'name',
          'content',
@@ -960,11 +958,17 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
          'checklistcontent'
       ];
       foreach ($changeFields as $changeField) {
-         $data[$changeField] = $this->fields[$changeField];
+         //TODO: 2.7.0 rename PluginFormcreatorTargetChange's comment into content
+         if ($changeField == 'content') {
+            // This handles mismatch of the column content in Change itemtype and comment in TargetChange itemtype
+            $data[$changeField] = $this->fields[$changeField];
+         } else {
+            $data[$changeField] = $this->fields['comment'];
+         }
          if (strpos($data[$changeField], '##FULLFORM##') !== false) {
             $data[$changeField] = str_replace('##FULLFORM##', $formanswer->getFullForm(), $data[$changeField]);
          }
-         $data[$changeField]                = addslashes($this->parseTags($data[$changeField], $formanswer));
+         $data[$changeField] = addslashes($this->parseTags($data[$changeField], $formanswer));
       }
 
       $data['_users_id_recipient']   = $_SESSION['glpiID'];

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -26,11 +26,15 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorTargetBase
    }
 
    protected function getTargetItemtypeName() {
-      return 'Ticket';
+      return Ticket::class;
    }
 
    public function getItem_Actor() {
       return new PluginFormcreatorTargetTicket_Actor();
+   }
+
+   protected function getCategoryFilter() {
+      return "`is_request` = '1' OR `is_incident` = '1'";
    }
 
    /**


### PR DESCRIPTION
various bug fixes for target change

* duplicating a form does duplicates target changes
* specific category for ticket or change not filtered (criterias : is_request is_incident and is_change)
* issue with different column name between Change itemtype and Targetchange itemtype

The last issue requires a schema change. This is not allowed for 2.6.1, so I choosed a workaround, and I'll build a PR for the future 2.7.0 version. Also, in 2.7.0 I plan refactor of the code to mutualize some string replacement code between duplication and generation of targets.