### PR TITLE
Email field as source of actors

### DIFF
--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -225,7 +225,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorTargetBase
                    WHERE s.id = {$section['id']}
                    AND ((q.fieldtype = 'glpiselect'
                      AND q.values IN ('User', 'Group', 'Supplier'))
-                     OR (q.fieldtype = 'actor'))";
+                     OR (q.fieldtype IN ('actor', 'email')))";
          $result2 = $DB->query($query2);
          $section_questions_user       = [];
          $section_questions_group      = [];
@@ -246,6 +246,8 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorTargetBase
                }
             } else if ($question['fieldtype'] == 'actor') {
                $section_questions_actors[$question['id']] = $question['name'];
+            } else if ($question['fieldtype'] == 'email') {
+               $section_questions_user[$question['id']] = $question['name'];
             }
          }
          $questions_user_list[$section['name']]     = $section_questions_user;


### PR DESCRIPTION
actors field is not allowed for anonymous forms, then allow email field to be used to populate requester, observer or assigned


### Changes description
Fix problem identified here: https://github.com/pluginsGLPI/formcreator/issues/475#issuecomment-455592563

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A