### PR TITLE
Use Event class from Glpi namespace

### DIFF
--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -31,6 +31,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Event;
+
 include ("../../../inc/includes.php");
 
 Session::checkRight("reservation", ReservationItem::RESERVEANITEM);


### PR DESCRIPTION
### Changes description
Event class from Glpi will be loaded from Glpi namespace to prevent conflict with PECL Event extension.

### Checklist
- [-] Tests for the changes have been added
- [-] Docs have been added/updated

### References
Closes #N/A