### PR TITLE
Hide garbage conditions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -457,6 +457,9 @@ input[type = radio]:checked + label.label-radio .check {
    font-style: italic;
    margin: 0 4px;
 }
+
+/* CONDITIONS */
+
 .div_show_condition_field, .div_show_condition_operator,
 .div_show_condition_value, .div_show_condition_logic,
 .div_show_condition_add, .div_show_condition_remove {
@@ -491,12 +494,12 @@ input[type = radio]:checked + label.label-radio .check {
    width: 12px;
    vertical-align: middle;
 }
-/* jQuery UI Combobox*/
-.pq-select-multiple {
-   display: inline-block;
-   width: 85% !important;
+tr[data-itemtype="PluginFormcreatorCondition"] .div_show_condition_logic {
+   visibility: hidden;
 }
-
+tr[data-itemtype="PluginFormcreatorCondition"] ~ tr[data-itemtype="PluginFormcreatorCondition"] .div_show_condition_logic {
+   visibility: visible;
+}
 .select2-container + select {
    display: none !important;
 }

--- a/inc/condition.class.php
+++ b/inc/condition.class.php
@@ -199,7 +199,7 @@ class PluginFormcreatorCondition extends CommonDBChild implements PluginFormcrea
     * get conditions applied to an item
     *
     * @param PluginFormcreatorConditionnableInterface $item
-    * @return array array of PluginFotrmcreatorCondition
+    * @return PluginFotrmcreatorCondition[]
     */
    public function getConditionsFromItem(PluginFormcreatorConditionnableInterface $item) {
       global $DB;
@@ -249,6 +249,10 @@ class PluginFormcreatorCondition extends CommonDBChild implements PluginFormcrea
       );
       echo '</td>';
       echo '</tr>';
+
+      if ($item->fields['show_rule'] == PluginFormcreatorCondition::SHOW_RULE_ALWAYS) {
+         return;
+      }
 
       // Get existing conditions for the item
       $conditions = $this->getConditionsFromItem($item);

--- a/js/scripts.js.php
+++ b/js/scripts.js.php
@@ -815,7 +815,7 @@ function plugin_formcreator_toggleCondition(target) {
 function plugin_formcreator_addEmptyCondition(target) {
    var form     = $(target).closest('form');
    var itemtype = form.attr('data-itemtype');
-   // value if the hidden id input field
+   // value of the hidden id input field
    var id       = form.find('[name="id"]').val();
    var parentKey;
    var parentId;
@@ -834,13 +834,11 @@ function plugin_formcreator_addEmptyCondition(target) {
       data: data
    }).done(function (data) {
       $(target).parents('tr').after(data);
-      $('.plugin_formcreator_logicRow .div_show_condition_logic').first().hide();
    });
 }
 
 function plugin_formcreator_removeNextCondition(target) {
    $(target).parents('tr').remove();
-   $('.plugin_formcreator_logicRow .div_show_condition_logic').first().hide();
 }
 
 function plugin_formcreator_changeDropdownItemtype(rand) {


### PR DESCRIPTION
In some cases (old versioins being upgraded) questions may have conditions in BD despite thei are always visible. since version 2.10.0 the conditions are visible. This path hides them.

The evaluation of conditions is not affected by the issue.

May consider a DB cleanup in the next version.