### PR TITLE
update readme url

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -53,7 +53,7 @@ Features
    <homepage>https://pluginsglpi.github.io/formcreator/</homepage>
    <download>https://github.com/pluginsGLPI/formcreator/releases</download>
    <issues>https://github.com/pluginsGLPI/formcreator/issues</issues>
-   <readme>https://github.com/pluginsGLPI/formcreator/blob/master/README.md</readme>
+   <readme>https://glpi-plugins.readthedocs.io/en/latest/formcreator/index.html</readme>
    <authors>
       <author>Jérémy Moreau</author>
       <author>Thierry Bugier</author>


### PR DESCRIPTION
with the incoming marketplace feature in glpi 9.5, we thought we must link docs.
Instead adding a new xml node, readme one could be the best one currently.

I target develop, but if you can cherry-pick on master, it will be directly available (at least on plugins directory).