### PR TITLE
Last valid answer

### DIFF
--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -665,10 +665,22 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
     * @return string
     */
    protected function getSubItemtype() {
-      $decodedValues = json_decode($this->question->fields['values'], JSON_OBJECT_AS_ARRAY);
+      return self::getSubItemtypeForValues($this->question->fields['values']);
+   }
+
+   /**
+    * Get the itemtype of the item to show for the given values
+    *
+    * @param string $values json or raw string
+    *
+    * @return string
+    */
+   public static function getSubItemtypeForValues($values) {
+      $decodedValues = json_decode($values, JSON_OBJECT_AS_ARRAY);
       if ($decodedValues === null) {
-         return $this->question->fields['values'];
+         return $values;
       }
-         return $decodedValues['itemtype'];
+
+      return $decodedValues['itemtype'];
    }
 }

--- a/inc/targetbase.class.php
+++ b/inc/targetbase.class.php
@@ -375,6 +375,8 @@ PluginFormcreatorConditionnableInterface
    protected function setTargetCategory($data, $formanswer) {
       global $DB;
 
+      $category = null;
+
       switch ($this->fields['category_rule']) {
          case self::CATEGORY_RULE_ANSWER:
             $category = $DB->request([
@@ -391,7 +393,6 @@ PluginFormcreatorConditionnableInterface
             $category = $this->fields['category_question'];
             break;
          case self::CATEGORY_RULE_LAST_ANSWER:
-            $category = null;
             $form_id = $formanswer->fields['id'];
 
             // Get all answers for dropdown questions of this form, ordered
@@ -419,12 +420,10 @@ PluginFormcreatorConditionnableInterface
 
             foreach ($answers as $answer) {
                // Decode dropdown settings
-               $values = json_decode($answer['values']);
+               $itemtype = \PluginFormcreatorDropdownField::getSubItemtypeForValues($answer['values']);
 
                // Skip if not a dropdown on categories
-               if (!isset($values->itemtype)
-                  || $values->itemtype !== "ITILCategory"
-               ) {
+               if ($itemtype !== "ITILCategory") {
                   continue;
                }
 
@@ -438,9 +437,6 @@ PluginFormcreatorConditionnableInterface
                break;
             }
             break;
-
-         default:
-            $category = null;
       }
       if ($category !== null) {
          $data['itilcategories_id'] = $category;


### PR DESCRIPTION
### Changes description

Add a new target option "Last valid answer" for categories and associated items.

This option pick the last answered question that is a valid target for this answer :
* Any dropdown question with the type "ITILCategory" for categories.
* Any glpiobject question with a type matching a valid asset itemtype for associated items.

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [ ] Docs have been added/updated
