### PR TITLE
Update relation

### DIFF
--- a/install/upgrade_to_2.7.php
+++ b/install/upgrade_to_2.7.php
@@ -53,6 +53,13 @@ class PluginFormcreatorUpgradeTo2_7 {
          ]
       );
       $DB->update(
+         'glpi_changes_items', [
+            'itemtype' => 'PluginFormcreatorFormAnswer',
+         ], [
+            'itemtype' => 'PluginFormcreatorForm_Answer'
+         ]
+      );
+      $DB->update(
          'glpi_notifications', [
             'itemtype' => 'PluginFormcreatorFormAnswer',
          ], [


### PR DESCRIPTION
when upgrading to 2.7.0 the plugin needs to update relation between form answers and changes

Version 2.7.0 renames PluginFormcreatorForm_Answer to PluginFormcreatorFormAnswer

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A