### PR TITLE
Show user firstname and lastname

### DIFF
--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -206,14 +206,18 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
    public function getValueForTargetText($richText) {
       $DbUtil = new DbUtils();
       $decodedValues = json_decode($this->fields['values'], JSON_OBJECT_AS_ARRAY);
-      if (!isset($decodedValues['itemtype'])) {
-         $value = Dropdown::getDropdownName($DbUtil->getTableForItemType($this->fields['values']), $this->value);
-      } else {
-         $value = Dropdown::getDropdownName($DbUtil->getTableForItemType($decodedValues['itemtype']), $this->value);
+      $itemtype = $this->fields['values'];
+      if (isset($decodedValues['itemtype'])) {
+         $itemtype = $decodedValues['itemtype'];
       }
-
+      if ($itemtype == User::class) {
+         $value = (new DBUtils())->getUserName($this->value);
+      } else {
+         $value = Dropdown::getDropdownName($DbUtil->getTableForItemType($itemtype), $this->value);
+      }
       return Toolbox::addslashes_deep($value);
    }
+
 
    public function getDocumentsForTarget() {
       return [];

--- a/tests/suite-unit/PluginFormcreatorGlpiselectField.php
+++ b/tests/suite-unit/PluginFormcreatorGlpiselectField.php
@@ -249,12 +249,12 @@ class PluginFormcreatorGlpiselectField extends CommonTestCase {
       return $dataset;
    }
 
-   public function ptroviderIsValid() {
+   public function providerIsValid() {
       return $this->providerGetAnswer();
    }
 
    /**
-    * @dataProvider ptroviderIsValid
+    * @dataProvider providerIsValid
     */
    public function testIsValid($fields, $data, $expectedValue, $expectedValidity) {
       $instance = $this->newTestedInstance($fields, $data);
@@ -274,5 +274,46 @@ class PluginFormcreatorGlpiselectField extends CommonTestCase {
       $instance = $this->newTestedInstance([]);
       $output = $instance->isPrerequisites();
       $this->boolean($output)->isEqualTo(true);
+   }
+
+   public function testGetValueForTargetText() {
+      $computer = new \Computer();
+      $computer->add([
+         'name' => 'computer foo',
+         'entities_id' => 0,
+      ]);
+
+      // Create a question glpi Object / computer
+      $question = $this->getQuestion([
+         'fieldtype' => 'glpiselect',
+         'values'    => \Computer::class,
+      ]);
+      $instance = $this->newTestedInstance($question->fields);
+      $instance->deserializeValue($computer->getID());
+
+      // test for the target text
+      $output = $instance->getValueForTargetText(true);
+      $this->string($output)->isEqualTo('computer foo');
+
+      // Create a user with first and last name
+      $user = new \User();
+      $user->add([
+         'name'       => 'foobar' . $this->getUniqueString(),
+         'firstname'  => 'foo',
+         'realname'   => 'bar',
+      ]);
+      $this->boolean($user->isNewItem())->isFalse();
+
+      // Create a question glpi Object / User
+      $question = $this->getQuestion([
+         'fieldtype' => 'glpiselect',
+         'values'    => \User::class,
+      ]);
+      $instance = $this->newTestedInstance($question->fields);
+      $instance->deserializeValue($user->getID());
+
+      // test the text for target
+      $output = $instance->getValueForTargetText(true);
+      $this->string($output)->isEqualTo('bar foo');
    }
 }


### PR DESCRIPTION
fix regression compared  to older versions of the plugin

when a glpi select field uses a User itemtype, the generated target shall show the name of the user, not his login.

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A