### PR TITLE
Added regex condition

### DIFF
--- a/inc/condition.class.php
+++ b/inc/condition.class.php
@@ -57,6 +57,7 @@ class PluginFormcreatorCondition extends CommonDBChild implements PluginFormcrea
    const SHOW_CONDITION_GE = 6;
    const SHOW_CONDITION_QUESTION_VISIBLE = 7;
    const SHOW_CONDITION_QUESTION_INVISIBLE = 8;
+   const SHOW_CONDITION_REGEX = 9;
 
    public static function getTypeName($nb = 0) {
       return _n('Condition', 'Conditions', $nb, 'formcreator');
@@ -100,6 +101,7 @@ class PluginFormcreatorCondition extends CommonDBChild implements PluginFormcrea
         self::SHOW_CONDITION_GE => '≥',
         self::SHOW_CONDITION_QUESTION_VISIBLE => __('is visible', 'formcreator'),
         self::SHOW_CONDITION_QUESTION_INVISIBLE => __('is not visible', 'formcreator'),
+        self::SHOW_CONDITION_REGEX => __('regular expression matches', 'formcreator'),
       ];
    }
 

--- a/inc/field/actorfield.class.php
+++ b/inc/field/actorfield.class.php
@@ -406,6 +406,10 @@ class ActorField extends PluginFormcreatorAbstractField
       throw new ComparisonException('Meaningless comparison');
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return false;
    }

--- a/inc/field/checkboxesfield.class.php
+++ b/inc/field/checkboxesfield.class.php
@@ -358,6 +358,10 @@ class CheckboxesField extends PluginFormcreatorAbstractField
       return true;
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/datefield.class.php
+++ b/inc/field/datefield.class.php
@@ -37,6 +37,7 @@ use Html;
 use DateTime;
 use Toolbox;
 use Session;
+use GlpiPlugin\Formcreator\Exception\ComparisonException;
 
 
 class DateField extends PluginFormcreatorAbstractField
@@ -190,6 +191,10 @@ class DateField extends PluginFormcreatorAbstractField
 
    public function lessThan($value): bool {
       return !$this->greaterThan($value) && !$this->equals($value);
+   }
+
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
    }
 
    public function parseAnswerValues($input, $nonDestructive = false): bool {

--- a/inc/field/datetimefield.class.php
+++ b/inc/field/datetimefield.class.php
@@ -37,6 +37,7 @@ use Html;
 use Session;
 use Toolbox;
 use DateTime;
+use GlpiPlugin\Formcreator\Exception\ComparisonException;
 
 class DatetimeField extends PluginFormcreatorAbstractField
 {
@@ -192,6 +193,10 @@ class DatetimeField extends PluginFormcreatorAbstractField
 
    public function lessThan($value): bool {
       return !$this->greaterThan($value) && !$this->equals($value);
+   }
+
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
    }
 
    public function parseAnswerValues($input, $nonDestructive = false): bool {

--- a/inc/field/descriptionfield.class.php
+++ b/inc/field/descriptionfield.class.php
@@ -139,6 +139,10 @@ class DescriptionField extends PluginFormcreatorAbstractField
       throw new ComparisonException('Meaningless comparison');
    }
 
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
    public function parseAnswerValues($input, $nonDestructive = false): bool {
       return true;
    }

--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -643,6 +643,10 @@ class DropdownField extends PluginFormcreatorAbstractField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
    public function parseAnswerValues($input, $nonDestructive = false): bool {
       $key = 'formcreator_field_' . $this->question->getID();
       if (!isset($input[$key])) {

--- a/inc/field/emailfield.class.php
+++ b/inc/field/emailfield.class.php
@@ -169,6 +169,10 @@ class EmailField extends TextField
       throw new ComparisonException('Meaningless comparison');
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/filefield.class.php
+++ b/inc/field/filefield.class.php
@@ -275,6 +275,10 @@ class FileField extends PluginFormcreatorAbstractField
       throw new ComparisonException('Meaningless comparison');
    }
 
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/floatfield.class.php
+++ b/inc/field/floatfield.class.php
@@ -38,6 +38,7 @@ use Toolbox;
 use Session;
 use PluginFormcreatorQuestionRange;
 use PluginFormcreatorQuestionRegex;
+use GlpiPlugin\Formcreator\Exception\ComparisonException;
 
 class FloatField extends PluginFormcreatorAbstractField
 {
@@ -285,6 +286,10 @@ class FloatField extends PluginFormcreatorAbstractField
 
    public function lessThan($value): bool {
       return !$this->greaterThan($value) && !$this->equals($value);
+   }
+
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
    }
 
    public function isAnonymousFormCompatible(): bool {

--- a/inc/field/glpiselectfield.class.php
+++ b/inc/field/glpiselectfield.class.php
@@ -210,6 +210,10 @@ class GlpiselectField extends DropdownField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return false;
    }

--- a/inc/field/hiddenfield.class.php
+++ b/inc/field/hiddenfield.class.php
@@ -155,6 +155,10 @@ class HiddenField extends PluginFormcreatorAbstractField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/hostnamefield.class.php
+++ b/inc/field/hostnamefield.class.php
@@ -144,6 +144,10 @@ class HostnameField extends PluginFormcreatorAbstractField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/integerfield.class.php
+++ b/inc/field/integerfield.class.php
@@ -149,6 +149,10 @@ class IntegerField extends FloatField
       return ((int) $this->value) > ((int) $value);
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, (int) $this->value)) ? true : false;
+   }
+
    public function getHtmlIcon() {
       return '<i class="fas fa-square-root-alt" aria-hidden="true"></i>';
    }

--- a/inc/field/ipfield.class.php
+++ b/inc/field/ipfield.class.php
@@ -152,6 +152,10 @@ class IpField extends PluginFormcreatorAbstractField
       throw new ComparisonException('Meaningless comparison');
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/ldapselectfield.class.php
+++ b/inc/field/ldapselectfield.class.php
@@ -292,6 +292,10 @@ class LdapselectField extends SelectField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return false;
    }

--- a/inc/field/radiosfield.class.php
+++ b/inc/field/radiosfield.class.php
@@ -271,6 +271,10 @@ class RadiosField extends PluginFormcreatorAbstractField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/requesttypefield.class.php
+++ b/inc/field/requesttypefield.class.php
@@ -36,6 +36,7 @@ use Html;
 use Session;
 use Ticket;
 use Dropdown;
+use GlpiPlugin\Formcreator\Exception\ComparisonException;
 
 class RequestTypeField extends SelectField
 {
@@ -216,6 +217,10 @@ class RequestTypeField extends SelectField
 
    public function lessThan($value): bool {
       return !$this->greaterThan($value) && !$this->equals($value);
+   }
+
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
    }
 
    public function isAnonymousFormCompatible(): bool {

--- a/inc/field/tagfield.class.php
+++ b/inc/field/tagfield.class.php
@@ -237,6 +237,10 @@ class TagField extends DropdownField
       throw new ComparisonException('Meaningless comparison');
    }
 
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return false;
    }

--- a/inc/field/textareafield.class.php
+++ b/inc/field/textareafield.class.php
@@ -239,6 +239,10 @@ class TextareaField extends TextField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      return (preg_grep($value, $this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/textfield.class.php
+++ b/inc/field/textfield.class.php
@@ -270,6 +270,10 @@ class TextField extends PluginFormcreatorAbstractField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      return preg_match($value, Toolbox::stripslashes_deep($this->value)) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }

--- a/inc/field/timefield.class.php
+++ b/inc/field/timefield.class.php
@@ -37,6 +37,7 @@ use Html;
 use PluginFormcreatorAbstractField;
 use Session;
 use Toolbox;
+use GlpiPlugin\Formcreator\Exception\ComparisonException;
 
 class TimeField extends PluginFormcreatorAbstractField
 {
@@ -191,6 +192,12 @@ class TimeField extends PluginFormcreatorAbstractField
    public function lessThan($value): bool {
       return !$this->greaterThan($value) && !$this->equals($value);
    }
+
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
+
 
    public function parseAnswerValues($input, $nonDestructive = false): bool {
 

--- a/inc/field/urgencyfield.class.php
+++ b/inc/field/urgencyfield.class.php
@@ -36,6 +36,7 @@ use PluginFormcreatorAbstractField;
 use Html;
 use Session;
 use Ticket;
+use GlpiPlugin\Formcreator\Exception\ComparisonException;
 
 class UrgencyField extends PluginFormcreatorAbstractField
 {
@@ -220,6 +221,10 @@ class UrgencyField extends PluginFormcreatorAbstractField
 
    public function lessThan($value): bool {
       return !$this->greaterThan($value) && !$this->equals($value);
+   }
+
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
    }
 
    public function isAnonymousFormCompatible(): bool {

--- a/inc/fieldinterface.class.php
+++ b/inc/fieldinterface.class.php
@@ -235,6 +235,13 @@ interface PluginFormcreatorFieldInterface
    public function LessThan($value) : bool;
 
    /**
+    * Tests if the given value is match with regex
+    *
+    * @return boolean True if the value is match with regex
+    */
+   public function regex($value) : bool;
+
+   /**
     * Is the field compatible with anonymous form ?
     *
     * @return boolean true if the field can work with anonymous forms

--- a/inc/fields.class.php
+++ b/inc/fields.class.php
@@ -304,6 +304,18 @@ class PluginFormcreatorFields
                         $value = false;
                      }
                      break;
+
+                  case PluginFormcreatorCondition::SHOW_CONDITION_REGEX:
+                     if (!$conditionField->isPrerequisites()) {
+                        self::$visibility[$itemtype][$itemId] = false;
+                        return self::$visibility[$itemtype][$itemId];
+                     }
+                     try {
+                        $value = $conditionField->regex($condition->fields['show_value']);
+                     } catch (ComparisonException $e) {
+                        $value = false;
+                     }
+                     break;
                }
             }
          }

--- a/tests/3-unit/PluginFormcreatorCondition.php
+++ b/tests/3-unit/PluginFormcreatorCondition.php
@@ -59,6 +59,7 @@ class PluginFormcreatorCondition extends CommonTestCase {
             '6' => '≥',
             '7' => 'is visible',
             '8' => 'is not visible',
+            '9' => 'regular expression matches'
          ]);
    }
 

--- a/tests/fixture/PluginFormcreatorDependentField.php
+++ b/tests/fixture/PluginFormcreatorDependentField.php
@@ -245,6 +245,10 @@ class DependentField extends PluginFormcreatorAbstractField
       return !$this->greaterThan($value) && !$this->equals($value);
    }
 
+   public function regex($value): bool {
+      return preg_match($value, $this->value) ? true : false;
+   }
+
    public function isAnonymousFormCompatible(): bool {
       return true;
    }


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
Added regex condition to show the question.

Existing conditions cannot handle all the elements of the question and the user has to handle each element of the question manually. For example, we will use a radio button. If I want to show the hidden field, when was selected at least one of all elements, then I should to describe each element in condition to show the question.

![_regexCondition](https://user-images.githubusercontent.com/46520039/104918652-1d8aa200-59a6-11eb-8a53-6bbc489a9e6c.gif)