### PR TITLE
fix warnings in  timeline when no fiel uploaded

### DIFF
--- a/inc/targetbase.class.php
+++ b/inc/targetbase.class.php
@@ -772,10 +772,14 @@ EOS;
             } else {
                if (strpos($content, '##answer_' . $id . '##') !== false) {
                   $content = str_replace('##question_' . $id . '##', $name, $content);
-                  $content = str_replace('##answer_' . $id . '##', __('Attached document', 'formcreator'), $content);
+                  if ($value !== '') {
+                     $content = str_replace('##answer_' . $id . '##', __('Attached document', 'formcreator'), $content);
 
-                  // keep the ID of the document
-                  $this->attachedDocuments[$value] = true;
+                     // keep the ID of the document
+                     $this->attachedDocuments[$value] = true;
+                  } else {
+                     $content = str_replace('##answer_' . $id . '##', __('No document', 'formcreator'), $content);
+                  }
                }
             }
          }


### PR DESCRIPTION
the target object (ticket or change) may contain a reference to a not uplaoded document. For example a not mandatory file field where the requester did not choosd a file.