### PR TITLE
Fix plugin tag integration

### DIFF
--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -578,6 +578,11 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
          $itemtype = $json->itemtype;
       }
 
+      // In some case, there is no itemtype (PluginFormcreatorTagField)
+      if (empty($itemtype)) {
+         return $content;
+      }
+
       $item = new $itemtype;
       $item->getFromDB($answer);
 

--- a/inc/fields/tagfield.class.php
+++ b/inc/fields/tagfield.class.php
@@ -70,6 +70,8 @@ class PluginFormcreatorTagField extends PluginFormcreatorDropdownField
                   ['type_menu' => ['LIKE', '%\"Ticket\"%']],
                   ['type_menu' => ['LIKE', '%\"Change\"%']],
                   ['type_menu' => ['LIKE', '0']],
+                  ['type_menu' => ''],
+                  ['type_menu' => 'NULL'],
                ]
             ] + getEntitiesRestrictCriteria(PluginTagTag::getTable(), '', '', true),
             'ORDER'  => 'name'


### PR DESCRIPTION
### Changes description

Fix two bugs with "Tag" question type in 2.10.0 : 
- Method `parseObjectProperties` on parent `PluginFormcreatorDropdownField` was expecting an itemtype
- Available tags query was missing some values due to changes on the Tag plugin (0 -> empty string)
