### PR TITLE
Add the new forms styling options to searchoptions

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -221,7 +221,7 @@ PluginFormcreatorDuplicatableInterface
          'id'                 => '31',
          'table'              => $this->getTable(),
          'field'              => 'icon',
-         'name'               => __('Icon'),
+         'name'               => __('Icon', 'formcreator'),
          'massiveaction'      => false
       ];
 
@@ -229,7 +229,7 @@ PluginFormcreatorDuplicatableInterface
          'id'                 => '32',
          'table'              => $this->getTable(),
          'field'              => 'icon_color',
-         'name'               => __('Icon color'),
+         'name'               => __('Icon color', 'formcreator'),
          'massiveaction'      => false
       ];
 
@@ -237,7 +237,7 @@ PluginFormcreatorDuplicatableInterface
          'id'                 => '33',
          'table'              => $this->getTable(),
          'field'              => 'background_color',
-         'name'               => __('Background color'),
+         'name'               => __('Background color', 'formcreator'),
          'massiveaction'      => false
       ];
 

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -217,6 +217,30 @@ PluginFormcreatorDuplicatableInterface
          'massiveaction'      => true
       ];
 
+      $tab[] = [
+         'id'                 => '31',
+         'table'              => $this->getTable(),
+         'field'              => 'icon',
+         'name'               => __('Icon'),
+         'massiveaction'      => false
+      ];
+
+      $tab[] = [
+         'id'                 => '32',
+         'table'              => $this->getTable(),
+         'field'              => 'icon_color',
+         'name'               => __('Icon color'),
+         'massiveaction'      => false
+      ];
+
+      $tab[] = [
+         'id'                 => '33',
+         'table'              => $this->getTable(),
+         'field'              => 'background_color',
+         'name'               => __('Background color'),
+         'massiveaction'      => false
+      ];
+
       return $tab;
    }
 


### PR DESCRIPTION
This is need to retrieve them when using the `search` endpoint of the API.