### PR TITLE
New syncissues command + fix sync issues cron

### DIFF
--- a/inc/command/syncissuescommand.class.php
+++ b/inc/command/syncissuescommand.class.php
@@ -30,7 +30,6 @@ namespace GlpiPlugin\Formcreator\Command;
 
 use PluginFormcreatorIssue;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/inc/command/syncissuescommand.class.php
+++ b/inc/command/syncissuescommand.class.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ -------------------------------------------------------------------------
+ location plugin for GLPI
+ Copyright (C) 2020 by the location Development Team.
+
+ https://github.com/pluginsGLPI/location
+ -------------------------------------------------------------------------
+
+ LICENSE
+
+ This file is part of location.
+
+ location is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ location is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with location. If not, see <http://www.gnu.org/licenses/>.
+ --------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Formcreator\Command;
+
+use PluginFormcreatorIssue;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SyncIssuesCommand extends Command
+{
+   protected function configure() {
+      $table = PluginFormcreatorIssue::getTable();
+
+      $this
+         ->setName('glpi:plugins:formcreator:syncissues')
+         ->setDescription("Rebuild `$table` table.");
+   }
+
+   protected function execute(InputInterface $input, OutputInterface $output) {
+      global $DB;
+
+      $output->write("<info>-> Step 1/2...</info>");
+      $DB->delete(PluginFormcreatorIssue::getTable(), [1]);
+      $output->write('<info> OK.</info>');
+      $output->writeln("");
+
+      $output->write("<info>-> Step 2/2...</info>");
+      PluginFormcreatorIssue::syncIssues();
+      $output->write('<info> OK.</info>');
+      $output->writeln("");
+
+      $output->writeln('<info>Done.</info>');
+      return 0;
+   }
+}

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -68,6 +68,11 @@ class PluginFormcreatorIssue extends CommonDBTM {
       return 1;
    }
 
+   /**
+    * Sync issues table
+    *
+    * @return int
+    */
    public static function syncIssues() {
       global $DB;
       $volume = 0;


### PR DESCRIPTION
### Changes description

1\) Added a new command to run syncissues from command line
When a user end up with a de-synchronized issues table due to a bug, he must delete the table content and run the syncissues cron task.
I've added a command that does both of theses actions to make it more simple for the end users.
![image](https://user-images.githubusercontent.com/42734840/96706550-046a5900-1397-11eb-8328-5da8b7f58157.png)

![image](https://user-images.githubusercontent.com/42734840/96706603-1815bf80-1397-11eb-8177-1fc28c7b8c4d.png)


2\) Fix syncissue query
While I was adding this request I noticed that the sync issue query was not working.
The cause was additional parenthesis around the queries that separated it from it's alias.

Ex:
```SQL
-- Do no work
SELECT count(*) FROM (LONG_UNION_QUERY AS union_xxxxxx) 
-- Work
SELECT count(*) FROM LONG_UNION_QUERY AS union_xxxxxx
````

Also I've noticed a weird subquery that should fail since the order by is not in the select clause but It seems to be working in GLPI (no errors in logs).
If I manually execute the query on my DB I do get the error.
Should we change this ?
```php
'SELECT' => ['users_id', $ticketFk],
'DISTINCT' => true,
 'FROM'  => $ticketUserTable,
'WHERE' => [
    'type' => CommonITILActor::REQUESTER,
],
'ORDER' => ['id ASC'],
```` 

