### PR TITLE
[2.10] Fix parseObjectProperties for tags

### DIFF
--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -558,6 +558,11 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
    ) {
       global $TRANSLATE;
 
+      // This feature is not available for PluginFormcreatorTagField
+      if (static::class == PluginFormcreatorTagField::class) {
+         return $content;
+      }
+
       // Get ID from question
       // $questionID = $question->fields['id'];
       $questionID = $this->getQuestion()->getID();
@@ -578,7 +583,7 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
          $itemtype = $json->itemtype;
       }
 
-      // In some case, there is no itemtype (PluginFormcreatorTagField)
+      // Safe check
       if (empty($itemtype) || !class_exists($itemtype)) {
          return $content;
       }

--- a/inc/fields/dropdownfield.class.php
+++ b/inc/fields/dropdownfield.class.php
@@ -579,7 +579,7 @@ class PluginFormcreatorDropdownField extends PluginFormcreatorField
       }
 
       // In some case, there is no itemtype (PluginFormcreatorTagField)
-      if (empty($itemtype)) {
+      if (empty($itemtype) || !class_exists($itemtype)) {
          return $content;
       }
 


### PR DESCRIPTION
Disable parseObjectProperties for PluginFormcreatorTagField (it can't use it anyway).
Add safe check to avoid error in case of wrong db config.