### PR TITLE
fix escaping of form name when inserting formanswer

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -657,7 +657,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
    public function prepareInputForAdd($input) {
       $form = new PluginFormcreatorForm();
       $form->getFromDB($input['plugin_formcreator_forms_id']);
-      $input['name'] = $form->getName();
+      $input['name'] = Toolbox::addslashes_deep($form->getName());
 
       return $input;
    }


### PR DESCRIPTION
### Changes description

```
[2019-02-05 14:05:10] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/9.4-git/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: INSERT INTO `glpi_plugin_formcreator_formanswers` (`entities_id`, `is_recursive`, `plugin_formcreator_forms_id`, `requester_id`, `users_id_validator`, `groups_id_validator`, `status`, `request_date`, `name`) VALUES ('0', '0', '4', '2', '0', '0', 'accepted', '2019-02-05 14:05:10', 'test'test')
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'test')' at line 1
  Backtrace :
  inc/dbmysql.class.php:821                          
  inc/commondbtm.class.php:658                       DBmysql->insert()
  inc/commondbtm.class.php:1140                      CommonDBTM->addToDB()
  plugins/formcreator/inc/formanswer.class.php:774   CommonDBTM->add()
  plugins/formcreator/inc/form.class.php:1220        PluginFormcreatorFormAnswer->saveAnswers()
  plugins/formcreator/front/form.form.php:123        PluginFormcreatorForm->saveForm()
  {"user":"2@LU002"} 
[2019-02-05 14:05:11] glpisqllog.ERROR: DBmysql::query() in /var/www/html/glpi/9.4-git/inc/dbmysql.class.php line 177
  *** MySQL query error:
  SQL: INSERT INTO `glpi_items_tickets` (`itemtype`, `items_id`, `tickets_id`) VALUES ('PluginFormcreatorFormAnswer', NULL, '3175')
  Error: Column 'items_id' cannot be null
  Backtrace :
  inc/dbmysql.class.php:821                          
  inc/commondbtm.class.php:658                       DBmysql->insert()
  inc/commondbtm.class.php:1140                      CommonDBTM->addToDB()
  ...ins/formcreator/inc/targetticket.class.php:1358 CommonDBTM->add()
  plugins/formcreator/inc/formanswer.class.php:1073  PluginFormcreatorTargetTicket->save()
  plugins/formcreator/inc/formanswer.class.php:817   PluginFormcreatorFormAnswer->generateTarget()
  plugins/formcreator/inc/form.class.php:1220        PluginFormcreatorFormAnswer->saveAnswers()
  plugins/formcreator/front/form.form.php:123        PluginFormcreatorForm->saveForm()
  {"user":"2@LU002","mem_usage":"0.007\", 17.09Mio)"} 

```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated
