### PR TITLE
fix(form): fix anonymous file upload

### DIFF
--- a/front/formdisplay.php
+++ b/front/formdisplay.php
@@ -90,6 +90,7 @@ if (isset($_REQUEST['id'])
 
    // If user was not authenticated, remove temporary user
    if ($_SESSION['glpiname'] == 'formcreator_temp_user') {
+      session_write_close();
       unset($_SESSION['glpiname']);
    }
 

--- a/inc/fields/filefield.class.php
+++ b/inc/fields/filefield.class.php
@@ -43,15 +43,11 @@ class PluginFormcreatorFileField extends PluginFormcreatorField
       if ($canEdit) {
          $required = $this->isRequired() ? ' required' : '';
 
-         echo '<input type="hidden" class="form-control"
-                  name="formcreator_field_' . $this->fields['id'] . '" value="" />' . PHP_EOL;
-
          echo Html::file([
             'name'    => 'formcreator_field_' . $this->fields['id'],
             'display' => false,
             'multiple' => 'multiple',
          ]);
-
       } else {
          $doc = new Document();
          $answer = $this->value;


### PR DESCRIPTION
### Changes description

A fake session is ceated by  the plugin to run an anonymous form, but it is not saved server side, making the file upload fail.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #925 