### PR TITLE
View of textarea with rich text

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -245,7 +245,8 @@ function plugin_init_formcreator() {
          $pages = [
             "plugins/formcreator/front/targetticket.form.php",
             "plugins/formcreator/front/formdisplay.php",
-            "plugins/formcreator/front/form.form.php"
+            "plugins/formcreator/front/form.form.php",
+            "plugins/formcreator/front/formanswer.form.php",
          ];
          foreach ($pages as $page) {
             if (strpos($_SERVER['REQUEST_URI'], $page) !== false) {


### PR DESCRIPTION
TinyMCE was not loaded when viewing a refused formanswer; needed F5 to refresh and get the exspected display.

fix #1802