### PR TITLE
Distinguish fields content

### DIFF
--- a/front/targetticket.form.php
+++ b/front/targetticket.form.php
@@ -45,10 +45,6 @@ $targetticket = new PluginFormcreatorTargetTicket();
 
 // Edit an existing target ticket
 if (isset($_POST["update"])) {
-   $target = new PluginFormcreatorTarget();
-   $found  = $target->find('items_id = ' . (int) $_POST['id']);
-   $found  = array_shift($found);
-   $target->update(['id' => $found['id'], 'name' => $_POST['name']]);
    $targetticket->update($_POST);
    Html::back();
 

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -924,6 +924,13 @@ EOS;
          $input['uuid'] = plugin_formcreator_getUuid();
       }
 
+      $target = new PluginFormcreatorTarget();
+      $found  = $target->find('items_id = ' . $this->getID());
+      $found  = array_shift($found);
+      $target->update(['id' => $found['id'], 'name' => $input['name']]);
+      $input['name'] = $input['title'];
+      unset($input['title']);
+
       return $input;
    }
 
@@ -1469,7 +1476,7 @@ EOS;
          foreach ($rows as $id => $question_line) {
             $uuid  = $question_line['uuid'];
 
-            $content = $target_data['name'];
+            $content = $target_data['title'];
             $content = str_replace("##question_$uuid##", "##question_$id##", $content);
             $content = str_replace("##answer_$uuid##", "##answer_$id##", $content);
             $target_data['name'] = $content;
@@ -1561,6 +1568,8 @@ EOS;
       unset($target_data['id'],
             $target_data['tickettemplates_id']);
 
+      $target_data['title'] = $target_data['name'];
+      unset($target_data['name']);
       return $target_data;
    }
 }

--- a/tests/0010_Integration/ExportImportTest.php
+++ b/tests/0010_Integration/ExportImportTest.php
@@ -282,7 +282,7 @@ class ExportImporTest extends SuperAdminTestCase {
    public function _checkTargetTicket($targetticket = []) {
       $this->assertArrayNotHasKey('id', $targetticket);
       $this->assertArrayNotHasKey('tickettemplates_id', $targetticket);
-      $this->assertArrayHasKey('name', $targetticket);
+      $this->assertArrayHasKey('title', $targetticket);
       $this->assertArrayHasKey('comment', $targetticket);
       $this->assertArrayHasKey('due_date_rule', $targetticket);
       $this->assertArrayHasKey('due_date_question', $targetticket);


### PR DESCRIPTION
When creating a target for a form, the UI shows 2 fields. One of them is used to populate the second, making confusion

![image](https://user-images.githubusercontent.com/14139801/36427108-8012b246-164c-11e8-8e8b-dd928e97a2fc.png)
