### PR TITLE
fix(dropdownfield,glpiselectfield): empty value parameter not honored

### DIFF
--- a/ajax/dropdown_values.php
+++ b/ajax/dropdown_values.php
@@ -37,20 +37,28 @@ if (!isset($_REQUEST['dropdown_itemtype'])
     || $_REQUEST['dropdown_itemtype'] == '0'
     || !class_exists($_REQUEST['dropdown_itemtype'])) {
    Dropdown::showFromArray(
-      'dropdown_default_value', 
+      'dropdown_default_value',
       [], [
          'display_emptychoice'   => true
       ]
    );
 } else {
+   $itemtype = $_REQUEST['dropdown_itemtype'];
    $question = new PluginFormcreatorQuestion();
    $question->getFromDB((int) $_REQUEST['id']);
-   $defaultValue = isset($question->fields['default_values']) 
+   $defaultValue = isset($question->fields['default_values'])
                    ? $question->fields['default_values']
                    : 0;
-   Dropdown::show($_REQUEST['dropdown_itemtype'], [
+
+   $options = [
       'name'  => 'dropdown_default_value',
       'rand'  => mt_rand(),
       'value' => $defaultValue,
-   ]);
+   ];
+   if ($itemtype == Entity::class) {
+      $options['toadd'] = [
+         -1 => Dropdown::EMPTY_VALUE,
+      ];
+   }
+   Dropdown::show($itemtype, $options);
 }

--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -60,13 +60,13 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
       }
 
       $optgroup = Dropdown::getStandardDropdownItemTypes();
-      array_unshift($optgroup, '---');
       $field = '<div id="dropdown_values_field">';
       $field .= Dropdown::showFromArray('dropdown_values', $optgroup, [
-         'value'     => $itemtype,
-         'rand'      => $rand,
-         'on_change' => 'plugin_formcreator_changeDropdownItemtype("' . $rand . '");',
-         'display'   => false,
+         'value'               => $itemtype,
+         'rand'                => $rand,
+         'on_change'           => 'plugin_formcreator_changeDropdownItemtype("' . $rand . '");',
+         'display_emptychoice' => true,
+         'display'             => false,
       ]);
 
       $decodedValues = json_decode($this->question->fields['values'], JSON_OBJECT_AS_ARRAY);

--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -253,7 +253,16 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
 
             $dparams['condition'] = $dparams_cond_crit;
 
-            $dparams['display_emptychoice'] = ($this->question->fields['show_empty'] !== '0');
+            $dparams['display_emptychoice'] = false;
+            if ($itemtype != Entity::class) {
+               $dparams['display_emptychoice'] = ($this->question->fields['show_empty'] !== '0');
+            } else {
+               if ($this->question->fields['show_empty'] !== '0') {
+                  $dparams['toadd'] = [
+                     -1 => Dropdown::EMPTY_VALUE,
+                  ];
+               }
+            }
 
             $emptyItem = new $itemtype();
             $emptyItem->getEmpty();

--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -136,7 +136,6 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
          $id           = $this->question->getID();
          $rand         = mt_rand();
          $fieldName    = 'formcreator_field_' . $id;
-         $domId        = $fieldName . '_' . $rand;
          if (!empty($this->question->fields['values'])) {
             $decodedValues = json_decode($this->question->fields['values'], JSON_OBJECT_AS_ARRAY);
             if ($decodedValues === null) {
@@ -254,6 +253,8 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
 
             $dparams['condition'] = $dparams_cond_crit;
 
+            $dparams['display_emptychoice'] = ($this->question->fields['show_empty'] !== '0');
+
             $emptyItem = new $itemtype();
             $emptyItem->getEmpty();
             $dparams['displaywith'] = [];
@@ -263,23 +264,7 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
             if (isset($emptyItem->fields['otherserial'])) {
                $dparams['displaywith'][] = 'otherserial';
             }
-            if (count($dparams['displaywith']) > 0) {
-               $dparams['itemtype'] = $itemtype;
-               $dparams['table'] = $itemtype::getTable();
-               $dparams['multiple'] = false;
-               $dparams['valuename'] = Dropdown::EMPTY_VALUE;
-               if ($dparams['value'] != 0) {
-                  $dparams['valuename'] = $dparams['value'];
-               }
-               echo Html::jsAjaxDropdown(
-                  $fieldName,
-                  $domId,
-                  $CFG_GLPI['root_doc']."/ajax/getDropdownFindNum.php",
-                  $dparams
-               );
-            } else {
-               $itemtype::dropdown($dparams);
-            }
+            $itemtype::dropdown($dparams);
          }
          echo PHP_EOL;
          echo Html::scriptBlock("$(function() {


### PR DESCRIPTION
With entity itemtype, a dropdown does not show the empty value.

Also itemtypes having serial or otherserial don't respect show_empty parameter.