### PR TITLE
Uploaded files lost

### DIFF
--- a/inc/fieldinterface.class.php
+++ b/inc/fieldinterface.class.php
@@ -113,9 +113,10 @@ interface PluginFormcreatorFieldInterface
    /**
     * Read the value of the field from answers
     * @param array $input answers of all questions of the form
+    * @param boolean $nonDestructive for File field, ensure that the file uploads imported as document
     * @return boolean true on sucess, false otherwise
     */
-   public function parseAnswerValues($input);
+   public function parseAnswerValues($input, $nonDestructive = false);
 
    /**
     * Prepares an answer value for output in a target object

--- a/inc/fields.class.php
+++ b/inc/fields.class.php
@@ -325,7 +325,7 @@ class PluginFormcreatorFields
             $question->fields['fieldtype'],
             $question
          );
-         $fields[$id]->parseAnswerValues($input);
+         $fields[$id]->parseAnswerValues($input, true);
       }
 
       $questionToShow = [];

--- a/inc/fields/actorfield.class.php
+++ b/inc/fields/actorfield.class.php
@@ -249,7 +249,7 @@ class PluginFormcreatorActorField extends PluginFormcreatorField
       return $input;
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!isset($input[$key])) {
          $this->value = [];

--- a/inc/fields/checkboxesfield.class.php
+++ b/inc/fields/checkboxesfield.class.php
@@ -114,7 +114,7 @@ class PluginFormcreatorCheckboxesField extends PluginFormcreatorField
       return implode("\r\n", $this->value);
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!isset($input[$key])) {
          $input[$key] = [];

--- a/inc/fields/datefield.class.php
+++ b/inc/fields/datefield.class.php
@@ -146,7 +146,7 @@ class PluginFormcreatorDateField extends PluginFormcreatorField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
 
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {

--- a/inc/fields/datetimefield.class.php
+++ b/inc/fields/datetimefield.class.php
@@ -149,7 +149,7 @@ class PluginFormcreatorDatetimeField extends PluginFormcreatorField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {
          return false;

--- a/inc/fields/descriptionfield.class.php
+++ b/inc/fields/descriptionfield.class.php
@@ -122,7 +122,7 @@ class PluginFormcreatorDescriptionField extends PluginFormcreatorField
       throw new PluginFormcreatorComparisonException('Meaningless comparison');
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       return true;
    }
 

--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -386,7 +386,7 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!isset($input[$key])) {
          $input[$key] = '0';

--- a/inc/fields/emailfield.class.php
+++ b/inc/fields/emailfield.class.php
@@ -138,7 +138,7 @@ class PluginFormcreatorEmailField extends PluginFormcreatorField
       return $input;
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {
          return false;

--- a/inc/fields/filefield.class.php
+++ b/inc/fields/filefield.class.php
@@ -188,7 +188,7 @@ class PluginFormcreatorFileField extends PluginFormcreatorField
       return null;
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (isset($input["_$key"])) {
          if (!is_array($input["_$key"])) {
@@ -197,12 +197,16 @@ class PluginFormcreatorFileField extends PluginFormcreatorField
 
          $answer_value = [];
          $index = 0;
-         foreach ($input["_$key"] as $document) {
-            if (is_file(GLPI_TMP_DIR . '/' . $document)) {
-               $prefix = $input['_prefix_formcreator_field_' . $this->fields['id']][$index];
-               $answer_value[] = $this->saveDocument($document, $prefix);
+         if ($nonDestructive) {
+            $index = count($input["_$key"]);
+         } else {
+            foreach ($input["_$key"] as $document) {
+               if (is_file(GLPI_TMP_DIR . '/' . $document)) {
+                  $prefix = $input['_prefix_formcreator_field_' . $this->fields['id']][$index];
+                  $answer_value[] = $this->saveDocument($document, $prefix);
+               }
+               $index++;
             }
-            $index++;
          }
          $this->uploadData = $answer_value;
          $this->value = __('Attached document', 'formcreator');

--- a/inc/fields/floatfield.class.php
+++ b/inc/fields/floatfield.class.php
@@ -176,7 +176,7 @@ class PluginFormcreatorFloatField extends PluginFormcreatorField
       return $input;
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {
          return false;

--- a/inc/fields/hiddenfield.class.php
+++ b/inc/fields/hiddenfield.class.php
@@ -92,7 +92,7 @@ class PluginFormcreatorHiddenField extends PluginFormcreatorField
       ];
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {
          return false;

--- a/inc/fields/hostnamefield.class.php
+++ b/inc/fields/hostnamefield.class.php
@@ -65,7 +65,7 @@ class PluginFormcreatorHostnameField extends PluginFormcreatorField
       ];
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {
          return false;

--- a/inc/fields/integerfield.class.php
+++ b/inc/fields/integerfield.class.php
@@ -222,7 +222,7 @@ class PluginFormcreatorIntegerField extends PluginFormcreatorField
       ];
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {
          return false;

--- a/inc/fields/ipfield.class.php
+++ b/inc/fields/ipfield.class.php
@@ -103,7 +103,7 @@ class PluginFormcreatorIpField extends PluginFormcreatorField
       ];
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {
          return false;

--- a/inc/fields/ldapselectfield.class.php
+++ b/inc/fields/ldapselectfield.class.php
@@ -185,7 +185,7 @@ class PluginFormcreatorLdapselectField extends PluginFormcreatorSelectField
       return "tab_fields_fields['ldapselect'] = 'showFields(" . implode(', ', $prefs) . ");';";
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!isset($input[$key])) {
          $input[$key] = '';

--- a/inc/fields/multiselectfield.class.php
+++ b/inc/fields/multiselectfield.class.php
@@ -212,7 +212,7 @@ class PluginFormcreatorMultiSelectField extends PluginFormcreatorField
       ];
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!isset($input[$key])) {
          $input[$key] = [];

--- a/inc/fields/radiosfield.class.php
+++ b/inc/fields/radiosfield.class.php
@@ -106,7 +106,7 @@ class PluginFormcreatorRadiosField extends PluginFormcreatorField
       return $input;
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (isset($input[$key])) {
          if (!is_string($input[$key])) {

--- a/inc/fields/selectfield.class.php
+++ b/inc/fields/selectfield.class.php
@@ -81,7 +81,7 @@ class PluginFormcreatorSelectField extends PluginFormcreatorMultiselectField
       return $input;
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!is_string($input[$key])) {
          return false;

--- a/inc/fields/tagfield.class.php
+++ b/inc/fields/tagfield.class.php
@@ -124,7 +124,7 @@ class PluginFormcreatorTagField extends PluginFormcreatorDropdownField
       return $input;
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!isset($input[$key])) {
          $input[$key] = [];

--- a/inc/fields/textfield.class.php
+++ b/inc/fields/textfield.class.php
@@ -179,7 +179,7 @@ class PluginFormcreatorTextField extends PluginFormcreatorField
       return "tab_fields_fields['text'] = 'showFields(" . implode(', ', $prefs) . ");';";
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!isset($input[$key])) {
          return false;

--- a/inc/fields/urgencyfield.class.php
+++ b/inc/fields/urgencyfield.class.php
@@ -69,7 +69,7 @@ class PluginFormcreatorUrgencyField extends PluginFormcreatorField
       return $input;
    }
 
-   public function parseAnswerValues($input) {
+   public function parseAnswerValues($input, $nonDestructive = false) {
       $key = 'formcreator_field_' . $this->fields['id'];
       if (!isset($input[$key])) {
          $input[$key] = '3';

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -733,7 +733,6 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
                   'plugin_formcreator_questions_id' => $questionId,
                ]);
                $answer->update([
-
                   'id'     => $answer->getID(),
                   'answer' => $fields[$questionId]->serializeValue(),
                ], 0);


### PR DESCRIPTION
When a requester uploads a file then trigger a field visibility update, files are processed early and moved.
When saving answers, the file is no longer available for building the answer and the generated targets

Closes #1367 #1358 