### PR TITLE
fix(gitignore): change data folder config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ vendor/
 .project
 /.gtm/
 
-# Ignore content of data expect for the index
-data/
+# Ignore content of data except for the index
+data/*
 !data/index.php
 
 # Ignore tests logs


### PR DESCRIPTION
### Changes description

Changes the ignore configuration for the data folder because the current configuration also ignores the negated data/index.php as explained in negate pattern manual : https://git-scm.com/docs/gitignore#_pattern_format

This error prevented the data folder to be created by git, which resulted in "No such file or directory" errors on the `robo build:fa-data -vvv` command.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated