### PR TITLE
Fix trailing commas in function

### DIFF
--- a/js/scripts.js.php
+++ b/js/scripts.js.php
@@ -995,7 +995,11 @@ var plugin_formcreator = new function() {
       });
    };
 
-   this.showQuestionForm = function (sectionId, questionId = 0) {
+   this.showQuestionForm = function (sectionId, questionId) {
+      if (questionId === undefined) {
+         questionId = 0;
+      }
+
       modalWindow.load(formcreatorRootDoc + '/ajax/question.php', {
          question_id: questionId,
          plugin_formcreator_sections_id: sectionId
@@ -1024,7 +1028,11 @@ var plugin_formcreator = new function() {
       });
    };
 
-   this.showSectionForm = function (formId, sectionId = 0) {
+   this.showSectionForm = function (formId, sectionId) {
+      if (sectionId === undefined) {
+         sectionId = 0;
+      }
+
       modalWindow.load(
          formcreatorRootDoc + '/ajax/section.php', {
             section_id: sectionId,

--- a/js/scripts.js.php
+++ b/js/scripts.js.php
@@ -732,7 +732,7 @@ var plugin_formcreator = new function() {
             that.initialPosition[id]['x'],
             that.initialPosition[id]['y'],
             that.initialPosition[id]['width'],
-            that.initialPosition[id]['height'],
+            that.initialPosition[id]['height']
          );
       });
    };


### PR DESCRIPTION
### Changes description

Trailing commas in function call aren't supported by all browsers:
![image](https://user-images.githubusercontent.com/42734840/109948148-5672a200-7cda-11eb-971a-b40aa16eabf6.png)

### References

Internal ref: 21303.
