### PR TITLE
Formanswer must display name, not the ID

### DIFF
--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -165,7 +165,19 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
             pluginFormcreatorInitializeDropdown('$fieldName', '$rand');
          });");
       } else {
-         echo $this->value;
+         $decodedValues = json_decode($this->fields['values'], JSON_OBJECT_AS_ARRAY);
+         if ($decodedValues === null) {
+            $itemtype = $this->fields['values'];
+         } else {
+            $itemtype = $decodedValues['itemtype'];
+         }
+         $item = new $itemtype();
+         $value = '';
+         if ($item->getFromDB($this->value)) {
+            $value = $item->getField('name');
+         }
+
+         echo $value;
       }
    }
 


### PR DESCRIPTION
### Changes description

for glpi object and dropdown fields, when a user displays answers for a form, the ID are displayed instead if the names.

https://forum.glpi-project.org/viewtopic.php?id=167952

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A