### PR TITLE
Restrict available LDAP servers.

### DIFF
--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -836,8 +836,15 @@ class PluginFormcreatorQuestion extends CommonDBChild implements PluginFormcreat
       if ($ldap_values === null) {
          $ldap_values = [];
       }
+      $current_entity = $_SESSION['glpiactive_entity'];
+      if ($current_entity == 0) {
+         $auth_ldap_condition = '';
+      } else {
+         $auth_ldap_condition = "glpi_authldaps.id = (select glpi_entities.authldaps_id from glpi_entities where id=${current_entity})";
+      }
       Dropdown::show('AuthLDAP', [
          'name'      => 'ldap_auth',
+         'condition' => $auth_ldap_condition,
          'rand'      => $rand,
          'value'     => (isset($ldap_values['ldap_auth'])) ? $ldap_values['ldap_auth'] : '',
          'on_change' => 'change_LDAP(this)',


### PR DESCRIPTION
Hi!

At work, we found a issue with your plugin. We realized that a new client that started using our GLPI could see and use any LDAP configured through the "LDAP Select" type.

This means that any client, with enough privileges in his entity, can see/use our LDAP and any LDAP of other clients.

We quickly implement an workaround based on many assumptions. There is probably a better way to fix this problem but I provide this pull request in case it helps someone or if you want to use it as a starting point.

### Changes description

![2019-06-21 22-16-42](https://user-images.githubusercontent.com/44313383/59949173-a3fd9b80-9472-11e9-924b-4c2644102ca7.png)

You can view any available LDAP if you have access
to the root entity.

Otherwise, only the LDAP configured as the default
for the current entity is displayed.
