### PR TITLE
Remove abusive encoding in target names

### DIFF
--- a/inc/target.class.php
+++ b/inc/target.class.php
@@ -102,11 +102,6 @@ class PluginFormcreatorTarget extends CommonDBTM
     * @return array the modified $input array
    **/
    public function prepareInputForAdd($input) {
-      // Decode (if already encoded) and encode strings to avoid problems with quotes
-      foreach ($input as $key => $value) {
-         $input[$key] = plugin_formcreator_encode($value);
-      }
-
       // Control fields values :
       // - name is required
       if (isset($input['name'])
@@ -194,11 +189,6 @@ class PluginFormcreatorTarget extends CommonDBTM
     * @return array the modified $input array
    **/
    public function prepareInputForUpdate($input) {
-      // Decode (if already encoded) and encode strings to avoid problems with quotes
-      foreach ($input as $key => $value) {
-         $input[$key] = plugin_formcreator_encode($value);
-      }
-
       // generate a uniq id
       if (!isset($input['uuid'])
           || empty($input['uuid'])) {

--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -826,8 +826,6 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
             return [];
          }
 
-         $input['name'] = plugin_formcreator_encode($input['title']);
-
          if ($CFG_GLPI['use_rich_text']) {
             $input['comment'] = Html::entity_decode_deep($input['comment']);
          }

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -818,8 +818,6 @@ EOS;
             return [];
          }
 
-         $input['name'] = plugin_formcreator_encode($input['title']);
-
          if ($CFG_GLPI['use_rich_text']) {
             $input['comment'] = Html::entity_decode_deep($input['comment']);
          }

--- a/install/update_dev.php
+++ b/install/update_dev.php
@@ -1,4 +1,5 @@
 <?php
+
 function plugin_formcreator_update_dev(Migration $migration) {
    global $DB;
 
@@ -6,4 +7,40 @@ function plugin_formcreator_update_dev(Migration $migration) {
    $table = 'glpi_displaypreferences';
    $query = "UPDATE `$table` SET `num`='8' WHERE `itemtype`='PluginFormcreatorForm_Answer' AND `num`='1'";
    $DB->query($query);
+
+   // Remove abusive encoding in targets
+   $table = 'glpi_plugin_formcreator_targets';
+   $request = [
+      'FROM' => $table,
+   ];
+   foreach ($DB->request($request) as $row) {
+      $id = $row['id'];
+      $name = Toolbox::addslashes_deep(html_entity_decode($row['name'], ENT_QUOTES|ENT_HTML5));
+      $id = $row['id'];
+      $DB->query("UPDATE `$table` SET `name`='$name' WHERE `id` = '$id'");
+   }
+
+   // Remove abusive encding in  target tickets
+   $table = 'glpi_plugin_formcreator_targettickets';
+   $request = [
+      'FROM' => $table,
+   ];
+   foreach ($DB->request($request) as $row) {
+      $id = $row['id'];
+      $name = Toolbox::addslashes_deep(html_entity_decode($row['name'], ENT_QUOTES|ENT_HTML5));
+      $id = $row['id'];
+      $DB->query("UPDATE `$table` SET `name`='$name' WHERE `id` = '$id'");
+   }
+
+   // Remove abusive encding in  target tickets
+   $table = 'glpi_plugin_formcreator_targetchanges';
+   $request = [
+      'FROM' => $table,
+   ];
+   foreach ($DB->request($request) as $row) {
+      $id = $row['id'];
+      $name = Toolbox::addslashes_deep(html_entity_decode($row['name'], ENT_QUOTES|ENT_HTML5));
+      $id = $row['id'];
+      $DB->query("UPDATE `$table` SET `name`='$name' WHERE `id` = '$id'");
+   }
 }

--- a/tests/0005_Unit/TargetTest.php
+++ b/tests/0005_Unit/TargetTest.php
@@ -1,0 +1,59 @@
+<?php
+class TargetTest extends SuperAdminTestCase {
+
+   public function addUpdateFormProvider() {
+      return [
+         [
+            'input' => [
+               'name' => '',
+               'itemtype' => PluginFormcreatorTargetTicket::class
+            ],
+            'expected' => false,
+         ],
+         [
+            'input' => [
+               'name' => 'should fail',
+               'itemtype' => ''
+            ],
+            'expected' => false,
+         ],
+         [
+            'input' => [
+               'name' => 'should pass',
+               'itemtype' => PluginFormcreatorTargetTicket::class
+            ],
+            'expected' => true,
+         ],
+         [
+            'input' => [
+               'name' => 'être ou ne pas être',
+               'itemtype' => PluginFormcreatorTargetTicket::class
+            ],
+            'expected' => true,
+         ],
+         [
+            'input' => [
+               'name' => 'test d\\\'apostrophe',
+               'itemtype' => PluginFormcreatorTargetTicket::class
+            ],
+            'expected' => true,
+         ],
+      ];
+   }
+
+   /**
+    * @dataProvider addUpdateFormProvider
+    * @param array $input
+    * @param boolean $expected
+    */
+   public function testPrepareInputForAdd($input, $expected) {
+      $target = new PluginFormcreatorTarget();
+      $output = $target->prepareInputForAdd($input);
+      if ($expected === false) {
+         $this->assertCount(0, $output);
+      } else {
+         $this->assertEquals($input['name'], $output['name']);
+         $this->assertArrayHasKey('uuid', $output);
+      }
+   }
+}


### PR DESCRIPTION
My tests show there is no consequence on titles of generated tickets or changes.