### PR TITLE
Self service can close own ticket

### DIFF
--- a/ajax/cancelticket.php
+++ b/ajax/cancelticket.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * Formcreator is a plugin which allows creation of custom forms of
+ * easy access.
+ * ---------------------------------------------------------------------
+ * LICENSE
+ *
+ * This file is part of Formcreator.
+ *
+ * Formcreator is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Formcreator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Formcreator. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ * @copyright Copyright © 2011 - 2019 Teclib'
+ * @license   http://www.gnu.org/licenses/gpl.txt GPLv3+
+ * @link      https://github.com/pluginsGLPI/formcreator/
+ * @link      https://pluginsglpi.github.io/formcreator/
+ * @link      http://plugins.glpi-project.org/#/plugin/formcreator
+ * ---------------------------------------------------------------------
+ */
+
+include ('../../../inc/includes.php');
+if (!isset($_POST['id'])) {
+    http_response_code(400);
+    exit;
+}
+$ticketId = (int) $_POST['id'];
+PluginFormcreatorCommon::cancelMyTicket($ticketId);

--- a/ajax/commontree.php
+++ b/ajax/commontree.php
@@ -1,4 +1,33 @@
 <?php
+/**
+ * ---------------------------------------------------------------------
+ * Formcreator is a plugin which allows creation of custom forms of
+ * easy access.
+ * ---------------------------------------------------------------------
+ * LICENSE
+ *
+ * This file is part of Formcreator.
+ *
+ * Formcreator is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Formcreator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Formcreator. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ * @copyright Copyright © 2011 - 2019 Teclib'
+ * @license   http://www.gnu.org/licenses/gpl.txt GPLv3+
+ * @link      https://github.com/pluginsGLPI/formcreator/
+ * @link      https://pluginsglpi.github.io/formcreator/
+ * @link      http://plugins.glpi-project.org/#/plugin/formcreator
+ * ---------------------------------------------------------------------
+ */
 include ('../../../inc/includes.php');
 
 // Check required parameters

--- a/css/styles.css
+++ b/css/styles.css
@@ -1375,6 +1375,9 @@ span.fc_list_icon {
    color: #a0a0a0;
 }
 
+.plugin_formcreator_cancel_my_ticket {
+   background: #fec95c;
+}
 
 /* ################--------------- Responsive  ---------------#################### */
 @media screen and (max-width: 700px) {

--- a/hook.php
+++ b/hook.php
@@ -207,6 +207,7 @@ function plugin_formcreator_addWhere($link, $nott, $itemtype, $ID, $val, $search
    switch ($table.".".$field) {
       case "glpi_plugin_formcreator_issues.status" :
          $tocheck = [];
+         /** @var CommonITILObject $item  */
          if ($item = getItemForItemtype($itemtype)) {
             switch ($val) {
                case 'all':
@@ -218,6 +219,7 @@ function plugin_formcreator_addWhere($link, $nott, $itemtype, $ID, $val, $search
                   break;
 
                case 'process' :
+                  // getProcessStatusArray should be an abstract method of CommonITILObject
                   $tocheck = $item->getProcessStatusArray();
                   break;
 

--- a/hook.php
+++ b/hook.php
@@ -483,3 +483,24 @@ function plugin_formcreator_dynamicReport($params) {
 
    return false;
 }
+
+/**
+ * Hook for timeline_actions; display a new action for a CommonITILObject
+ * @see CommonITILObject
+ *
+ * @return void
+ */
+function plugin_formcreator_timelineActions($options) {
+   $item = $options['item'];
+   if (!$item->canDeleteItem()) {
+      return;
+   }
+
+   if (!(isset($_SESSION['glpiactiveprofile']) &&
+       $_SESSION['glpiactiveprofile']['interface'] == 'helpdesk')) {
+      return;
+   }
+   echo "<li class='plugin_formcreator_cancel_my_ticket' onclick='".
+      "javascript:plugin_formcreator_cancelMyTicket(".$item->fields['id'].");'>"
+      ."<i class='fa'></i>".__('Cancel my ticket', 'formcreator')."</li>";
+}

--- a/hook.php
+++ b/hook.php
@@ -106,7 +106,7 @@ function plugin_formcreator_getCondition($itemtype) {
    $table = $itemtype::getTable();
    if ($itemtype == PluginFormcreatorFormAnswer::class) {
       if (Session::haveRight('config', UPDATE)) {
-         return "";
+         return '';
       }
       if (plugin_formcreator_canValidate()) {
          $groupUser = new Group_User();

--- a/hook.php
+++ b/hook.php
@@ -96,6 +96,12 @@ function plugin_formcreator_canValidate() {
       || Session::haveRight('ticketvalidation', TicketValidation::VALIDATEREQUEST);
 }
 
+/**
+ * Undocumented function
+ *
+ * @param string $itemtype
+ * @return string
+ */
 function plugin_formcreator_getCondition($itemtype) {
    $table = $itemtype::getTable();
    if ($itemtype == PluginFormcreatorFormAnswer::class) {

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -229,4 +229,14 @@ class PluginFormcreatorCommon {
       $output .= '<i id="' . $previewId . '" class="'. $options['value'] . '"></i>';
       echo $output;
    }
+
+   public static function cancelMyTicket($id) {
+      $ticket = new Ticket();
+      $ticket->getFromDB($id);
+      if (!$ticket->canRequesterUpdateItem()) {
+         return false;
+      }
+
+      return $ticket->delete($ticket->fields);
+   }
 }

--- a/js/scripts.js.php
+++ b/js/scripts.js.php
@@ -1261,3 +1261,14 @@ function plugin_formcreator_updateCompositePeerType(rand) {
       $('#plugin_formcreator_link_target').show();
    }
 }
+
+function plugin_formcreator_cancelMyTicket(id) {
+   $.ajax({
+      url: rootDoc + '/plugins/formcreator/ajax/cancelticket.php',
+      data: {id: id},
+      type: "POST",
+      dataType: "json"
+   }).done(function(response) {
+      reloadTab;
+   });
+}

--- a/setup.php
+++ b/setup.php
@@ -154,6 +154,8 @@ function plugin_init_formcreator() {
       PluginFormcreatorTargetTicket::class => 'plugin_formcreator_hook_pre_purge_targetTicket',
       PluginFormcreatorTargetChange::class => 'plugin_formcreator_hook_pre_purge_targetChange'
    ];
+   // hook to add custom actions on a ticket in service catalog
+   $PLUGIN_HOOKS['timeline_actions']['formcreator'] = 'plugin_formcreator_timelineActions';
 
    $plugin = new Plugin();
    if ($plugin->isInstalled('formcreator') && $plugin->isActivated('formcreator')) {


### PR DESCRIPTION
In GLPI, a user can delete his ticket if he is in self service, the ticket is new and does not has any timeline item.

Formcreator shall allow this as well