### PR TITLE
feat(core): clean doc name on create issue

### DIFF
--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -933,10 +933,14 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
       } else if (isset($_POST['_formcreator_field_' . $question->getID()])) {
          $documents = $_POST['_formcreator_field_' . $question->getID()];
          $answer_value = [];
+         $index = 0;
          foreach ($documents as $document) {
             if (is_file(GLPI_TMP_DIR . '/' . $document)) {
-               $answer_value[] = $this->saveDocument($form, $question, $document);
+               //retrive prefix of doc uploaded to clean his name on add
+               $prefix = $_POST['_prefix_formcreator_field_' . $question->getID()][$index];
+               $answer_value[] = $this->saveDocument($form, $question, $document, $prefix);
             }
+            $index++;
          }
          $answer_value = json_encode($answer_value);
       }
@@ -950,21 +954,23 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
     * @param PluginFormcreatorForm $form
     * @param PluginFormcreatorQuestion $question
     * @param array $file                         an item from $_FILES array
+    * @param string $prefix                      the prefix of item from $_FILES array
     *
     * @return integer|NULL
     */
-   private function saveDocument(PluginFormcreatorForm $form, PluginFormcreatorQuestion $question, $file) {
+   private function saveDocument(PluginFormcreatorForm $form, PluginFormcreatorQuestion $question, $file, $prefix) {
       global $DB;
 
       $doc                        = new Document();
 
-      $file_data                 = [];
-      $file_data["name"]         = Toolbox::addslashes_deep($form->getField('name'). ' - ' . $question->getField('name'));
-      $file_data["entities_id"]  = isset($_SESSION['glpiactive_entity'])
-                                    ? $_SESSION['glpiactive_entity']
-                                    : $form->getField('entities_id');
-      $file_data["is_recursive"] = $form->getField('is_recursive');
-      $file_data['_filename'] = [$file];
+      $file_data                       = [];
+      $file_data["name"]               = Toolbox::addslashes_deep($form->getField('name'). ' - ' . $question->getField('name'));
+      $file_data["entities_id"]        = isset($_SESSION['glpiactive_entity'])
+                                             ? $_SESSION['glpiactive_entity']
+                                             : $form->getField('entities_id');
+      $file_data["is_recursive"]       = $form->getField('is_recursive');
+      $file_data['_filename']          = [$file];
+      $file_data['_prefix_filename']   = [$prefix];
 
       if ($docID = $doc->add($file_data)) {
          $docID    = intval($docID);


### PR DESCRIPTION
### Changes description

when responding to a form, the documents added to the name are "polluted" by a rand, this PR aims to correct the formatting of the names of documents

Before
![image](https://user-images.githubusercontent.com/7335054/47647479-6cef1880-db77-11e8-8e8b-6b9ea794ac21.png)

After
![image](https://user-images.githubusercontent.com/7335054/47647500-79737100-db77-11e8-80ed-b0c52c32a6c5.png)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ x] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A