### PR TITLE
Do not compute take into account time when adding the validation appr…

### DIFF
--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -1281,9 +1281,10 @@ EOS;
          PluginFormcreatorCommon::setNotification(false);
 
          $followUpInput = [
-           'date'     => $_SESSION['glpi_currenttime'],
-           'users_id' => Session::getLoginUserID(),
-           'content'  => $message,
+           'date'                            => $_SESSION['glpi_currenttime'],
+           'users_id'                        => Session::getLoginUserID(),
+           'content'                         => $message,
+           '_do_not_compute_takeintoaccount' => true
          ];
          if (class_exists(ITILFollowup::class)) {
             // GLPI 9.4+


### PR DESCRIPTION
Do not compute take into account time when adding the validation approval followup.
Without this the progression bar for "Take into account" is broken on a form with validation.

Internal ref : 17135
Depends on this GLPI pull request : [#6031](https://github.com/glpi-project/glpi/pull/6031)