### PR TITLE
More consistent status display for status of issues

### DIFF
--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -269,7 +269,8 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
       switch ($field) {
          case 'status' :
             $output = '<img src="' . $CFG_GLPI['root_doc'] . '/plugins/formcreator/pics/' . $values[$field] . '.png"
-                         alt="' . __($values[$field], 'formcreator') . '" title="' . __($values[$field], 'formcreator') . '" />';
+                         alt="' . __($values[$field], 'formcreator') . '" title="' . __($values[$field], 'formcreator') . '" /> '
+                      . __($values[$field], 'formcreator');
             return $output;
             break;
       }


### PR DESCRIPTION
### Changes description

make more consistent display of statuses 

before 
![image](https://user-images.githubusercontent.com/14139801/42750570-fe3518e0-88e7-11e8-8a31-806a5e3cd4fd.png)

after 
![image](https://user-images.githubusercontent.com/14139801/42750561-f4dafc1a-88e7-11e8-9506-a36bcf118c0b.png)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A