### PR TITLE
Add full SLA/OLA support in target

### DIFF
--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -62,6 +62,12 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
       }
 
       $optgroup = Dropdown::getStandardDropdownItemTypes();
+
+      $optgroup[__('Service levels')] = [
+         SLA::getType() => __("SLA", "formcreator"),
+         OLA::getType() => __("OLA", "formcreator"),
+      ];
+
       $field = '<div id="dropdown_values_field">';
       $field .= Dropdown::showFromArray('dropdown_values', $optgroup, [
          'value'               => $itemtype,
@@ -119,6 +125,32 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
       $additions .= '</tr>';
       $additions .= Html::scriptBlock("plugin_formcreator_changeDropdownItemtype($rand);");
 
+      // Service level specific
+      $additions .= '<tr class="plugin_formcreator_question_specific plugin_formcreator_dropdown_service_level">';
+      $additions .= '<td>';
+      $additions .= '<label for="dropdown_show_service_level_types'.$rand.'" id="label_show_service_level_types">';
+      $additions .= __('Type', 'formcreator');
+      $additions .= '</label>';
+      $additions .= '</td>';
+      $additions .= '<td>';
+      $serviceLevelTypes = [
+         SLM::TTO  => __('Time to own', 'formcreator'),
+         SLM::TTR  => __('Time to resolve', 'formcreator'),
+      ];
+      $additions .= dropdown::showFromArray('show_service_level_types', $serviceLevelTypes, [
+         'rand'  => $rand,
+         'value' => isset($decodedValues['show_service_level_types'])
+                    ? $decodedValues['show_service_level_types']
+                    : SLM::TTO,
+         'display' => false,
+      ]);
+      $additions .= '</td>';
+      $additions .= '<td>';
+      $additions .= '</td>';
+      $additions .= '</td>';
+      $additions .= '<td>';
+      $additions .= '</tr>';
+
       $common = parent::getDesignSpecializationField();
       $additions .= $common['additions'];
 
@@ -158,6 +190,14 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
       );
 
       switch ($itemtype) {
+         case SLA::class:
+         case OLA::class:
+            // Apply service level type if defined
+            if (isset($decodedValues['show_service_level_types'])) {
+               $dparams_cond_crit['type'] = $decodedValues['show_service_level_types'];
+            }
+            break;
+
          case Entity::class:
             unset($dparams['entity']);
 
@@ -405,6 +445,9 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
       foreach ($stdtypes as $categoryOfTypes) {
          $allowedDropdownValues = array_merge($allowedDropdownValues, array_keys($categoryOfTypes));
       }
+      $allowedDropdownValues[] = SLA::getType();
+      $allowedDropdownValues[] = OLA::getType();
+
       if (!in_array($input['dropdown_values'], $allowedDropdownValues)) {
          Session::addMessageAfterRedirect(
                sprintf(__('Invalid dropdown type: %s', 'formcreator'), $input['name']),
@@ -431,6 +474,11 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
          $input['values']['show_ticket_categories_root'] = isset($input['show_ticket_categories_root'])
                                                             ? $input['show_ticket_categories_root']
                                                             : '';
+      } else if ($input['dropdown_values'] == SLA::getType()
+         || $input['dropdown_values'] == OLA::getType()
+      ) {
+         $input['values']['show_service_level_types'] = $input['show_service_level_types'];
+         unset($input['show_service_level_types']);
       }
 
       $input['values'] = json_encode($input['values']);

--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -358,6 +358,9 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
       echo '<td colspan="2"></td>';
       echo '</tr>';
 
+      $this->showSLASettings();
+      $this->showOLASettings();
+
       // -------------------------------------------------------------------------------------------
       //  category of the target
       // -------------------------------------------------------------------------------------------
@@ -483,6 +486,28 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
                default:
                   $input['category_question'] = '0';
             }
+         }
+
+         switch ($input['sla_rule']) {
+            case PluginFormcreatorTargetBase::SLA_RULE_SPECIFIC:
+               $input['sla_question_tto'] = $input['_sla_specific_tto'];
+               $input['sla_question_ttr'] = $input['_sla_specific_ttr'];
+               break;
+            case PluginFormcreatorTargetBase::SLA_RULE_FROM_ANWSER:
+               $input['sla_question_tto'] = $input['_sla_questions_tto'];
+               $input['sla_question_ttr'] = $input['_sla_questions_ttr'];
+               break;
+         }
+
+         switch ($input['ola_rule']) {
+            case PluginFormcreatorTargetBase::OLA_RULE_SPECIFIC:
+               $input['ola_question_tto'] = $input['_ola_specific_tto'];
+               $input['ola_question_ttr'] = $input['_ola_specific_ttr'];
+               break;
+            case PluginFormcreatorTargetBase::OLA_RULE_FROM_ANWSER:
+               $input['ola_question_tto'] = $input['_ola_questions_tto'];
+               $input['ola_question_ttr'] = $input['_ola_questions_ttr'];
+               break;
          }
 
          $plugin = new Plugin();
@@ -640,6 +665,8 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorTargetBase
 
       $data = $this->setTargetEntity($data, $formanswer, $requesters_id);
       $data = $this->setTargetDueDate($data, $formanswer);
+      $data = $this->setSLA($data, $formanswer);
+      $data = $this->setOLA($data, $formanswer);
       $data = $this->setTargetUrgency($data, $formanswer);
       $data = $this->setTargetCategory($data, $formanswer);
 

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -166,6 +166,9 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorTargetBase
       $this->showDueDateSettings($form, $rand);
       echo '</tr>';
 
+      $this->showSLASettings();
+      $this->showOLASettings();
+
       $this->showTypeSettings($rand);
       // -------------------------------------------------------------------------------------------
       //  associated elements of the target
@@ -413,6 +416,28 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorTargetBase
                break;
             default:
                $input['urgency_question'] = '0';
+         }
+
+         switch ($input['sla_rule']) {
+            case PluginFormcreatorTargetBase::SLA_RULE_SPECIFIC:
+               $input['sla_question_tto'] = $input['_sla_specific_tto'];
+               $input['sla_question_ttr'] = $input['_sla_specific_ttr'];
+               break;
+            case PluginFormcreatorTargetBase::SLA_RULE_FROM_ANWSER:
+               $input['sla_question_tto'] = $input['_sla_questions_tto'];
+               $input['sla_question_ttr'] = $input['_sla_questions_ttr'];
+               break;
+         }
+
+         switch ($input['ola_rule']) {
+            case PluginFormcreatorTargetBase::OLA_RULE_SPECIFIC:
+               $input['ola_question_tto'] = $input['_ola_specific_tto'];
+               $input['ola_question_ttr'] = $input['_ola_specific_ttr'];
+               break;
+            case PluginFormcreatorTargetBase::OLA_RULE_FROM_ANWSER:
+               $input['ola_question_tto'] = $input['_ola_questions_tto'];
+               $input['ola_question_ttr'] = $input['_ola_questions_ttr'];
+               break;
          }
 
          $input['type_question'] = '0';
@@ -711,6 +736,8 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorTargetBase
 
       $data = $this->setTargetEntity($data, $formanswer, $requesters_id);
       $data = $this->setTargetDueDate($data, $formanswer);
+      $data = $this->setSLA($data, $formanswer);
+      $data = $this->setOLA($data, $formanswer);
       $data = $this->setTargetUrgency($data, $formanswer);
       $data = $this->setTargetCategory($data, $formanswer);
       $data = $this->setTargetLocation($data, $formanswer);

--- a/install/mysql/plugin_formcreator_empty.sql
+++ b/install/mysql/plugin_formcreator_empty.sql
@@ -173,6 +173,12 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_formcreator_targetchanges` (
   `category_question` int(11) NOT NULL DEFAULT '0',
   `show_rule` int(11) NOT NULL DEFAULT '1',
   `uuid` varchar(255) DEFAULT NULL,
+  `sla_rule` int(11) NOT NULL DEFAULT '1',
+  `sla_question_tto` int(11) NOT NULL DEFAULT '0',
+  `sla_question_ttr` int(11) NOT NULL DEFAULT '0',
+  `ola_rule` int(11) NOT NULL DEFAULT '1',
+  `ola_question_tto` int(11) NOT NULL DEFAULT '0',
+  `ola_question_ttr` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 

--- a/install/mysql/plugin_formcreator_empty.sql
+++ b/install/mysql/plugin_formcreator_empty.sql
@@ -172,13 +172,13 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_formcreator_targetchanges` (
   `category_rule` int(11) NOT NULL DEFAULT '1',
   `category_question` int(11) NOT NULL DEFAULT '0',
   `show_rule` int(11) NOT NULL DEFAULT '1',
-  `uuid` varchar(255) DEFAULT NULL,
   `sla_rule` int(11) NOT NULL DEFAULT '1',
   `sla_question_tto` int(11) NOT NULL DEFAULT '0',
   `sla_question_ttr` int(11) NOT NULL DEFAULT '0',
   `ola_rule` int(11) NOT NULL DEFAULT '1',
   `ola_question_tto` int(11) NOT NULL DEFAULT '0',
   `ola_question_ttr` int(11) NOT NULL DEFAULT '0',
+  `uuid` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
@@ -222,6 +222,12 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_formcreator_targettickets` (
   `location_rule` INT(11) NOT NULL DEFAULT '1',
   `location_question` int(11) NOT NULL DEFAULT '0',
   `show_rule` int(11) NOT NULL DEFAULT '1',
+  `sla_rule` int(11) NOT NULL DEFAULT '1',
+  `sla_question_tto` int(11) NOT NULL DEFAULT '0',
+  `sla_question_ttr` int(11) NOT NULL DEFAULT '0',
+  `ola_rule` int(11) NOT NULL DEFAULT '1',
+  `ola_question_tto` int(11) NOT NULL DEFAULT '0',
+  `ola_question_ttr` int(11) NOT NULL DEFAULT '0',
   `uuid` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   INDEX `tickettemplates_id` (`tickettemplates_id`)

--- a/install/upgrade_to_2.11.php
+++ b/install/upgrade_to_2.11.php
@@ -84,6 +84,78 @@ class PluginFormcreatorUpgradeTo2_11 {
 
       $this->migrateCheckboxesAndMultiselect();
       $this->migrateRadiosAndSelect();
+
+      // Add SLA in target ticket
+      $migration->addField(
+         PluginFormcreatorTargetTicket::getTable(),
+         "sla_rule",
+         "int",
+         ['value' => 1]
+      );
+      $migration->addField(
+         PluginFormcreatorTargetTicket::getTable(),
+         "sla_question_tto",
+         "int"
+      );
+      $migration->addField(
+         PluginFormcreatorTargetTicket::getTable(),
+         "sla_question_ttr",
+         "int"
+      );
+
+      // Add OLA in target ticket
+      $migration->addField(
+         PluginFormcreatorTargetTicket::getTable(),
+         "ola_rule",
+         "int",
+         ['value' => 1]
+      );
+      $migration->addField(
+         PluginFormcreatorTargetTicket::getTable(),
+         "ola_question_tto",
+         "int"
+      );
+      $migration->addField(
+         PluginFormcreatorTargetTicket::getTable(),
+         "ola_question_ttr",
+         "int"
+      );
+
+      // Add SLA in target change
+      $migration->addField(
+         PluginFormcreatorTargetChange::getTable(),
+         "sla_rule",
+         "int",
+         ['value' => 1]
+      );
+      $migration->addField(
+         PluginFormcreatorTargetChange::getTable(),
+         "sla_question_tto",
+         "int"
+      );
+      $migration->addField(
+         PluginFormcreatorTargetChange::getTable(),
+         "sla_question_ttr",
+         "int"
+      );
+
+      // Add OLA in target change
+      $migration->addField(
+         PluginFormcreatorTargetChange::getTable(),
+         "ola_rule",
+         "int",
+         ['value' => 1]
+      );
+      $migration->addField(
+         PluginFormcreatorTargetChange::getTable(),
+         "ola_question_tto",
+         "int"
+      );
+      $migration->addField(
+         PluginFormcreatorTargetChange::getTable(),
+         "ola_question_ttr",
+         "int"
+      );
    }
 
    /**

--- a/install/upgrade_to_2.11.php
+++ b/install/upgrade_to_2.11.php
@@ -78,84 +78,60 @@ class PluginFormcreatorUpgradeTo2_11 {
          ) or plugin_formcreator_upgrade_error($migration);
       }
 
-      // Move uuid field at last position
-      $table = 'glpi_plugin_formcreator_targettickets';
-      $migration->addPostQuery("ALTER TABLE `$table` MODIFY `uuid` varchar(255) DEFAULT NULL AFTER `show_rule`");
-
       $this->migrateCheckboxesAndMultiselect();
       $this->migrateRadiosAndSelect();
 
-      // Add SLA in target ticket
-      $migration->addField(
-         PluginFormcreatorTargetTicket::getTable(),
-         "sla_rule",
-         "int",
-         ['value' => 1]
-      );
-      $migration->addField(
-         PluginFormcreatorTargetTicket::getTable(),
-         "sla_question_tto",
-         "int"
-      );
-      $migration->addField(
-         PluginFormcreatorTargetTicket::getTable(),
-         "sla_question_ttr",
-         "int"
-      );
+      $tables = [
+         'glpi_plugin_formcreator_targettickets',
+         'glpi_plugin_formcreator_targetchanges'
+      ];
+      foreach ($tables as $table) {
+         // Add SLA
+         $migration->addField(
+            $table,
+            "sla_rule",
+            "integer",
+            ['value' => 1, 'after' => 'show_rule']
+         );
+         $migration->addField(
+            $table,
+            "sla_question_tto",
+            "integer",
+            ['value' => 0, 'after' => 'sla_rule']
+         );
+         $migration->addField(
+            $table,
+            "sla_question_ttr",
+            "integer",
+            ['value' => 0, 'after' => 'sla_question_tto']
+         );
 
-      // Add OLA in target ticket
-      $migration->addField(
-         PluginFormcreatorTargetTicket::getTable(),
-         "ola_rule",
-         "int",
-         ['value' => 1]
-      );
-      $migration->addField(
-         PluginFormcreatorTargetTicket::getTable(),
-         "ola_question_tto",
-         "int"
-      );
-      $migration->addField(
-         PluginFormcreatorTargetTicket::getTable(),
-         "ola_question_ttr",
-         "int"
-      );
+         // Add OLA
+         $migration->addField(
+            $table,
+            "ola_rule",
+            "integer",
+            ['value' => 1, 'after' => 'sla_question_ttr']
+         );
+         $migration->addField(
+            $table,
+            "ola_question_tto",
+            "integer",
+            ['value' => 0, 'after' => 'ola_rule']
+         );
+         $migration->addField(
+            $table,
+            "ola_question_ttr",
+            "integer",
+            ['value' => 0, 'after' => 'ola_question_tto']
+         );
+         $migration->migrationOneTable($table);
+      }
 
-      // Add SLA in target change
-      $migration->addField(
-         PluginFormcreatorTargetChange::getTable(),
-         "sla_rule",
-         "int",
-         ['value' => 1]
-      );
-      $migration->addField(
-         PluginFormcreatorTargetChange::getTable(),
-         "sla_question_tto",
-         "int"
-      );
-      $migration->addField(
-         PluginFormcreatorTargetChange::getTable(),
-         "sla_question_ttr",
-         "int"
-      );
-
-      // Add OLA in target change
-      $migration->addField(
-         PluginFormcreatorTargetChange::getTable(),
-         "ola_rule",
-         "int",
-         ['value' => 1]
-      );
-      $migration->addField(
-         PluginFormcreatorTargetChange::getTable(),
-         "ola_question_tto",
-         "int"
-      );
-      $migration->addField(
-         PluginFormcreatorTargetChange::getTable(),
-         "ola_question_ttr",
-         "int"
-      );
+      // Move uuid field at last position
+      $table = 'glpi_plugin_formcreator_targettickets';
+      $migration->addPostQuery("ALTER TABLE `$table` MODIFY `uuid` varchar(255) DEFAULT NULL AFTER `ola_question_ttr`");
+      $migration->migrationOneTable($table);
    }
 
    /**

--- a/js/scripts.js.php
+++ b/js/scripts.js.php
@@ -1013,6 +1013,54 @@ function plugin_formcreator_formcreatorChangeDueDate(value) {
    }
 }
 
+function plugin_formcreator_formcreatorChangeSla(value) {
+   switch (value) {
+      default:
+      case '1' :
+         $('#sla_specific_title').hide();
+         $('#sla_specific_value').hide();
+         $('#sla_question_title').hide();
+         $('#sla_questions').hide();
+         break;
+      case '2' :
+         $('#sla_question_title').hide();
+         $('#sla_questions').hide();
+         $('#sla_specific_title').show();
+         $('#sla_specific_value').show();
+         break;
+      case '3' :
+         $('#sla_specific_title').hide();
+         $('#sla_specific_value').hide();
+         $('#sla_question_title').show();
+         $('#sla_questions').show();
+         break;
+   }
+}
+
+function plugin_formcreator_formcreatorChangeOla(value) {
+   switch (value) {
+      default:
+      case '1' :
+         $('#ola_specific_title').hide();
+         $('#ola_specific_value').hide();
+         $('#ola_question_title').hide();
+         $('#ola_questions').hide();
+         break;
+      case '2' :
+         $('#ola_question_title').hide();
+         $('#ola_questions').hide();
+         $('#ola_specific_title').show();
+         $('#ola_specific_value').show();
+         break;
+      case '3' :
+         $('#ola_specific_title').hide();
+         $('#ola_specific_value').hide();
+         $('#ola_question_title').show();
+         $('#ola_questions').show();
+         break;
+   }
+}
+
 function plugin_formcreator_displayRequesterForm() {
    $('#form_add_requester').show();
    $('#btn_add_requester').hide();
@@ -1139,11 +1187,15 @@ function plugin_formcreator_changeDropdownItemtype(rand) {
       },
    }).done(function(response) {
       var showTicketCategorySpecific = false;
+      var showServiceLevelSpecific = false;
       if (dropdown_type == 'ITILCategory') {
          showTicketCategorySpecific = true;
+      } else if (dropdown_type == 'SLA' || dropdown_type == 'OLA') {
+         showServiceLevelSpecific = true;
       }
       $('#dropdown_default_value_field').html(response);
       $('.plugin_formcreator_dropdown_ticket').toggle(showTicketCategorySpecific);
+      $('.plugin_formcreator_dropdown_service_level').toggle();
 
       $.ajax({
          url: formcreatorRootDoc + '/ajax/commontree.php',

--- a/tests/suite-integration/PluginFormcreatorTargetTicket.php
+++ b/tests/suite-integration/PluginFormcreatorTargetTicket.php
@@ -221,6 +221,8 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
          $targetTicketData['destination_entity'] = 'NULL';
          $targetTicketData['category_rule'] = '';
          $targetTicketData['location_rule'] = '';
+         $targetTicketData['sla_rule'] = (string) \PluginFormcreatorTargetTicket::SLA_RULE_NONE;
+         $targetTicketData['ola_rule'] = (string) \PluginFormcreatorTargetTicket::OLA_RULE_NONE;
          $targetTicketData['type_rule'] = \PluginFormcreatorTargetTicket::REQUESTTYPE_SPECIFIC;
          $targetTicketData['_type_specific'] = \Ticket::INCIDENT_TYPE;
          $this->boolean($targetTicket->update($targetTicketData))->isTrue();

--- a/tests/suite-unit/PluginFormcreatorTargetChange.php
+++ b/tests/suite-unit/PluginFormcreatorTargetChange.php
@@ -77,6 +77,8 @@ class PluginFormcreatorTargetChange extends CommonTestCase {
             'input' => [
                'name' => '',
                'content' => '',
+               'sla_rule' => (string) \PluginFormcreatorTargetChange::SLA_RULE_NONE,
+               'ola_rule' => (string) \PluginFormcreatorTargetChange::OLA_RULE_NONE,
             ],
             'expected' => [
             ],
@@ -86,6 +88,8 @@ class PluginFormcreatorTargetChange extends CommonTestCase {
             'input' => [
                'name' => 'something',
                'content' => '',
+               'sla_rule' => (string) \PluginFormcreatorTargetChange::SLA_RULE_NONE,
+               'ola_rule' => (string) \PluginFormcreatorTargetChange::OLA_RULE_NONE,
             ],
             'expected' => [
             ],
@@ -101,6 +105,8 @@ class PluginFormcreatorTargetChange extends CommonTestCase {
                '_urgency_specific' => '3',
                'category_rule' => \PluginFormcreatorTargetChange::CATEGORY_RULE_NONE,
                'category_question' => '0',
+               'sla_rule' => (string) \PluginFormcreatorTargetChange::SLA_RULE_NONE,
+               'ola_rule' => (string) \PluginFormcreatorTargetChange::OLA_RULE_NONE,
             ],
             'expected' => [
                'name' => 'something',
@@ -446,6 +452,12 @@ class PluginFormcreatorTargetChange extends CommonTestCase {
          'category_rule',
          'category_question',
          'show_rule',
+         'sla_rule',
+         'sla_question_tto',
+         'sla_question_ttr',
+         'ola_rule',
+         'ola_question_tto',
+         'ola_question_ttr',
       ];
       $extraFields = [
          '_actors',

--- a/tests/suite-unit/PluginFormcreatorTargetTicket.php
+++ b/tests/suite-unit/PluginFormcreatorTargetTicket.php
@@ -748,6 +748,12 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
          'location_rule',
          'location_question',
          'show_rule',
+         'sla_rule',
+         'sla_question_tto',
+         'sla_question_ttr',
+         'ola_rule',
+         'ola_question_tto',
+         'ola_question_ttr',
       ];
       $extraFields = [
          '_tickettemplate',


### PR DESCRIPTION
Internal ref: 19538.

Add new options in targets to set service levels (SLA and OLA) or directly the expected dates (TTO, internal TTO, TTR and external TTR).
Full details regarding these new options can be found in the internal ref.
