### PR TITLE
Fix double quote renderiing in targets

### DIFF
--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -973,7 +973,6 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
          } else {
             $data[$changeField] = $this->fields['comment'];
          }
-         $data[$changeField] = addslashes($data[$changeField]);
          $data[$changeField] = str_replace("\r\n", '\r\n', $data[$changeField]);
          if (strpos($data[$changeField], '##FULLFORM##') !== false) {
             $data[$changeField] = str_replace('##FULLFORM##', $formanswer->getFullForm(), $data[$changeField]);
@@ -985,10 +984,11 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
 
          $data[$changeField] = $this->parseTags($data[$changeField], $formanswer);
 
-         // This targer does not supports rich text
+         // This target does not supports rich text
          $data[$changeField] = strip_tags($data[$changeField], '<p>');
          $data[$changeField] = str_replace('<p>', '', $data[$changeField]);
          $data[$changeField] = str_replace('</p>', '\r\n', $data[$changeField]);
+         $data[$changeField] = Toolbox::addslashes_deep($data[$changeField]);
       }
 
       $data['_users_id_recipient']   = $_SESSION['glpiID'];

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -1106,10 +1106,11 @@ EOS;
       // Parse data
       // TODO: generate instances of all answers of the form and use them for the fullform computation
       //       and the computation from a admin-defined target ticket template
-      $data['name'] = addslashes($this->fields['name']);
+      $data['name'] = $this->fields['name'];
       $data['name'] = $this->parseTags($data['name'], $formanswer);
+      $data['name'] = Toolbox::addslashes_deep($data['name']);
 
-      $data['content'] = addslashes($this->fields['comment']);
+      $data['content'] = $this->fields['comment'];
       $data['content'] = str_replace("\r\n", '\r\n', $data['content']);
       if (strpos($data['content'], '##FULLFORM##') !== false) {
          $data['content'] = str_replace('##FULLFORM##', $formanswer->getFullForm(), $data['content']);
@@ -1121,8 +1122,9 @@ EOS;
 
       $data['content'] = $this->parseTags($data['content'], $formanswer);
       if (version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI['use_rich_text']) {
-         $data['content'] = htmlentities($data['content']);
+         $data['content'] = htmlentities($data['content'], ENT_NOQUOTES);
       }
+      $data['content'] = Toolbox::addslashes_deep($data['content']);
       $data['_users_id_recipient'] = $_SESSION['glpiID'];
       $data['_tickettemplates_id'] = $this->fields['tickettemplates_id'];
 


### PR DESCRIPTION
If a double quote exists in a target ticket it is rendered in rich text mode with a single quote and a semicolon

### Changes description

replace htmlentities() with toolbox::addslashes_deep() and move this call at the end of the content computation.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A