### PR TITLE
Remove unused searchtype

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -329,8 +329,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
          'field'              => 'status',
          'name'               => __('Status'),
          'searchtype'         => [
-            '0'                  => 'equals',
-            '1'                  => 'notequals'
+            '0'                  => 'equals'
          ],
          'datatype'           => 'specific',
          'massiveaction'      => false


### PR DESCRIPTION
Internal ref: 17654

The current `notequals` search type for status doesn't work: 
![image](https://user-images.githubusercontent.com/42734840/63332841-96f90d80-c338-11e9-9863-c547d8587628.png)


To make the previous example work, you should use the `NOT` link:
![image](https://user-images.githubusercontent.com/42734840/63332890-b1cb8200-c338-11e9-8932-d3c031e50f44.png)

The `notequals`searchtype should just be be delete as it doesn't work and isn't consistent with the searchtypes available for `Ticket`.