### PR TITLE
Bad session var type when using anonymous form

### DIFF
--- a/front/formdisplay.php
+++ b/front/formdisplay.php
@@ -81,7 +81,7 @@ if (isset($_REQUEST['id'])
          $_SESSION['formcreator_forms_id'] = $form->fields['id'];
          $_SESSION['glpiname'] = 'formcreator_temp_user';
          $_SESSION['valid_id'] = session_id();
-         $_SESSION['glpiactiveentities'] = $form->fields['entities_id'];
+         $_SESSION['glpiactiveentities'] = [$form->fields['entities_id']];
          $subentities = getSonsOf('glpi_entities', $form->fields['entities_id']);
          $_SESSION['glpiactiveentities_string'] = (!empty($subentities))
                                                 ? "'" . implode("', '", $subentities) . "'"


### PR DESCRIPTION
Whern a requester use a anonymous form, the variable $_SESSION['glpiactiveentities'] is initialized with the entity of the form. This variable must be an array.