### PR TITLE
Fix default value of integer and float fields

### DIFF
--- a/inc/fields/floatfield.class.php
+++ b/inc/fields/floatfield.class.php
@@ -165,7 +165,11 @@ class PluginFormcreatorFloatField extends PluginFormcreatorField
       }
 
       if (isset($input['default_values'])) {
-         $this->value = (float) str_replace(',', '.', $input['default_values']);
+         if ($input['default_values'] != '') {
+            $this->value = (float) str_replace(',', '.', $input['default_values']);
+         } else {
+            $this->value = '';
+         }
       }
       $input['values'] = '';
 

--- a/inc/fields/integerfield.class.php
+++ b/inc/fields/integerfield.class.php
@@ -166,7 +166,11 @@ class PluginFormcreatorIntegerField extends PluginFormcreatorField
       }
 
       if (isset($input['default_values'])) {
-         $this->value = (int) $input['default_values'];
+         if ($input['default_values'] != '') {
+            $this->value = (int) $input['default_values'];
+         } else {
+            $this->value = '';
+         }
       }
       $input['values'] = '';
 


### PR DESCRIPTION
empty string support for default vfalues of integer and float fields. Without this fix, the value "0" is forced while editing  the question properties

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A