### PR TITLE
Counter support for validator group / fix bad value for status

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -142,7 +142,7 @@ function plugin_formcreator_addDefaultWhere($itemtype) {
          $condition = Search::addDefaultWhere(Ticket::class);
          $condition = str_replace('`glpi_tickets`', '`glpi_plugin_formcreator_issues`', $condition);
          $condition = str_replace('`users_id_recipient`', '`requester_id`', $condition);
-         $condition = "($condition OR `glpi_plugin_formcreator_issues`.`validator_id` = '" . Session::getLoginUserID() . "')";
+         $condition = "($condition OR `glpi_plugin_formcreator_issues`.`users_id_validator` = '" . Session::getLoginUserID() . "')";
          break;
 
       case PluginFormcreatorFormAnswer::class:
@@ -178,10 +178,16 @@ function plugin_formcreator_addLeftJoin($itemtype, $ref_table, $new_table, $link
          if ($new_table == 'glpi_groups') {
             foreach ($already_link_tables as $table) {
                if (strpos($table, $new_table) === 0) {
-                  $AS = $table;
+                  $ref = explode('.', $table);
+                  $AS = $ref[0];
+                  $fk = getForeignKeyFieldForTable($ref[0]);
+                  if (count($ref) > 1) {
+                     $AS = $ref[0];
+                     $fk = $ref[1];
+                  }
                }
             }
-            $join = " LEFT JOIN `$new_table` AS `$AS` ON (`glpi_groups_tickets_original_id`.`groups_id` = `$AS`.`id`) ";
+            $join = " LEFT JOIN `$new_table` AS `$AS` ON (`$ref_table`.`$fk` = `$AS`.`id`) ";
          }
 
          if ($new_table == 'glpi_users' &&  $linkfield == 'users_id') {
@@ -190,7 +196,7 @@ function plugin_formcreator_addLeftJoin($itemtype, $ref_table, $new_table, $link
                   $AS = $table;
                }
             }
-            $join = " LEFT JOIN `$new_table` AS `$AS` ON (`glpi_tickets_users_original_id`.`users_id` = `$AS`.`id`) ";
+            $join = " LEFT JOIN `$new_table` AS `$AS` ON (`$ref_table`.`users_id` = `$AS`.`id`) ";
          }
       break;
    }

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1331,17 +1331,18 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
             // There are several tickets for this form answer
             // The issue must be created from this form answer
             $issue->add([
-               'original_id'     => $this->getID(),
-               'sub_itemtype'    => PluginFormcreatorFormAnswer::class,
-               'name'            => addslashes($this->fields['name']),
-               'status'          => $this->fields['status'],
-               'date_creation'   => $this->fields['request_date'],
-               'date_mod'        => $this->fields['request_date'],
-               'entities_id'     => $this->fields['entities_id'],
-               'is_recursive'    => $this->fields['is_recursive'],
-               'requester_id'    => $this->fields['requester_id'],
-               'validator_id'    => $this->fields['users_id_validator'],
-               'comment'         => '',
+               'original_id'        => $this->getID(),
+               'sub_itemtype'       => PluginFormcreatorFormAnswer::class,
+               'name'               => addslashes($this->fields['name']),
+               'status'             => $this->fields['status'],
+               'date_creation'      => $this->fields['request_date'],
+               'date_mod'           => $this->fields['request_date'],
+               'entities_id'        => $this->fields['entities_id'],
+               'is_recursive'       => $this->fields['is_recursive'],
+               'requester_id'       => $this->fields['requester_id'],
+               'users_id_validator' => $this->fields['users_id_validator'],
+               'groups_id_validator'=> $this->fields['groups_id_validator'],
+               'comment'            => '',
             ]);
          } else {
             // There is one ticket for this form answer
@@ -1365,17 +1366,18 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
             );
             $ticketUserRow = array_pop($ticketUserRow);
             $issue->add([
-               'original_id'     => $ticketId,
-               'sub_itemtype'    => Ticket::class,
-               'name'            => addslashes($ticket->getField('name')),
-               'status'          => $ticket->getField('status'),
-               'date_creation'   => $ticket->getField('date'),
-               'date_mod'        => $ticket->getField('date_mod'),
-               'entities_id'     => $ticket->getField('entities_id'),
-               'is_recursive'    => '0',
-               'requester_id'    => $ticketUserRow['users_id'],
-               'validator_id'    => '',
-               'comment'         => addslashes($ticket->getField('content')),
+               'original_id'        => $ticketId,
+               'sub_itemtype'       => Ticket::class,
+               'name'               => addslashes($ticket->getField('name')),
+               'status'             => $ticket->getField('status'),
+               'date_creation'      => $ticket->getField('date'),
+               'date_mod'           => $ticket->getField('date_mod'),
+               'entities_id'        => $ticket->getField('entities_id'),
+               'is_recursive'       => '0',
+               'requester_id'       => $ticketUserRow['users_id'],
+               'users_id_validator' => '',
+               'groups_id_validator'=> '',
+               'comment'            => addslashes($ticket->getField('content')),
             ]);
          }
       }
@@ -1404,18 +1406,19 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
                ]
             ]);
             $issue->update([
-               'id'              => $issue->getID(),
-               'original_id'     => $this->getID(),
-               'sub_itemtype'    => PluginFormcreatorFormAnswer::class,
-               'name'            => addslashes($this->fields['name']),
-               'status'          => $this->fields['status'],
-               'date_creation'   => $this->fields['request_date'],
-               'date_mod'        => $this->fields['request_date'],
-               'entities_id'     => $this->fields['entities_id'],
-               'is_recursive'    => $this->fields['is_recursive'],
-               'requester_id'    => $this->fields['requester_id'],
-               'validator_id'    => $this->fields['users_id_validator'],
-               'comment'         => '',
+               'id'                 => $issue->getID(),
+               'original_id'        => $this->getID(),
+               'sub_itemtype'       => PluginFormcreatorFormAnswer::class,
+               'name'               => addslashes($this->fields['name']),
+               'status'             => $this->fields['status'],
+               'date_creation'      => $this->fields['request_date'],
+               'date_mod'           => $this->fields['request_date'],
+               'entities_id'        => $this->fields['entities_id'],
+               'is_recursive'       => $this->fields['is_recursive'],
+               'requester_id'       => $this->fields['requester_id'],
+               'users_id_validator' => $this->fields['users_id_validator'],
+               'groups_id_validator'=> $this->fields['groups_id_validator'],
+               'comment'            => '',
             ]);
          } else {
             // There is one ticket for this form answer
@@ -1445,18 +1448,19 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
                ]
              ]);
              $issue->update([
-                'id'              => $issue->getID(),
-                'original_id'     => $ticketId,
-                'sub_itemtype'    => Ticket::class,
-                'name'            => addslashes($ticket->getField('name')),
-                'status'          => $ticket->getField('status'),
-                'date_creation'   => $ticket->getField('date'),
-                'date_mod'        => $ticket->getField('date_mod'),
-                'entities_id'     => $ticket->getField('entities_id'),
-                'is_recursive'    => '0',
-                'requester_id'    => $ticketUserRow['users_id'],
-                'validator_id'    => '',
-                'comment'         => addslashes($ticket->getField('content')),
+                'id'                 => $issue->getID(),
+                'original_id'        => $ticketId,
+                'sub_itemtype'       => Ticket::class,
+                'name'               => addslashes($ticket->getField('name')),
+                'status'             => $ticket->getField('status'),
+                'date_creation'      => $ticket->getField('date'),
+                'date_mod'           => $ticket->getField('date_mod'),
+                'entities_id'        => $ticket->getField('entities_id'),
+                'is_recursive'       => '0',
+                'requester_id'       => $ticketUserRow['users_id'],
+                'users_id_validator' => '',
+                'groups_id_validator'=> '',
+                'comment'            => addslashes($ticket->getField('content')),
              ]);
          }
       } else {

--- a/install/mysql/plugin_formcreator_empty.sql
+++ b/install/mysql/plugin_formcreator_empty.sql
@@ -242,14 +242,16 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_formcreator_issues` (
   `date_mod` datetime NOT NULL,
   `entities_id` int(11) NOT NULL DEFAULT '0',
   `is_recursive` tinyint(1) NOT NULL DEFAULT '0',
-   `requester_id` int(11) NOT NULL DEFAULT '0',
-  `validator_id` int(11) NOT NULL DEFAULT '0',
+  `requester_id` int(11) NOT NULL DEFAULT '0',
+  `users_id_validator` int(11) NOT NULL DEFAULT '0',
+  `groups_id_validator` int(11) NOT NULL DEFAULT '0',
   `comment` longtext,
   PRIMARY KEY (`id`),
   INDEX `original_id_sub_itemtype` (`original_id`, `sub_itemtype`),
   INDEX `entities_id` (`entities_id`),
   INDEX `requester_id` (`requester_id`),
-  INDEX `validator_id` (`validator_id`)
+  INDEX `users_id_validator` (`users_id_validator`),
+  INDEX `groups_id_validator` (`groups_id_validator`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `glpi_plugin_formcreator_items_targettickets` (

--- a/install/upgrade_to_2.10.php
+++ b/install/upgrade_to_2.10.php
@@ -62,5 +62,14 @@ class PluginFormcreatorUpgradeTo2_10 {
       $migration->addField($table, 'show_rule', 'integer', ['value' => '1', 'after' => 'category_question']);
       $table = 'glpi_plugin_formcreator_targettickets';
       $migration->addField($table, 'show_rule', 'integer', ['value' => '1', 'after' => 'location_question']);
+
+      // support for validator group in issues
+      $table = 'glpi_plugin_formcreator_issues';
+      $migration->changeField($table, 'validator_id', 'users_id_validator', 'integer');
+      $migration->addField($table, 'groups_id_validator', 'integer', ['after' => 'users_id_validator']);
+      $migration->migrationOneTable($table);
+      $migration->dropKey($table, 'validator_id');
+      $migration->addKey($table, 'users_id_validator');
+      $migration->addKey($table, 'groups_id_validator');
    }
 }


### PR DESCRIPTION
It was reported that service catalog does not show forms waiting for validation.

This PR should address this. By the way, using nested criterias make searches more readable.

### To validate search

changed from
![image](https://user-images.githubusercontent.com/14139801/82220793-6376fe00-991f-11ea-8055-c34ab93149a7.png)

to

![image](https://user-images.githubusercontent.com/14139801/82220837-78ec2800-991f-11ea-9215-5eb204db808c.png)

The status was "new" by error; missed a conversion while removing enums. Now fixed.

### solved search

changed from
![image](https://user-images.githubusercontent.com/14139801/82221054-c4063b00-991f-11ea-9ff2-01aa2d848dfc.png)

to

![image](https://user-images.githubusercontent.com/14139801/82221089-ccf70c80-991f-11ea-8996-ac0db687f98c.png)

Here again, a string from the old enum was not updated.
