### PR TITLE
Escaped chars in database when saving default value in text and textarea questions

### DIFF
--- a/inc/fields/textareafield.class.php
+++ b/inc/fields/textareafield.class.php
@@ -153,7 +153,7 @@ class PluginFormcreatorTextareaField extends PluginFormcreatorTextField
    }
 
    public function prepareQuestionInputForSave($input) {
-      $this->value = str_replace('\r\n', "\r\n", $input['default_values']);
+      $this->value = Toolbox::stripslashes_deep(str_replace('\r\n', "\r\n", $input['default_values']));
       return $input;
    }
 

--- a/inc/fields/textfield.class.php
+++ b/inc/fields/textfield.class.php
@@ -189,7 +189,7 @@ class PluginFormcreatorTextField extends PluginFormcreatorField
       if (!$success) {
          return [];
       }
-      $this->value = str_replace('\r\n', "\r\n", $input['default_values']);
+      $this->value = Toolbox::stripslashes_deep(str_replace('\r\n', "\r\n", $input['default_values']));
 
       return $input;
    }


### PR DESCRIPTION
When "default value" field of a text or textarea question is stored in the database, quote characters are backslashed.
When viewing or editing the question, the backslashes still appear in the question. #1955 