### PR TITLE
Fix image paste on multiple pages

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -216,8 +216,16 @@ function plugin_init_formcreator() {
             ];
          }
 
-         if (strpos($_SERVER['REQUEST_URI'], 'plugins/formcreator/front/targetticket.form.php') !== false) {
-            Html::requireJs('tinymce');
+         $pages = [
+            "plugins/formcreator/front/targetticket.form.php",
+            "plugins/formcreator/front/formdisplay.php",
+            "plugins/formcreator/front/form.form.php"
+         ];
+         foreach ($pages as $page) {
+            if (strpos($_SERVER['REQUEST_URI'], $page) !== false) {
+               Html::requireJs('tinymce');
+               break;
+            }
          }
 
          if (strpos($_SERVER['REQUEST_URI'], 'helpdesk') !== false


### PR DESCRIPTION
Image paste is not working on multiple pages because `fileupload.js` is loaded before `tinymce.js`.
We need tinymce to be loaded first to set up our custom upload plugin:

#### fileupload.js
```js
/**
 * Plugin for tinyMce editor who intercept paste event
 * to check if a file upload can be proceeded
 * @param  {[Object]} editor TinyMCE editor
 */
if (typeof tinymce != 'undefined') {
    tinymce.PluginManager.add('glpi_upload_doc', function(editor) {
        editor.on('PastePreProcess', function(event) {


```



### Changes description

Force tinymce to be loaded first on the following pages :
* Form preview 
* Self service with formcreator interface
* Form in tech interface

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Possibly internal ref 18722 ?