### PR TITLE
Double star may cause bad SQL request

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -139,6 +139,7 @@ class PluginFormcreatorCommon {
       foreach ($matches as &$keyword) {
          if (strpos($keyword, '"') !== 0) {
             // keyword does not begins with a double quote (assume it does not ends with this char)
+            $keyword = rtrim($keyword, '*');
             $keyword .= '*';
          }
       }

--- a/tests/suite-unit/PluginFormcreatorCommon.php
+++ b/tests/suite-unit/PluginFormcreatorCommon.php
@@ -112,6 +112,10 @@ class PluginFormcreatorCommon extends CommonTestCase {
             'input' => 'foo bar ',
             'expected' => 'foo* bar*',
          ],
+         [
+            'input' => 'foo***** bar* ',
+            'expected' => 'foo* bar*',
+         ],
       ];
    }
 


### PR DESCRIPTION
When  a user types some words in the search engiine and appends a star to a word.