### PR TITLE
[9.4 BC BREAK] Inline imagein default value converted to document

### DIFF
--- a/inc/fields/textfield.class.php
+++ b/inc/fields/textfield.class.php
@@ -58,7 +58,7 @@ class PluginFormcreatorTextField extends PluginFormcreatorField
       $additions .= '</td>';
       $additions .= '</tr>';
 
-      $common = $common = parent::getDesignSpecializationField();
+      $common = parent::getDesignSpecializationField();
       $additions .= $common['additions'];
 
       return [
@@ -178,7 +178,6 @@ class PluginFormcreatorTextField extends PluginFormcreatorField
    public function prepareQuestionInputForSave($input) {
       $success = true;
       $fieldType = $this->getFieldTypeName();
-      // Add leading and trailing regex marker automaticaly
       if (isset($input['_parameters'][$fieldType]['regex']['regex']) && !empty($input['_parameters'][$fieldType]['regex']['regex'])) {
          $regex = Toolbox::stripslashes_deep($input['_parameters'][$fieldType]['regex']['regex']);
          $success = $this->checkRegex($regex);

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -876,6 +876,7 @@ PluginFormcreatorConditionnableInterface
          'id'      => 'description',
          'value'   => $this->fields['description'],
          'enable_richtext' => true,
+         'filecontainer'   => 'description_info',
          'display' => false,
       ]);
       echo '</td>';


### PR DESCRIPTION
- Fix inline image handling in textareas, uploads are converted into documents
- default value inline image converted into document in default value of textarea

this solve a missing image problem in email notification of tickets generated by formcreator, when viewed from a webmail such Gmail.

Should be merged ONLY in develop branch, when GLPI 9.4 compatibility is dropped.