### PR TITLE
Validity check different from radios field

### DIFF
--- a/inc/field/selectfield.class.php
+++ b/inc/field/selectfield.class.php
@@ -34,6 +34,8 @@ namespace GlpiPlugin\Formcreator\Field;
 
 use Dropdown;
 use Html;
+use Session;
+use Toolbox;
 
 class SelectField extends RadiosField
 {
@@ -86,6 +88,30 @@ class SelectField extends RadiosField
 
    public static function getName(): string {
       return __('Select', 'formcreator');
+   }
+
+   public function isValid(): bool {
+      // If the field is required it can't be empty
+      if ($this->isRequired() && $this->value == '0') {
+         Session::addMessageAfterRedirect(
+            sprintf(__('A required field is empty: %s', 'formcreator'), $this->getLabel()),
+            false,
+            ERROR
+         );
+         return false;
+      }
+
+      // All is OK
+      return $this->isValidValue($this->value);
+   }
+
+   public function isValidValue($value): bool {
+      if ($value == '0') {
+         return true;
+      }
+      $value = Toolbox::stripslashes_deep($value);
+      $value = trim($value);
+      return in_array($value, $this->getAvailableValues());
    }
 
    public function equals($value): bool {

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/SelectField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/SelectField.php
@@ -141,8 +141,8 @@ class SelectField extends CommonTestCase {
                   'order'           => '1',
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
-            'expectedValue'   => '1',
-            'expectedIsValid' => true
+            'value'   => '1',
+            'expected' => true
          ],
          [
             'fields'          => [
@@ -155,8 +155,8 @@ class SelectField extends CommonTestCase {
                   'order'           => '1',
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
-            'expectedValue'   => '',
-            'expectedIsValid' => true
+            'value'   => '0',
+            'expected' => true
          ],
          [
             'fields'          => [
@@ -169,8 +169,8 @@ class SelectField extends CommonTestCase {
                   'order'           => '1',
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
-            'expectedValue'   => '3',
-            'expectedIsValid' => true
+            'value'   => '3',
+            'expected' => true
          ],
          [
             'fields'          => [
@@ -183,8 +183,8 @@ class SelectField extends CommonTestCase {
                   'order'           => '1',
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
-            'expectedValue'   => '1',
-            'expectedIsValid' => true
+            'value'   => '1',
+            'expected' => true
          ],
          [
             'fields'          => [
@@ -197,8 +197,8 @@ class SelectField extends CommonTestCase {
                   'order'           => '1',
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
-            'expectedValue'   => '',
-            'expectedIsValid' => false
+            'value'   => '0',
+            'expected' => false
          ],
       ];
    }
@@ -206,13 +206,13 @@ class SelectField extends CommonTestCase {
    /**
     * @dataProvider providerIsValid
     */
-   public function testIsValid($fields, $expectedValue, $expected) {
+   public function testIsValid($fields, $value, $expected) {
       $question = $this->getQuestion($fields);
       $instance = $this->newTestedInstance($question);
-      $instance->deserializeValue($fields['default_values']);
+      $instance->deserializeValue($value);
 
-      $isValid = $instance->isValid();
-      $this->boolean((boolean) $isValid)->isEqualTo($expected);
+      $output = $instance->isValid();
+      $this->boolean((boolean) $output)->isEqualTo($expected);
    }
 
    public function testGetName() {


### PR DESCRIPTION
Radios may have no value, select field must have a value. Validity check is not the same

fix #2139 