### PR TITLE
fix(target): content generation

### DIFF
--- a/front/form.form.php
+++ b/front/form.form.php
@@ -120,7 +120,7 @@ if (isset($_POST["add"])) {
       }
 
       // Save form
-      if (!$form->saveForm($_POST)) {
+      if ($form->saveForm($_POST) === false) {
          Html::back();
       }
       $form->increaseUsageCount();

--- a/inc/fields/datetimefield.class.php
+++ b/inc/fields/datetimefield.class.php
@@ -96,7 +96,7 @@ class PluginFormcreatorDatetimeField extends PluginFormcreatorField
    }
 
    public static function getName() {
-      return __('Datetime', 'formcreator');
+      return __('Date & time', 'formcreator');
    }
 
    public static function getPrefs() {
@@ -155,7 +155,8 @@ class PluginFormcreatorDatetimeField extends PluginFormcreatorField
          return false;
       }
 
-      if (DateTime::createFromFormat("Y-m-d H:i", $input[$key]) === false) {
+      if ($input[$key] != ''
+         && DateTime::createFromFormat("Y-m-d H:i", $input[$key]) === false) {
          return false;
       }
 

--- a/inc/fields/textareafield.class.php
+++ b/inc/fields/textareafield.class.php
@@ -115,7 +115,7 @@ class PluginFormcreatorTextareaField extends PluginFormcreatorTextField
    }
 
    public function getValueForTargetText($richText) {
-      return str_replace("\r\n", '\r\n', Toolbox::addslashes_deep($this->value));
+      return $this->value;
    }
 
    public static function getJSFields() {

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1163,7 +1163,7 @@ class PluginFormcreatorForm extends CommonDBTM implements PluginFormcreatorExpor
     * Validates answers of a form and saves them in database
     *
     * @param array $input fields from the HTML form
-    * @return boolean true if the form is valid, false otherwise
+    * @return integer|boolean ID of the form_answer if sucess, false otherwise
     */
    public function saveForm($input) {
       $valid = true;
@@ -1199,7 +1199,7 @@ class PluginFormcreatorForm extends CommonDBTM implements PluginFormcreatorExpor
 
       // Check required_validator
       if ($this->fields['validation_required'] && empty($input['formcreator_validator'])) {
-         Session::addMessageAfterRedirect(__('You must select validator !', 'formcreator'), false, ERROR);
+         Session::addMessageAfterRedirect(__('You must select validator!', 'formcreator'), false, ERROR);
          $valid = false;
       }
 
@@ -1210,9 +1210,7 @@ class PluginFormcreatorForm extends CommonDBTM implements PluginFormcreatorExpor
       }
 
       $formanswer = new PluginFormcreatorForm_Answer();
-      $formanswer->saveAnswers($this, $input, $fields);
-
-      return true;
+      return $formanswer->saveAnswers($this, $input, $fields);
    }
 
    public function increaseUsageCount() {

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1205,7 +1205,7 @@ class PluginFormcreatorForm extends CommonDBTM implements PluginFormcreatorExpor
 
       if (!$valid) {
          // Save answers in session to display it again with the same values
-         $_SESSION['formcreator']['data'] = $input;
+         $_SESSION['formcreator']['data'] = Toolbox::stripslashes_deep($input);
          return false;
       }
 

--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -684,7 +684,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
                         : -1;
 
       $question = new PluginFormcreatorQuestion();
-      $questions = $question->getQuestionsFromForm($data['formcreator_form']);
+      $questions = $question->getQuestionsFromForm($form->getID());
 
       //Collect answers
       $answer_value = [];
@@ -747,7 +747,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
                                                 ? $_SESSION['glpiactive_entity']
                                                 : $form->fields['entities_id'],
             'is_recursive'                => $form->fields['is_recursive'],
-            'plugin_formcreator_forms_id' => $data['formcreator_form'],
+            'plugin_formcreator_forms_id' => $form->getID(),
             'requester_id'                => isset($_SESSION['glpiID'])
                                                 ? $_SESSION['glpiID']
                                                 : 0,
@@ -961,12 +961,11 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
     * @return boolean
     */
    public function refuseAnswers($data) {
-      $data['plugin_formcreator_forms_id'] = intval($data['formcreator_form']);
-      $data['status']                      = 'refused';
-      $data['save_formanswer']             = true;
+      $data['status']          = 'refused';
+      $data['save_formanswer'] = true;
 
       $form   = new PluginFormcreatorForm();
-      $form->getFromDB($data['plugin_formcreator_forms_id']);
+      $form->getFromDB((int) $data['formcreator_form']);
 
       $fields = [];
       // Prepare form fields for validation
@@ -995,12 +994,11 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
     * @return boolean
     */
    public function acceptAnswers($data) {
-      $data['plugin_formcreator_forms_id'] = intval($data['formcreator_form']);
       $data['status']                      = 'accepted';
       $data['save_formanswer']             = true;
 
       $form   = new PluginFormcreatorForm();
-      $form->getFromDB($data['plugin_formcreator_forms_id']);
+      $form->getFromDB((int) $data['formcreator_form']);
 
       if (!$this->canValidate($form, $this)) {
          Session::addMessageAfterRedirect(__('You are not the validator of these answers', 'formcreator'), true, ERROR);
@@ -1101,7 +1099,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
 
       $question_no = 0;
       $output      = '';
-      $eol = "\r\n";
+      $eol = "\n";
 
       if ($richText) {
          $output .= '<h1>' . __('Form data', 'formcreator') . '</h1>';
@@ -1170,8 +1168,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
                $output .= '<h2>' . Toolbox::addslashes_deep($question_line['section_name']) . '</h2>';
             } else {
                $output .= $eol . Toolbox::addslashes_deep($question_line['section_name']) . $eol;
-               $output .= '---------------------------------';
-               $output .= $eol;
+               $output .= '---------------------------------' . $eol;
             }
             $last_section = $question_line['section_name'];
          }

--- a/inc/form_answer.class.php
+++ b/inc/form_answer.class.php
@@ -1068,7 +1068,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
       $answers = $answer->find("`plugin_formcreator_forms_answers_id` = '$formAnswerId'");
       $answers_values = [];
       foreach ($answers as $found_answer) {
-         $answers_values['formcreator_field_' . $found_answer['plugin_formcreator_questions_id']] = stripslashes($found_answer['answer']);
+         $answers_values['formcreator_field_' . $found_answer['plugin_formcreator_questions_id']] = $found_answer['answer'];
       }
       return $answers_values;
    }
@@ -1099,7 +1099,7 @@ class PluginFormcreatorForm_Answer extends CommonDBChild
 
       $question_no = 0;
       $output      = '';
-      $eol = "\n";
+      $eol = '\n';
 
       if ($richText) {
          $output .= '<h1>' . __('Form data', 'formcreator') . '</h1>';

--- a/inc/targetbase.class.php
+++ b/inc/targetbase.class.php
@@ -976,7 +976,7 @@ EOS;
          }
 
          $content = str_replace('##question_' . $questionId . '##', Toolbox::addslashes_deep($name), $content);
-         $content = str_replace('##answer_' . $questionId . '##', $value, $content);
+         $content = str_replace('##answer_' . $questionId . '##', Toolbox::addslashes_deep($value), $content);
          foreach ($fields[$questionId]->getDocumentsForTarget() as $documentId) {
             $this->addAttachedDocument($documentId);
          }

--- a/inc/targetbase.class.php
+++ b/inc/targetbase.class.php
@@ -940,7 +940,7 @@ EOS;
     *
     * @param  string $content                            String to be parsed
     * @param  PluginFormcreatorForm_Answer $formanswer   Formanswer object where answers are stored
-    * @param  boolean $richText                   Disable rich text mode for field rendering
+    * @param  boolean $richText                          Disable rich text mode for field rendering
     * @return string                                     Parsed string with tags replaced by form values
     */
    protected function parseTags($content, PluginFormcreatorForm_Answer $formanswer, $richText = false) {
@@ -1143,5 +1143,28 @@ JAVASCRIPT;
       }
 
       return $input;
+   }
+
+   /**
+    * Prepare the template of the target
+    *
+    * @param string $template
+    * @param PluginFormcreatorForm_Answer $formAnswer form answer to render
+    * @param boolean $richText Disable rich text output
+    * @return string
+    */
+   protected function prepareTemplate($template, PluginFormcreatorForm_Answer $formAnswer, $richText = false) {
+      global $CFG_GLPI;
+
+      if (strpos($template, '##FULLFORM##') !== false) {
+         $template = str_replace('##FULLFORM##', $formAnswer->getFullForm($richText), $template);
+      }
+
+      if ($richText) {
+         $template = str_replace(['<p>', '</p>'], ['<div>', '</div>'], $template);
+         $template = Html::entities_deep($template);
+      }
+
+      return $template;
    }
 }

--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -966,11 +966,11 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
          'checklistcontent'
       ];
       foreach ($changeFields as $changeField) {
-         $data[$changeField] = $this->fields[$changeField];
-         $data[$changeField] = str_replace("\r\n", '\r\n', $data[$changeField]);
-         if (strpos($data[$changeField], '##FULLFORM##') !== false) {
-            $data[$changeField] = str_replace('##FULLFORM##', $formanswer->getFullForm(), $data[$changeField]);
-         }
+         $data[$changeField] = $this->prepareTemplate(
+            $this->fields[$changeField],
+            $formanswer,
+            true
+         );
 
          $data[$changeField] = $this->parseTags($data[$changeField], $formanswer);
       }

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -1097,13 +1097,13 @@ EOS;
       $data['name'] = $this->prepareTemplate(
          $this->fields['name'],
          $formanswer,
-         true
+         false
       );
       $data['name'] = $this->parseTags($data['name'], $formanswer);
       $data['content'] = $this->prepareTemplate(
          $this->fields['content'],
          $formanswer,
-         false
+         $richText
       );
 
       $data['content'] = $this->parseTags($data['content'], $formanswer, $richText);

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -1094,25 +1094,20 @@ EOS;
       // TODO: generate instances of all answers of the form and use them for the fullform computation
       //       and the computation from a admin-defined target ticket template
       $richText = version_compare(PluginFormcreatorCommon::getGlpiVersion(), 9.4) >= 0 || $CFG_GLPI['use_rich_text'];
-      $data['name'] = $this->fields['name'];
+      $data['name'] = $this->prepareTemplate(
+         $this->fields['name'],
+         $formanswer,
+         true
+      );
       $data['name'] = $this->parseTags($data['name'], $formanswer);
-      $data['name'] = Toolbox::addslashes_deep($data['name']);
-
-      $data['content'] = $this->fields['content'];
-      $data['content'] = str_replace("\r\n", '\r\n', $data['content']);
-      if (strpos($data['content'], '##FULLFORM##') !== false) {
-         $data['content'] = str_replace('##FULLFORM##', $formanswer->getFullForm($richText), $data['content']);
-      }
-      if ($richText) {
-         // replace HTML P tags with DIV tags
-         $data['content'] = str_replace(['<p>', '</p>'], ['<div>', '</div>'], $data['content']);
-      }
+      $data['content'] = $this->prepareTemplate(
+         $this->fields['content'],
+         $formanswer,
+         false
+      );
 
       $data['content'] = $this->parseTags($data['content'], $formanswer, $richText);
-      if ($richText) {
-         $data['content'] = htmlentities($data['content'], ENT_NOQUOTES);
-      }
-      $data['content'] = Toolbox::addslashes_deep($data['content']);
+
       $data['_users_id_recipient'] = $_SESSION['glpiID'];
       $data['_tickettemplates_id'] = $this->fields['tickettemplates_id'];
 

--- a/tests/src/PluginFormcreatorTargetChangeDummy.php
+++ b/tests/src/PluginFormcreatorTargetChangeDummy.php
@@ -42,4 +42,8 @@ class PluginFormcreatorTargetChangeDummy extends \PluginFormcreatorTargetChange
    public function publicGetTargetEntity(\PluginFormcreatorForm_Answer $formanswer, $requesters_id) {
       return $this->getTargetEntity($formanswer, $requesters_id);
    }
+
+   public function publicPrepareTemplate($template, \PluginFormcreatorForm_Answer $formAnswer, $disableRichText = false) {
+      return $this->prepareTemplate($template, $formAnswer, $disableRichText);
+   }
 }

--- a/tests/src/PluginFormcreatorTargetTicketDummy.php
+++ b/tests/src/PluginFormcreatorTargetTicketDummy.php
@@ -42,4 +42,8 @@ class PluginFormcreatorTargetTicketDummy extends \PluginFormcreatorTargetTicket
    public function publicGetTargetEntity(\PluginFormcreatorForm_Answer $formanswer, $requesters_id) {
       return $this->getTargetEntity($formanswer, $requesters_id);
    }
+
+   public function publicPrepareTemplate($template, \PluginFormcreatorForm_Answer $formAnswer, $disableRichText = false) {
+      return $this->prepareTemplate($template, $formAnswer, $disableRichText);
+   }
 }

--- a/tests/suite-unit/PluginFormcreatorDatetimeField.php
+++ b/tests/suite-unit/PluginFormcreatorDatetimeField.php
@@ -156,8 +156,8 @@ class PluginFormcreatorDatetimeField extends CommonTestCase {
             'input' => [
                'formcreator_field_1' => ''
             ],
-            'expected' => false,
-            'expectedValue' => null,
+            'expected' => true,
+            'expectedValue' => ' ',
          ],
          [
             'id' => '1',

--- a/tests/suite-unit/PluginFormcreatorTargetTicket.php
+++ b/tests/suite-unit/PluginFormcreatorTargetTicket.php
@@ -307,8 +307,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
       $sectionName = $section->fields['name'];
       $questionTag = '##question_' . $question->getID() . '##';
       $answerTag = '##answer_' . $question->getID() . '##';
-      $eolSimple = "\n";
-      $eolRich = "\r\n";
+      $eolSimple = '\n';
       // 2 expected values
       // 0 : Rich text mode disabled
       // 1 : Rich text mode enabled


### PR DESCRIPTION
probably caused by a chery-pick from release 2.6.5

Attempt to resolve in deep the template rendering isues, and add unit tests to prevent regressions

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #1193 