### PR TITLE
Allow self-service to see formcreator objects

### DIFF
--- a/inc/category.class.php
+++ b/inc/category.class.php
@@ -35,12 +35,12 @@ if (!defined('GLPI_ROOT')) {
 
 class PluginFormcreatorCategory extends CommonTreeDropdown
 {
-   static function canView() {
-      return Session::haveRight('ticket', CREATE);
-   }
-
    // Activate translation on GLPI 0.85
    var $can_be_translated = true;
+
+   static function canView() {
+      return parent::canView() || $_SESSION['glpiactiveprofile']['interface'] == 'helpdesk';
+   }
 
    public static function getTypeName($nb = 1) {
       return _n('Form category', 'Form categories', $nb, 'formcreator');

--- a/inc/category.class.php
+++ b/inc/category.class.php
@@ -35,6 +35,10 @@ if (!defined('GLPI_ROOT')) {
 
 class PluginFormcreatorCategory extends CommonTreeDropdown
 {
+   static function canView() {
+      return Session::haveRight('ticket', CREATE);
+   }
+
    // Activate translation on GLPI 0.85
    var $can_be_translated = true;
 

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -56,7 +56,7 @@ PluginFormcreatorDuplicatableInterface
    }
 
    public static function canView() {
-      return Session::haveRight('ticket', CREATE);
+      return Session::haveRight('entity', UPDATE) || $_SESSION['glpiactiveprofile']['interface'] == 'helpdesk';
    }
 
    public static function canDelete() {

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -56,7 +56,7 @@ PluginFormcreatorDuplicatableInterface
    }
 
    public static function canView() {
-      return Session::haveRight('entity', UPDATE);
+      return Session::haveRight('ticket', CREATE);
    }
 
    public static function canDelete() {


### PR DESCRIPTION
This is needed to access the formcreator objects though the API as a self-service user.
