### PR TITLE
Syncissues drops most requesters

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -117,11 +117,10 @@ class PluginFormcreatorIssue extends CommonDBTM {
                   ON `itic`.`tickets_id` = `tic`.`id`
                   AND `itic`.`itemtype` = 'PluginFormcreatorFormAnswer'
                LEFT JOIN (
-                  SELECT `users_id`, `tickets_id`
+                  SELECT DISTINCT `users_id`, `tickets_id`
                   FROM `glpi_tickets_users` AS `tu`
                   WHERE `tu`.`type` = '"  . CommonITILActor::REQUESTER . "'
                   ORDER BY `id` ASC
-                  LIMIT 1
                ) AS `tu` ON (`tic`.`id` = `tu`.`tickets_id`)
                LEFT JOIN `glpi_ticketvalidations` as `tv`
                   ON (`tic`.`id` = `tv`.`tickets_id`)


### PR DESCRIPTION
If the sync issues automatic action runs, all requester_id values of the table are lost, except on the 1st row