### PR TITLE
Rename the plugin

### DIFF
--- a/install/upgrade_to_2.7.php
+++ b/install/upgrade_to_2.7.php
@@ -306,5 +306,13 @@ class PluginFormcreatorUpgradeTo2_7 {
          $id = $row['id'];
          $DB->query("UPDATE `glpi_plugin_formcreator_forms` SET `name` = '$name', `description` = '$description', `content` = '$content' WHERE `id` = '$id'");
       }
+
+      // Rename the plugin
+      $plugin = new Plugin();
+      $plugin->getFromDBbyDir('formcreator');
+      $success = $plugin->update([
+         'id' => $plugin->getID(),
+         'name' => 'Form Creator',
+      ]);
    }
 }

--- a/install/upgrade_to_2.7.php
+++ b/install/upgrade_to_2.7.php
@@ -306,13 +306,5 @@ class PluginFormcreatorUpgradeTo2_7 {
          $id = $row['id'];
          $DB->query("UPDATE `glpi_plugin_formcreator_forms` SET `name` = '$name', `description` = '$description', `content` = '$content' WHERE `id` = '$id'");
       }
-
-      // Rename the plugin
-      $plugin = new Plugin();
-      $plugin->getFromDBbyDir('formcreator');
-      $success = $plugin->update([
-         'id' => $plugin->getID(),
-         'name' => 'Form Creator',
-      ]);
    }
 }

--- a/install/upgrade_to_2.8.php
+++ b/install/upgrade_to_2.8.php
@@ -58,5 +58,13 @@ class PluginFormcreatorUpgradeTo2_8 {
          }
       }
       $migration->addField($table, 'associate_question', 'integer', ['after' => 'associate_rule']);
+
+      // Rename the plugin
+      $plugin = new Plugin();
+      $plugin->getFromDBbyDir('formcreator');
+      $success = $plugin->update([
+         'id' => $plugin->getID(),
+         'name' => 'Form Creator',
+      ]);
    }
 }

--- a/setup.php
+++ b/setup.php
@@ -56,7 +56,7 @@ function plugin_version_formcreator() {
       return false;
    }
    $requirements = [
-      'name'           => _n('Form', 'Forms', 2, 'formcreator'),
+      'name'           => 'Form Creator',
       'version'        => PLUGIN_FORMCREATOR_VERSION,
       'author'         => '<a href="http://www.teclib.com">Teclib\'</a>',
       'homepage'       => 'https://github.com/pluginsGLPI/formcreator',

--- a/tests/suite-install/Config.php
+++ b/tests/suite-install/Config.php
@@ -145,4 +145,10 @@ class Config extends CommonTestCase {
          $this->array($update_diff)->isEmpty("Index missing in empty for $table: " . implode(', ', $update_diff));
       }
    }
+
+   public function testPluginName() {
+      $plugin = new \Plugin();
+      $plugin->getFromDBbyDir(TEST_PLUGIN_NAME);
+      $this->string($plugin->fields['name'])->isEqualTo('Form Creator');
+   }
 }


### PR DESCRIPTION
The plugin has a misleading name in the list of plugins. It is form creator, then it must show with these words

closes #1264

Signed-off-by: Thierry Bugier <tbugier@teclib.com>

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #1264 