### PR TITLE
Fix entities restriction for dropdown fields

### DIFF
--- a/inc/fields/checkboxesfield.class.php
+++ b/inc/fields/checkboxesfield.class.php
@@ -225,7 +225,7 @@ class PluginFormcreatorCheckboxesField extends PluginFormcreatorField
    }
 
    public function getDocumentsForTarget() {
-      return [];;
+      return [];
    }
 
    public static function getPrefs() {

--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -57,6 +57,7 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
             $dparams = ['name'     => $fieldName,
                         'value'    => $this->value,
                         'comments' => false,
+                        'entity'   => $_SESSION['glpiactive_entity'],
                         'rand'     => $rand];
 
             switch ($itemtype) {
@@ -78,13 +79,13 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
                         $dparams['condition'] .= " AND `is_incident` = '1'";
                         break;
                      case 'both':
-                        $dparams['condition'] .= " AND `is_incident` = '1' OR `is_request` = '1' ";
+                        $dparams['condition'] .= " AND (`is_incident` = '1' OR `is_request` = '1')";
                         break;
                      case 'change':
                         $dparams['condition'] .= " AND `is_change` = '1'";
                         break;
                      case 'all':
-                        $dparams['condition'] .= " AND `is_change` = '1' OR `is_incident` = '1' OR  `is_request` = '1'";
+                        $dparams['condition'] .= " AND (`is_change` = '1' OR `is_incident` = '1' OR  `is_request` = '1')";
                         break;
                   }
                   if (isset($decodedValues['show_ticket_categories_depth'])

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -979,7 +979,7 @@ class PluginFormcreatorQuestion extends CommonDBChild implements PluginFormcreat
       $defaultValues = '';
       if (!$this->isNewItem()) {
          $fieldObject = PluginFormcreatorFields::getFieldInstance(
-            $this->getField('fieldtype'),
+            $this->fields['fieldtype'],
             $this
          );
          $fieldObject->deserializeValue($this->fields['default_values']);


### PR DESCRIPTION
### Changes description

When a dropdown field has entities_id column, we must obey entities restrictions

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #1208 