### PR TITLE
Logout icon on first releases of GLPI 9.3.x

### DIFF
--- a/inc/wizard.class.php
+++ b/inc/wizard.class.php
@@ -211,7 +211,7 @@ class PluginFormcreatorWizard {
       if (isset($_SESSION['glpiextauth']) && $_SESSION['glpiextauth']) {
          echo '?noAUTO=1';
       }
-      echo '" class="fa fa-sign-out-alt" title="'.__s('Logout').'">';
+      echo '" class="fa fa-sign-out fa-sign-out-alt" title="'.__s('Logout').'">';
       echo '<span id="logout_icon" title="'.__s('Logout').'" alt="'.__s('Logout').'" class="button-icon"></span></a>';
       echo '</li>';
 


### PR DESCRIPTION
It seems that the icon is missing with GLPI 9.2.1 or 9.3.2.

Add old and new class to ensure font awesome works for all supported GLPI versions.

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A