### PR TITLE
Better name for actor

### DIFF
--- a/inc/abstracttarget.class.php
+++ b/inc/abstracttarget.class.php
@@ -603,7 +603,7 @@ PluginFormcreatorConditionnableInterface
          }
 
          switch ($actor['actor_type']) {
-            case PluginFormcreatorTarget_Actor::ACTOR_TYPE_CREATOR :
+            case PluginFormcreatorTarget_Actor::ACTOR_TYPE_AUTHOR :
                $userIds = [$formanswer->fields['requester_id']];
                break;
             case PluginFormcreatorTarget_Actor::ACTOR_TYPE_VALIDATOR :
@@ -702,7 +702,7 @@ PluginFormcreatorConditionnableInterface
          $notify = $actor['use_notification'];
 
          switch ($actor['actor_type']) {
-            case PluginFormcreatorTarget_Actor::ACTOR_TYPE_CREATOR :
+            case PluginFormcreatorTarget_Actor::ACTOR_TYPE_AUTHOR :
             case PluginFormcreatorTarget_Actor::ACTOR_TYPE_VALIDATOR :
             case PluginFormcreatorTarget_Actor::ACTOR_TYPE_PERSON :
             case PluginFormcreatorTarget_Actor::ACTOR_TYPE_QUESTION_PERSON :
@@ -1597,7 +1597,7 @@ SCRIPT;
       $target_actor->add([
          $myFk                 => $this->getID(),
          'actor_role'          => PluginFormcreatorTarget_Actor::ACTOR_ROLE_REQUESTER,
-         'actor_type'          => PluginFormcreatorTarget_Actor::ACTOR_TYPE_CREATOR,
+         'actor_type'          => PluginFormcreatorTarget_Actor::ACTOR_TYPE_AUTHOR,
          'use_notification'    => '1',
       ]);
       $target_actor = $this->getItem_Actor();
@@ -2018,7 +2018,7 @@ SCRIPT;
       foreach ($actors[$actorRole] as $id => $values) {
          echo '<div>';
          switch ($values['actor_type']) {
-            case PluginFormcreatorTarget_Actor::ACTOR_TYPE_CREATOR :
+            case PluginFormcreatorTarget_Actor::ACTOR_TYPE_AUTHOR :
                echo $img_user . ' <b>' . __('Form requester', 'formcreator') . '</b>';
                break;
             case PluginFormcreatorTarget_Actor::ACTOR_TYPE_VALIDATOR :

--- a/inc/target_actor.class.php
+++ b/inc/target_actor.class.php
@@ -39,7 +39,7 @@ abstract class PluginFormcreatorTarget_Actor extends CommonDBChild implements Pl
 {
    use PluginFormcreatorExportable;
 
-   const ACTOR_TYPE_CREATOR = 1;
+   const ACTOR_TYPE_AUTHOR = 1;
    const ACTOR_TYPE_VALIDATOR = 2;
    const ACTOR_TYPE_PERSON = 3;
    const ACTOR_TYPE_QUESTION_PERSON = 4;
@@ -58,7 +58,7 @@ abstract class PluginFormcreatorTarget_Actor extends CommonDBChild implements Pl
 
    static function getEnumActorType() {
       return [
-         self::ACTOR_TYPE_CREATOR                => __('Form requester', 'formcreator'),
+         self::ACTOR_TYPE_AUTHOR                => __('Form author', 'formcreator'),
          self::ACTOR_TYPE_VALIDATOR              => __('Form validator', 'formcreator'),
          self::ACTOR_TYPE_PERSON                 => __('Specific person', 'formcreator'),
          self::ACTOR_TYPE_QUESTION_PERSON        => __('Person from the question', 'formcreator'),

--- a/tests/suite-integration/PluginFormcreatorTargetChange.php
+++ b/tests/suite-integration/PluginFormcreatorTargetChange.php
@@ -60,7 +60,7 @@ class PluginFormcreatorTargetChange extends CommonTestCase {
          'AND' => [
             'plugin_formcreator_targetchanges_id' => $targetChangeId,
             'actor_role' => \PluginFormcreatorTarget_Actor::ACTOR_ROLE_REQUESTER,
-            'actor_type' => \PluginFormcreatorTarget_Actor::ACTOR_TYPE_CREATOR,
+            'actor_type' => \PluginFormcreatorTarget_Actor::ACTOR_TYPE_AUTHOR,
          ]
       ]);
       $observerActor->getFromDBByCrit([

--- a/tests/suite-integration/PluginFormcreatorTargetTicket.php
+++ b/tests/suite-integration/PluginFormcreatorTargetTicket.php
@@ -63,7 +63,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
          'AND' => [
             'plugin_formcreator_targettickets_id' => $targetTicketId,
             'actor_role' => \PluginFormcreatorTarget_Actor::ACTOR_ROLE_REQUESTER,
-            'actor_type' => \PluginFormcreatorTarget_Actor::ACTOR_TYPE_CREATOR,
+            'actor_type' => \PluginFormcreatorTarget_Actor::ACTOR_TYPE_AUTHOR,
          ]
       ]);
       $observerActor->getFromDBByCrit([


### PR DESCRIPTION
A form requester in the requester actors is actually the author (the currently logged in user). 

It is possible to set the target to use an other user as a requester, then the requester actor must be renamed as requester author.

This change requires to change a localizable string, then this PR is planned for next minor version.