### PR TITLE
fix(core): clean doc name on create issue

### DIFF
--- a/inc/fields/filefield.class.php
+++ b/inc/fields/filefield.class.php
@@ -144,7 +144,7 @@ class PluginFormcreatorFileField extends PluginFormcreatorField
     *
     * @return integer|NULL
     */
-   private function saveDocument($file) {
+   private function saveDocument($file, $prefix) {
       global $DB;
 
       $sectionTable = PluginFormcreatorSection::getTable();
@@ -177,14 +177,15 @@ class PluginFormcreatorFileField extends PluginFormcreatorField
          return;
       }
 
-      $doc                        = new Document();
-      $file_data                 = [];
-      $file_data["name"]         = Toolbox::addslashes_deep($form->getField('name'). ' - ' . $this->fields['name']);
-      $file_data["entities_id"]  = isset($_SESSION['glpiactive_entity'])
-                                   ? $_SESSION['glpiactive_entity']
-                                   : $form->getField('entities_id');
-      $file_data["is_recursive"] = $form->getField('is_recursive');
-      $file_data['_filename'] = [$file];
+      $doc                          = new Document();
+      $file_data                       = [];
+      $file_data["name"]               = Toolbox::addslashes_deep($form->getField('name'). ' - ' . $this->fields['name']);
+      $file_data["entities_id"]        = isset($_SESSION['glpiactive_entity'])
+                                       ? $_SESSION['glpiactive_entity']
+                                       : $form->getField('entities_id');
+      $file_data["is_recursive"]       = $form->getField('is_recursive');
+      $file_data['_filename']          = [$file];
+      $file_data['_prefix_filename']   = [$prefix];
       if ($docID = $doc->add($file_data)) {
          return $docID;
       }
@@ -199,10 +200,13 @@ class PluginFormcreatorFileField extends PluginFormcreatorField
          }
 
          $answer_value = [];
+         $index = 0;
          foreach ($input["_$key"] as $document) {
             if (is_file(GLPI_TMP_DIR . '/' . $document)) {
-               $answer_value[] = $this->saveDocument($document);
+               $prefix = $input['_prefix_formcreator_field_' . $this->fields['id']][$index];
+               $answer_value[] = $this->saveDocument($document, $prefix);
             }
+            $index++;
          }
          $this->uploadData = $answer_value;
          $this->value = __('Attached document', 'formcreator');


### PR DESCRIPTION
### Changes description

when responding to a form, the documents added to the name are "polluted" by a rand, this PR aims to correct the formatting of the names of documents

Before
![image](https://user-images.githubusercontent.com/7335054/47647479-6cef1880-db77-11e8-8e8b-6b9ea794ac21.png)

After
![image](https://user-images.githubusercontent.com/7335054/47647500-79737100-db77-11e8-80ed-b0c52c32a6c5.png)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ x] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #975 