### PR TITLE
force margin left of wizard right panel to prevent ios browsers to break line

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -880,6 +880,7 @@ a.plugin_formcreator_formTile_title {
    padding: 10px 0 3px 23px;
    margin: -10px 0 -3px -23px;
    background-color: #FFFFFF;
+   margin-left: 300px;
 }
 
 #plugin_formcreator_wizard_forms {


### PR DESCRIPTION
internal ref:14477

i can't provide screenshot, i don't have my "aillepad" with me.
But the issue was the tiles panel (on right) passed under the category tree on ios browsers (all browsers, as chrome for example, use internal safari for rendering)