### PR TITLE
fix: compatibility with GLPI 9.4

### DIFF
--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -1081,7 +1081,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
       $output      = '';
       $eol = '\r\n';
 
-      if ($CFG_GLPI['use_rich_text']) {
+      if (version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI['use_rich_text']) {
          $output .= '<h1>' . __('Form data', 'formcreator') . '</h1>';
       } else {
          $output .= __('Form data', 'formcreator') . $eol;
@@ -1110,7 +1110,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
 
          // Get and display current section if needed
          if ($last_section != $question_line['section_name']) {
-            if ($CFG_GLPI['use_rich_text']) {
+            if (version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI['use_rich_text']) {
                $output .= '<h2>' . Toolbox::addslashes_deep($question_line['section_name']) . '</h2>';
             } else {
                $output .= $eol . Toolbox::addslashes_deep($question_line['section_name']) . $eol;
@@ -1131,7 +1131,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
 
          if ($question_line['fieldtype'] != 'description') {
             $question_no++;
-            if ($CFG_GLPI['use_rich_text']) {
+            if (version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI['use_rich_text']) {
                $output .= '<div>';
                $output .= '<b>' . $question_no . ') ##question_' . $question_line['id'] . '## : </b>';
                $output .= '##answer_' . $question_line['id'] . '##';

--- a/inc/targetbase.class.php
+++ b/inc/targetbase.class.php
@@ -217,7 +217,7 @@ abstract class PluginFormcreatorTargetBase extends CommonDBTM
                ]);
 
                if ($answer->isNewItem()) {
-                  continue;
+                  continue 2;
                } else {
                   $userIds = [$answer->getField('answer')];
                }
@@ -235,7 +235,7 @@ abstract class PluginFormcreatorTargetBase extends CommonDBTM
                ]);
 
                if ($answer->isNewItem()) {
-                  continue;
+                  continue 2;
                } else {
                   $userIds = array_filter(explode(',', trim($answer->getField('answer'))));
                }

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -117,7 +117,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorTargetBase
       echo '<td><strong>' . __('Description') . ' <span style="color:red;">*</span></strong></td>';
       echo '<td colspan="3">';
       echo '<textarea name="comment" style="width:700px;" rows="15">' . $this->fields['comment'] . '</textarea>';
-      if ($CFG_GLPI["use_rich_text"]) {
+      if (version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI["use_rich_text"]) {
          Html::initEditorSystem('comment');
       }
       echo '</td>';
@@ -850,7 +850,7 @@ EOS;
             return [];
          }
 
-         if ($CFG_GLPI['use_rich_text']) {
+         if (version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI['use_rich_text']) {
             $input['comment'] = Html::entity_decode_deep($input['comment']);
          }
 
@@ -1114,13 +1114,13 @@ EOS;
       if (strpos($data['content'], '##FULLFORM##') !== false) {
          $data['content'] = str_replace('##FULLFORM##', $formanswer->getFullForm(), $data['content']);
       }
-      if ($CFG_GLPI['use_rich_text']) {
+      if (version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI['use_rich_text']) {
          // replace HTML P tags with DIV tags
          $data['content'] = str_replace(['<p>', '</p>'], ['<div>', '</div>'], $data['content']);
       }
 
       $data['content'] = $this->parseTags($data['content'], $formanswer);
-      if ($CFG_GLPI['use_rich_text']) {
+      if (version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI['use_rich_text']) {
          $data['content'] = htmlentities($data['content']);
       }
       $data['_users_id_recipient'] = $_SESSION['glpiID'];


### PR DESCRIPTION
rich text switch removed, and always enabled

fix #1022

Signed-off-by: btry <tbugier@teclib.com>

### Changes description

add glpi version test in addition of $CFG_GLPI['use_rich_text']

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->