### PR TITLE
Root and depth params for all CommonTreeDropdown

### DIFF
--- a/ajax/commonTree.php
+++ b/ajax/commonTree.php
@@ -1,0 +1,47 @@
+<?php
+
+use function GuzzleHttp\json_encode;
+
+include ('../../../inc/includes.php');
+header('Content-Type: application/json');
+
+if (!isset($_GET['itemtype']) || !isset($_GET['values'])) {
+    http_response_code(400);
+    die;
+}
+
+$itemtype = $_GET['itemtype'];
+$values   = json_decode(stripcslashes($_GET['values']), true);
+
+if (!is_a($itemtype, "CommonTreeDropdown", true)) {
+    die;
+}
+
+$rootValue = Dropdown::EMPTY_VALUE;
+if (isset($values['show_ticket_categories_root'])) {
+    $rootValue = $values['show_ticket_categories_root'];
+}
+$root = Dropdown::show($itemtype, [
+    'name'    => 'show_ticket_categories_root',
+    'value'   => $rootValue,
+    'rand'    => mt_rand(),
+    'display' => false,
+ ]);
+
+$deptValue = 0;
+if (isset($values['show_ticket_categories_depth'])) {
+    $deptValue = $values['show_ticket_categories_depth'];
+}
+$depth = dropdown::showNumber('show_ticket_categories_depth', [
+    'rand'    => $rand,
+    'value'   => $deptValue,
+    'min'     => 1,
+    'max'     => 16,
+    'toadd'   => [0 => __('No limit', 'formcreator')],
+    'display' => false,
+]);
+
+echo json_encode([
+    'root'  => $root,
+    'depth' => $depth,
+]);

--- a/ajax/commonTree.php
+++ b/ajax/commonTree.php
@@ -1,7 +1,5 @@
 <?php
 
-use function GuzzleHttp\json_encode;
-
 include ('../../../inc/includes.php');
 header('Content-Type: application/json');
 

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -990,14 +990,14 @@ class PluginFormcreatorQuestion extends CommonDBChild implements PluginFormcreat
       echo '<tr class="line1" id="cat_root_tr">';
       echo '<td>';
       echo '<label for="dropdown_root_ticket_categories'.$rand.'" id="label_root_ticket_categories">';
-      echo __('ticket categories root', 'formcreator');
+      echo __('Tree root', 'formcreator');
       echo '</label>';
       echo '</td>';
       echo '<td id="td_show_ticket_categories_root">';
       echo '</td>';
       echo '<td>';
       echo '<label for="dropdown_show_ticket_categories_depth'.$rand.'" id="label_show_ticket_categories_depth">';
-      echo __('Limit ticket categories depth', 'formcreator');
+      echo __('Max depth of tree', 'formcreator');
       echo '</label>';
       echo '</td>';
       echo '<td id="td_show_ticket_categories_depth">';


### PR DESCRIPTION
Allow any CommonTreeDropdown field to use the root and dept params.
![image](https://user-images.githubusercontent.com/42734840/62943586-1b004200-bddb-11e9-8027-8d80889bc3c3.png)


I'll do the 2.9 port after the validation.