### PR TITLE
Fix fatal error

### DIFF
--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -367,11 +367,11 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
 
       // prepare params for search
       $item          = new PluginFormcreatorForm_Answer();
-      $searchOptions      = $item->getSearchOptions();
+      $searchOptions      = $item->getSearchOptionsNew();
       $filteredOptions = [];
-      foreach ($searchOptions as $key => $value) {
-         if (is_numeric($key) && $key <= 7) {
-            $filteredOptions[$key] = $value;
+      foreach ($searchOptions as $value) {
+         if (is_numeric($value['id']) && $value['id'] <= 7) {
+            $filteredOptions[$value['id']] = $value;
          }
       }
       $searchOptions = $filteredOptions;


### PR DESCRIPTION
getSearchOptions does not longer exists, replaced by getSearchOptionsNew


### Changes description

fix a fatal error when displaying answers saved for a form.
