### PR TITLE
Deduplication of group raises a warning

### DIFF
--- a/inc/targetbase.class.php
+++ b/inc/targetbase.class.php
@@ -381,7 +381,7 @@ abstract class PluginFormcreatorTargetBase extends CommonDBTM implements PluginF
             return false;
       }
 
-      $actorKey = array_search($userId, $actorType);
+      $actorKey = array_search($group, $actorType);
       if ($actorKey !== false) {
          return false;
       }


### PR DESCRIPTION
Resolve a php warning due to an undefined var

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #1163 