### PR TITLE
More resilient export / import

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1914,7 +1914,6 @@ class PluginFormcreatorForm extends CommonDBTM implements PluginFormcreatorExpor
 
          $importLinker = new PluginFormcreatorImportLinker();
          foreach ($forms_toimport['forms'] as $form) {
-            //self::import($form);
             self::import($importLinker, $form);
          }
          if (!$importLinker->importPostponed()) {
@@ -2020,6 +2019,8 @@ class PluginFormcreatorForm extends CommonDBTM implements PluginFormcreatorExpor
 
    public static function import(PluginFormcreatorImportLinker $importLinker, $form = []) {
       global $DB;
+
+      set_time_limit(30);
 
       $form_obj = new self;
       $entity   = new Entity;


### PR DESCRIPTION
If many forms are being exported, it may be possible to hit the php time limit.

fixes also warnings on import when the export of form_profile is incomplete
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A