### PR TITLE
Broken footer

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1129,8 +1129,7 @@ a.plugin_formcreator_formTile_title {
    clear: both;
    position: fixed;
    bottom: 0;
-   width:  100%;
-   padding: 5px 0;
+   width:  calc(100% - 10px);
 }
 
 .plugin_formcreator_leftHeader#header .plugin_formcreator_leftMenu {

--- a/inc/wizard.class.php
+++ b/inc/wizard.class.php
@@ -163,6 +163,7 @@ class PluginFormcreatorWizard {
       self::showHeaderTopContent();
       echo '</div>'; //.formcreator_header_top
 
+      echo "<main role='main' id='page'>";
       echo '<div id="page" class="plugin_formcreator_page">';
 
       // call static function callcron() every 5min


### PR DESCRIPTION
Internal ref 20757, alternative to #1947 

It lloks like HTML tag MAIN has been added (among others like HEADER).

There is a closing MAIN in the footer generated bi the plugin, because itreloes on GLPI core for this task. However, the header generated by the plugin was not updated to match changes in GLPI code. Header generated by the plugin cannot rely on the core.