### PR TITLE
Allow forms to be submitted through API

### DIFF
--- a/inc/formanswerapi.class.php
+++ b/inc/formanswerapi.class.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * Formcreator is a plugin which allows creation of custom forms of
+ * easy access.
+ * ---------------------------------------------------------------------
+ * LICENSE
+ *
+ * This file is part of Formcreator.
+ *
+ * Formcreator is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Formcreator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Formcreator. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ * @copyright Copyright © 2011 - 2019 Teclib'
+ * @license   http://www.gnu.org/licenses/gpl.txt GPLv3+
+ * @link      https://github.com/pluginsGLPI/formcreator/
+ * @link      https://pluginsglpi.github.io/formcreator/
+ * @link      http://plugins.glpi-project.org/#/plugin/formcreator
+ * ---------------------------------------------------------------------
+ */
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+class PluginFormcreatorFormAnswerAPI extends CommonDBTM
+{
+   public static function canCreate() {
+      return true;
+   }
+
+   function add(array $input, $options = [], $history = true) {
+      $form = new PluginFormcreatorForm();
+      $id = $input['formcreator_form'];
+
+      $form->getFromDB($id);
+
+      if (!$form) {
+         return;
+      }
+
+      $newID = $form->saveForm($input);
+      $form->increaseUsageCount();
+      return $newID;
+   }
+}


### PR DESCRIPTION
As seen in #1486, the $form->saveForm() endpoint is not reachable from the API.

This is a simple fix to allow form creation though the API using a new "PluginFormcreatorFormAnswerAPI" endpoint that forward the request to the $form->saveForm() endpoint.  


As we discussed, the correct way to solve this would be use the $formanswer->add() entry point but it would require a lot of code re-factorization which require a good knowledge of this plugin and time that I currently lake.  


These proposed changes won't impact the plugin in any way and allow us to move forward with this feature (the "clean" way can always be implemented later on).  

