### PR TITLE
Self service compatibility / improvements

### DIFF
--- a/inc/fields/checkboxesfield.class.php
+++ b/inc/fields/checkboxesfield.class.php
@@ -210,6 +210,11 @@ class PluginFormcreatorCheckboxesField extends PluginFormcreatorField
          }
       }
 
+      // Not required and no answer -> valid
+      if (!$this->isRequired() && count($value) == 0) {
+         return true;
+      }
+
       $parameters = $this->getParameters();
 
       // Check the field matches the format regex

--- a/inc/fields/datefield.class.php
+++ b/inc/fields/datefield.class.php
@@ -132,9 +132,10 @@ class PluginFormcreatorDateField extends PluginFormcreatorField
    }
 
    public function isValidValue($value) {
-      if ($value == '') {
+      if (!$this->isRequired() && empty($value)) {
          return true;
       }
+
       $check = DateTime::createFromFormat(self::DATE_FORMAT, $value);
       return $check !== false;
    }

--- a/inc/fields/datetimefield.class.php
+++ b/inc/fields/datetimefield.class.php
@@ -135,9 +135,10 @@ class PluginFormcreatorDatetimeField extends PluginFormcreatorField
    }
 
    public function isValidValue($value) {
-      if ($value == '') {
+      if (!$this->isRequired() && empty($value)) {
          return true;
       }
+
       $check = DateTime::createFromFormat(self::DATE_FORMAT, $value);
       return $check !== false;
    }

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -1176,6 +1176,33 @@ PluginFormcreatorConditionnableInterface
          );
       }
 
+      if (isset($data['_questions'])) {
+         foreach ($data['_questions'] as $key => $question) {
+            if ($question['fieldtype'] == "dropdown") {
+               $question = new PluginFormcreatorQuestion();
+               $question->getFromDB($key);
+
+               /** @var PluginFormcreatorDropdownField */
+               $field = PluginFormcreatorFields::getFieldInstance(
+                  "dropdown",
+                  $question
+               );
+
+               $decodedValues = json_decode($question->fields['values'], JSON_OBJECT_AS_ARRAY);
+               if ($decodedValues === null) {
+                  $itemtype = $question->fields['values'];
+               } else {
+                  $itemtype = $decodedValues['itemtype'];
+               }
+
+               $searchParams = $field->buildParams();
+               $searchParams['itemtype'] = $itemtype;
+               $searchParams['show_empty'] = false;
+               $data['_questions'][$key]['_values'] = Dropdown::getDropdownValue($searchParams, false)['results'];
+            }
+         }
+      }
+
       // Load conditions, regexes and ranges
       $data['_conditions'] = self::getQuestionDataById(
          \PluginFormcreatorCondition::getTable(),


### PR DESCRIPTION
### Changes description

- Not mandatory > Range check for checkboxes (if checkbox is not mandatory and empty, no need to check the range)
- Allow empty value for non mandatory date and datetime question (not sure if this was an API only bug but empty values were rejected as an invalid format)
- For dropdown question, the possible answers are included in the question data when retrieving it from the API.
This is needed as self-services users doesn't have access to these itemtypes (and can't be granted access, this is a limitation of self-services profiles).

Something like that might be also needed later for ObjectGLPI questions but for now they are still querying directly the API for the available items.

### Checklist


- [ ] Tests for the changes have been added
- [x] Docs have been added/updated (Not needed)
