### PR TITLE
Fix search option

### DIFF
--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -109,14 +109,10 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
 
       $tab[] = [
          'id'                 => '1',
-         'table'              => $this::getTable(),
-         'field'              => 'status',
-         'name'               => __('Status'),
-         'searchtype'         => [
-            '0'                  => 'equals',
-            '1'                  => 'notequals'
-         ],
-         'datatype'           => 'specific',
+         'table'              => $this->getTable(),
+         'field'              => 'name',
+         'name'               => __('Name'),
+         'datatype'           => 'itemlink',
          'massiveaction'      => false
       ];
 
@@ -177,6 +173,19 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
          'datatype'      => 'itemlink',
          'massiveaction' => false,
          'linkfield'     => 'groups_id_validator',
+      ];
+
+      $tab[] = [
+         'id'                 => '8',
+         'table'              => $this::getTable(),
+         'field'              => 'status',
+         'name'               => __('Status'),
+         'searchtype'         => [
+            '0'                  => 'equals',
+            '1'                  => 'notequals'
+         ],
+         'datatype'           => 'specific',
+         'massiveaction'      => false
       ];
 
       if ($display_for_form) {

--- a/install/update_dev.php
+++ b/install/update_dev.php
@@ -1,0 +1,9 @@
+<?php
+function plugin_formcreator_update_dev(Migration $migration) {
+   global $DB;
+
+   // Change id of search option for status of form_answer
+   $table = 'glpi_displaypreferences';
+   $query = "UPDATE `$table` SET `num`='8' WHERE `itemtype`='PluginFormcreatorForm_Answer' AND `num`='1'";
+   $DB->query($query);
+}

--- a/setup.php
+++ b/setup.php
@@ -1,7 +1,7 @@
 <?php
 global $CFG_GLPI;
 // Version of the plugin
-define('PLUGIN_FORMCREATOR_VERSION', '2.6.1');
+define('PLUGIN_FORMCREATOR_VERSION', '2.6.2-dev');
 // Schema version of this version
 define('PLUGIN_FORMCREATOR_SCHEMA_VERSION', '2.6');
 


### PR DESCRIPTION
fix #602 

the column number of tickets is added by  the search engine: https://github.com/glpi-project/glpi/blob/dabd12d64fb1210bcfdbf9b5c9f38efa16cbf6ce/inc/search.class.php#L5464

By comarison with the same behaviour with computer, GLPI expects the search option ID 1 is the name for the itemtype. For Form_Answer this is **status** which is a violation of conventions.



