### PR TITLE
Show menu entry on low width

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -486,8 +486,30 @@ function plugin_formcreator_dynamicReport($params) {
 
 
 function plugin_formcreator_redefine_menus($menus) {
-   if (isset($menus['tickets'])) {
-      unset($menus['tickets']);
+   if (!Session::getCurrentInterface() == "helpdesk") {
+      return $menus;
+   }
+
+   if (PluginFormcreatorEntityconfig::getUsedConfig(
+         'replace_helpdesk',
+         $_SESSION['glpiactive_entity']
+   )) {
+      if (isset($menus['tickets'])) {
+         unset($menus['tickets']);
+      }
+   } else {
+      $newMenus = [];
+      foreach ($menus as $key => $menu) {
+         $newMenus[$key] = $menu;
+         if ($key == 'create_ticket') {
+            $newMenus['forms'] = [
+               'default' => '/' . Plugin::getWebDir('formcreator', false) . '/front/formlist.php',
+               'title'   => _n('Form', 'Forms', 2, 'formcreator'),
+               'content' => [0 => true]
+            ];
+         }
+      }
+      $menus = $newMenus;
    }
 
    return $menus;

--- a/js/scripts.js.php
+++ b/js/scripts.js.php
@@ -66,14 +66,6 @@ function getTimer(object) {
    }
 }
 
-// === MENU ===
-var link = '';
-link += '<li id="menu7">';
-link += '<a href="' + formcreatorRootDoc + '/front/formlist.php" class="itemP">';
-link += "<?php echo Toolbox::addslashes_deep(_n('Form', 'Forms', 2, 'formcreator')); ?>";
-link += '</a>';
-link += '</li>';
-
 $(function() {
    var target = $('body');
    modalWindow = $("<div></div>").dialog({
@@ -107,13 +99,6 @@ $(function() {
          e.stopImmediatePropagation();
       }
    });
-
-   <?php
-   if (Session::getCurrentInterface() == 'helpdesk'
-       && PluginFormcreatorForm::countAvailableForm() > 0) {
-      echo "$('#c_menu #menu1:first-child').after(link);";
-   }
-   ?>
 
    if (location.pathname.indexOf("helpdesk.public.php") != -1) {
 

--- a/setup.php
+++ b/setup.php
@@ -288,14 +288,7 @@ function plugin_init_formcreator() {
 
          Plugin::registerClass(PluginFormcreatorEntityconfig::class, ['addtabon' => Entity::class]);
 
-         if (Session::getCurrentInterface() == "helpdesk"
-            && PluginFormcreatorEntityconfig::getUsedConfig(
-               'replace_helpdesk',
-               $_SESSION['glpiactive_entity']
-            )
-         ) {
-            $PLUGIN_HOOKS['redefine_menus']['formcreator'] = "plugin_formcreator_redefine_menus";
-         }
+         $PLUGIN_HOOKS['redefine_menus']['formcreator'] = "plugin_formcreator_redefine_menus";
       }
 
       // Load JS and CSS files if we are on a page which need them


### PR DESCRIPTION
When the browser's window is hafl width of a 1080p monitor, GLPI hides the top menu. As the additional menu is added by JS, GLPI does now about its existence and does not show it in the hamburger modal.

Now, it is available
![image](https://user-images.githubusercontent.com/14139801/110613321-6cc4a600-8191-11eb-8715-916ea25ba21d.png)
