### PR TITLE
Issues repopulate

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -134,10 +134,13 @@ class PluginFormcreatorIssue extends CommonDBTM {
                   ON `itic`.`tickets_id` = `tic`.`id`
                   AND `itic`.`itemtype` = 'PluginFormcreatorFormAnswer'
                LEFT JOIN (
-                  SELECT DISTINCT `users_id`, `tickets_id`
-                  FROM `glpi_tickets_users` AS `tu`
-                  WHERE `tu`.`type` = '"  . CommonITILActor::REQUESTER . "'
-                  ORDER BY `id` ASC
+                  SELECT * FROM (
+                     SELECT DISTINCT `users_id`, `tickets_id`
+                     FROM `glpi_tickets_users`
+                     WHERE `tu`.`type` = '"  . CommonITILActor::REQUESTER . "'
+                     ORDER BY `id` ASC
+                  ) AS `inner_tu`
+                  GROUP BY `tickets_id`
                ) AS `tu` ON (`tic`.`id` = `tu`.`tickets_id`)
                LEFT JOIN `glpi_ticketvalidations` as `tv`
                   ON (`tic`.`id` = `tv`.`tickets_id`)

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -136,7 +136,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
                LEFT JOIN (
                   SELECT * FROM (
                      SELECT DISTINCT `users_id`, `tickets_id`
-                     FROM `glpi_tickets_users`
+                     FROM `glpi_tickets_users` AS `tu`
                      WHERE `tu`.`type` = '"  . CommonITILActor::REQUESTER . "'
                      ORDER BY `id` ASC
                   ) AS `inner_tu`


### PR DESCRIPTION
Missing rows in issues after repopulate

see #1948 

Not unit testable due to implementation of the automatic action. Tests added in the version for 2.11 and develop branches.