### PR TITLE
SQL single quote escaping

### DIFF
--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -932,7 +932,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
       $doc                        = new Document();
 
       $file_data                 = [];
-      $file_data["name"]         = $form->getField('name'). ' - ' . $question->getField('name');
+      $file_data["name"]         = Toolbox::addslashes_deep($form->getField('name'). ' - ' . $question->getField('name'));
       $file_data["entities_id"]  = isset($_SESSION['glpiactive_entity'])
                                     ? $_SESSION['glpiactive_entity']
                                     : $form->getField('entities_id');


### PR DESCRIPTION
if the file field has a single quote in its name, the file is not added to Documents
and the generated ticket may be missing information provided by the requester

