### PR TITLE
Search engine and accented chars

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -133,4 +133,25 @@ class PluginFormcreatorCommon {
       }
       return (int) $line[$fieldName];
    }
+
+   /**
+    * Prepare keywords for a fulltext search in boolean mode
+    * takes into account strings in double quotes
+    *
+    * @param string $keywords
+    * @return string
+    */
+   public static function prepareBooleanKeywords($keywords) {
+      // @see https://stackoverflow.com/questions/2202435/php-explode-the-string-but-treat-words-in-quotes-as-a-single-word
+      preg_match_all('/"(?:\\\\.|[^\\\\"])*"|\S+/', $keywords, $matches);
+      $matches = $matches[0];
+      foreach ($matches as &$keyword) {
+         if (strpos($keyword, '"') === 0) {
+            // keyword does not begins with a double quote (assume it does not ends with this char)
+            $keyword .= '*';
+         }
+      }
+
+      return implode(' ', $matches);
+   }
 }

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -686,7 +686,6 @@ class PluginFormcreatorForm extends CommonDBTM implements PluginFormcreatorExpor
       }
 
       // Find forms accessible by the current user
-      $keywords = preg_replace("/[^A-Za-z0-9 ]/", '', $keywords);
       if (!empty($keywords)) {
          // Determine the optimal search mode
          $searchMode = "BOOLEAN MODE";
@@ -696,13 +695,15 @@ class PluginFormcreatorForm extends CommonDBTM implements PluginFormcreatorExpor
             $row = $DB->fetch_assoc($result);
             if ($row['Rows'] > 20) {
                $searchMode = "NATURAL LANGUAGE MODE";
+            } else {
+               $keywords = PluginFormcreatorCommon::prepareBooleanKeywords($keywords);
             }
          }
          $keywords = $DB->escape($keywords);
          $highWeightedMatch = " MATCH($table_form.`name`, $table_form.`description`)
-               AGAINST('$keywords*' IN $searchMode)";
+               AGAINST('$keywords' IN $searchMode)";
          $lowWeightedMatch = " MATCH($table_question.`name`, $table_question.`description`)
-               AGAINST('$keywords*' IN $searchMode)";
+               AGAINST('$keywords' IN $searchMode)";
          $where_form .= " AND ($highWeightedMatch OR $lowWeightedMatch)";
       }
       $query_forms = "SELECT


### PR DESCRIPTION
Accented chars are simply dropped from words when using the search engine.

Also solves other search engine issues (sometimes need 2 words)

This PR needs that no HTML entity exist in the searched columns.

### Changes description

convert accented chars into html entities.

To be changed again for 2.7.0

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #1020 