### PR TITLE
Fixed hyphen bugs and non reactive fields

### DIFF
--- a/inc/fields/descriptionfield.class.php
+++ b/inc/fields/descriptionfield.class.php
@@ -35,7 +35,7 @@
 class PluginFormcreatorDescriptionField extends PluginFormcreatorField
 {
    public function show($canEdit = true) {
-      echo '<div class="description_field form-group" id="form-group-field' . $this->fields['id'] . '">';
+      echo '<div class="description_field form-group" id="form-group-formcreator_field_' . $this->fields['id'] . '">';
       echo nl2br(html_entity_decode($this->fields['description']));
       echo '</div>' . PHP_EOL;
       echo Html::scriptBlock('$(function() {

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1199,7 +1199,7 @@ class PluginFormcreatorForm extends CommonDBTM
                $data[$key] = plugin_formcreator_encode($value);
             }
          }
-
+         
          $_SESSION['formcreator']['data'] = $data;
          // Save form
       } else {
@@ -1261,6 +1261,7 @@ class PluginFormcreatorForm extends CommonDBTM
     * @return Boolean true if success, false toherwize.
     */
    public function duplicate() {
+   	  global $DB; 
       $target              = new PluginFormcreatorTarget();
       $target_ticket       = new PluginFormcreatorTargetTicket();
       $target_change       = new PluginFormcreatorTargetChange();
@@ -1292,7 +1293,12 @@ class PluginFormcreatorForm extends CommonDBTM
          unset($row['id'],
                $row['uuid']);
          $row['plugin_formcreator_forms_id'] = $new_form_id;
-         if (!$form_profile->add($row)) {
+
+		  $row['name'] = html_entity_decode($row['name'], ENT_QUOTES | ENT_HTML401);
+		  $row['name'] = stripslashes($row['name']);
+		  $row['name'] = mysqli_real_escape_string($DB->dbh, $row['name']);
+
+		 if (!$form_profile->add($row)) {
             return false;
          }
       }
@@ -1314,6 +1320,11 @@ class PluginFormcreatorForm extends CommonDBTM
          unset($sectionRow['id'],
                $sectionRow['uuid']);
          $sectionRow['plugin_formcreator_forms_id'] = $new_form_id;
+
+         $sectionRow['name'] = html_entity_decode($sectionRow['name'], ENT_QUOTES | ENT_HTML401);
+		 $sectionRow['name'] = stripslashes($sectionRow['name']);
+		 $sectionRow['name'] = mysqli_real_escape_string($DB->dbh, $sectionRow['name']);
+         
          if (!$new_sections_id = $form_section->add($sectionRow)) {
             return false;
          }
@@ -1324,6 +1335,11 @@ class PluginFormcreatorForm extends CommonDBTM
             unset($questionRow['id'],
                   $questionRow['uuid']);
             $questionRow['plugin_formcreator_sections_id'] = $new_sections_id;
+
+            $questionRow['name'] = html_entity_decode($questionRow['name'], ENT_QUOTES | ENT_HTML401);
+			$questionRow['name'] = stripslashes($questionRow['name']);
+			$questionRow['name'] = mysqli_real_escape_string($DB->dbh, $questionRow['name']);
+            
             if (!$new_questions_id = $section_question->add($questionRow)) {
                return false;
             }
@@ -1703,7 +1719,7 @@ class PluginFormcreatorForm extends CommonDBTM
       if ($remove_uuid) {
          $form['uuid'] = '';
       }
-
+      
       return $form;
    }
 
@@ -1868,11 +1884,6 @@ class PluginFormcreatorForm extends CommonDBTM
       if ($forms_id
           && isset($form['_sections'])) {
          foreach ($form['_sections'] as $section) {
-         	
-         	$section['name'] = html_entity_decode($section['name'], ENT_QUOTES | ENT_HTML401);
-         	$section['name'] = stripslashes($section['name']);
-         	$section['name'] = mysqli_real_escape_string($DB->dbh, $section['name']);
-            
          	PluginFormcreatorSection::import($forms_id, $section);
          }
       }

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1832,6 +1832,7 @@ class PluginFormcreatorForm extends CommonDBTM
       $form_obj = new self;
       $entity   = new Entity;
       $form_cat = new PluginFormcreatorCategory;
+      global $DB;
 
       // retrieve foreign keys
       if (!isset($form['_entity'])
@@ -1867,7 +1868,12 @@ class PluginFormcreatorForm extends CommonDBTM
       if ($forms_id
           && isset($form['_sections'])) {
          foreach ($form['_sections'] as $section) {
-            PluginFormcreatorSection::import($forms_id, $section);
+         	
+         	$section['name'] = html_entity_decode($section['name'], ENT_QUOTES | ENT_HTML401);
+         	$section['name'] = stripslashes($section['name']);
+         	$section['name'] = mysqli_real_escape_string($DB->dbh, $section['name']);
+            
+         	PluginFormcreatorSection::import($forms_id, $section);
          }
       }
       // Save all question conditions stored in memory

--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -705,7 +705,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
          foreach ($questions as $question) {
             // unset the answer value
             $answer_value = $this->transformAnswerValue($question, $data['formcreator_field_' . $question->getID()]);
-
+            
             if ($answer_value !== null) {
                // Save the answer to the question
                $answer->add([
@@ -715,6 +715,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
                ], [], 0);
             }
          }
+
          $is_newFormAnswer = true;
       }
 

--- a/inc/section.class.php
+++ b/inc/section.class.php
@@ -280,6 +280,7 @@ class PluginFormcreatorSection extends CommonDBChild
     */
    public static function import($forms_id = 0, $section = []) {
       $item = new self;
+      global $DB;
 
       $section['plugin_formcreator_forms_id'] = $forms_id;
       $section['_skip_checks']                = true;
@@ -307,6 +308,11 @@ class PluginFormcreatorSection extends CommonDBChild
          );
 
          foreach ($section['_questions'] as $question) {
+
+         	$question['name'] = html_entity_decode($question['name'], ENT_QUOTES | ENT_HTML401);
+			$question['name'] = stripslashes($question['name']);
+			$question['name'] = mysqli_real_escape_string($DB->dbh, $question['name']);
+			 
             PluginFormcreatorQuestion::import($sections_id, $question);
          }
       }

--- a/inc/target.class.php
+++ b/inc/target.class.php
@@ -135,6 +135,7 @@ class PluginFormcreatorTarget extends CommonDBTM
     * @return array the modified $input array
    **/
    public function prepareInputForAdd($input) {
+   	  global $DB;
       // Control fields values :
       // - name is required
       if (isset($input['name'])
@@ -148,10 +149,15 @@ class PluginFormcreatorTarget extends CommonDBTM
             Session::addMessageAfterRedirect(__('The type cannot be empty!', 'formcreator'), false, ERROR);
             return [];
          }
-
+         
          switch ($input['itemtype']) {
             case PluginFormcreatorTargetTicket::class:
                $targetticket      = new PluginFormcreatorTargetTicket();
+               
+               $input['name'] = html_entity_decode($input['name'], ENT_QUOTES | ENT_HTML401);
+               $input['name'] = stripslashes($input['name']);
+               $input['name'] = mysqli_real_escape_string($DB->dbh, $input['name']);
+               
                $id_targetticket   = $targetticket->add([
                   'name'    => $input['name'],
                   'comment' => '##FULLFORM##'
@@ -253,6 +259,7 @@ class PluginFormcreatorTarget extends CommonDBTM
     */
    public static function import($forms_id = 0, $target = []) {
       $item = new self;
+      global $DB;
 
       $target['plugin_formcreator_forms_id'] = $forms_id;
       $target['_skip_checks']                = true;
@@ -270,6 +277,9 @@ class PluginFormcreatorTarget extends CommonDBTM
          $item->getFromDB('$targets_id');
       }
 
+	   $target['_data']['title'] = html_entity_decode($target['_data']['title'], ENT_QUOTES | ENT_HTML401);
+	   $target['_data']['title'] = mysqli_real_escape_string($DB->dbh, $target['_data']['title']);
+      
       // import sub table
       $target['itemtype']::import($item->fields['items_id'], $target['_data']);
 

--- a/inc/target.class.php
+++ b/inc/target.class.php
@@ -183,7 +183,12 @@ class PluginFormcreatorTarget extends CommonDBTM
                }
                break;
             case PluginFormcreatorTargetChange::class:
-               $targetchange      = new PluginFormcreatorTargetChange();
+            	$targetchange      = new PluginFormcreatorTargetChange();
+            	
+				$input['name'] = html_entity_decode($input['name'], ENT_QUOTES | ENT_HTML401);
+				$input['name'] = stripslashes($input['name']);
+				$input['name'] = mysqli_real_escape_string($DB->dbh, $input['name']);
+               
                $id_targetchange   = $targetchange->add([
                   'name'    => $input['name'],
                   'comment' => '##FULLFORM##'
@@ -268,17 +273,17 @@ class PluginFormcreatorTarget extends CommonDBTM
       if ($targets_id = plugin_formcreator_getFromDBByField($item, 'uuid', $target['uuid'])) {
          // add id key
          $target['id'] = $targets_id;
-
          // update target
          $item->update($target);
       } else {
          //create target
          $targets_id = $item->add($target);
-         $item->getFromDB('$targets_id');
+         $item->getFromDB($targets_id);
       }
 
 	   $target['_data']['title'] = html_entity_decode($target['_data']['title'], ENT_QUOTES | ENT_HTML401);
 	   $target['_data']['title'] = mysqli_real_escape_string($DB->dbh, $target['_data']['title']);
+	   
       
       // import sub table
       $target['itemtype']::import($item->fields['items_id'], $target['_data']);

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -928,8 +928,13 @@ EOS;
       $target = new PluginFormcreatorTarget();
       $found  = $target->find('items_id = ' . $this->getID());
       $found  = array_shift($found);
-	   $input['name'] = mysqli_real_escape_string($DB->dbh, $input['name']); 
-      $target->update(['id' => $found['id'], 'name' => $input['name']]);
+
+
+	  $input['name'] = html_entity_decode($input['name'], ENT_QUOTES | ENT_HTML401);
+	  $input['name'] = stripslashes($input['name']);
+      $input['name'] = mysqli_real_escape_string($DB->dbh, $input['name']); 
+	   
+	  $target->update(['id' => $found['id'], 'name' => $input['name']]);
       $input['name'] = $input['title'];
       unset($input['title']);
 
@@ -1260,6 +1265,14 @@ EOS;
          $data = $this->assignedGroups + $data;
       }
 
+	   $data['content'] = str_replace('\r\n', "\r\n", $data['content']);
+	   $data['content'] = html_entity_decode($data['content'], ENT_QUOTES | ENT_HTML401);
+	   $data['content'] = stripslashes($data['content']);
+	   $data['content'] = mysqli_real_escape_string($DB->dbh, $data['content']);
+      
+//      print_r($data);
+//      die();
+      
       // Create the target ticket
       if (!$ticketID = $ticket->add($data)) {
          return false;

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -1269,10 +1269,7 @@ EOS;
 	   $data['content'] = html_entity_decode($data['content'], ENT_QUOTES | ENT_HTML401);
 	   $data['content'] = stripslashes($data['content']);
 	   $data['content'] = mysqli_real_escape_string($DB->dbh, $data['content']);
-      
-//      print_r($data);
-//      die();
-      
+	   
       // Create the target ticket
       if (!$ticketID = $ticket->add($data)) {
          return false;

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -835,6 +835,7 @@ EOS;
    **/
    public function prepareInputForUpdate($input) {
       global $CFG_GLPI;
+      global $DB;
 
       // Control fields values :
       if (!isset($input['_skip_checks'])
@@ -927,6 +928,7 @@ EOS;
       $target = new PluginFormcreatorTarget();
       $found  = $target->find('items_id = ' . $this->getID());
       $found  = array_shift($found);
+	   $input['name'] = mysqli_real_escape_string($DB->dbh, $input['name']); 
       $target->update(['id' => $found['id'], 'name' => $input['name']]);
       $input['name'] = $input['title'];
       unset($input['title']);
@@ -1470,6 +1472,7 @@ EOS;
     */
    public static function import($targetitems_id = 0, $target_data = []) {
       $item = new self;
+      global $DB;
 
       $target_data['_skip_checks'] = true;
       $target_data['id'] = $targetitems_id;
@@ -1477,6 +1480,7 @@ EOS;
       // convert question uuid into id
       $targetTicket = new PluginFormcreatorTargetTicket();
       $targetTicket->getFromDB($targetitems_id);
+      
       $formId        = $targetTicket->getForm()->getID();
       $section       = new PluginFormcreatorSection();
       $found_section = $section->find("plugin_formcreator_forms_id = '$formId'",
@@ -1504,9 +1508,16 @@ EOS;
             $target_data['comment'] = $content;
          }
       }
-
+      else
+	  {
+		  $target_data['name'] = $target_data['title'];
+	  }
+      
+      $target_data['name'] = html_entity_decode($target_data['name'], ENT_QUOTES | ENT_HTML401);
+      $target_data['name'] = stripslashes($target_data['name']);
+      
       // update target ticket
-      $item->update($target_data);
+      $item->update($target_data); // This method already escapes strings so we don't need to do it here
 
       if ($targetitems_id) {
          if (isset($target_data['_actors'])) {


### PR DESCRIPTION
This request hopefully fixes all the problems linked with importing and duplicating forms with hyphens in their names. It happened because they weren't escaped properly and it messed up the underlying sql.

Also, there was a mistake in the descriptionfield.class.php. The id attribute was misconstructed which in turn made it impossible to hide or show said field. 