### PR TITLE
fix(issue): update modificaitoin date when a followup is added to ticket

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -463,6 +463,37 @@ function plugin_formcreator_hook_update_ticketvalidation(CommonDBTM $item) {
    $issue->update(['status' => $status['status']] + $issue->fields);
 }
 
+function plugin_formcreator_hook_update_itilFollowup($followup) {
+   $itemtype = $followup->fields['itemtype'];
+   if ($itemtype != Ticket::getType()) {
+      return;
+   }
+
+   $item = new Ticket();
+   if (!$item->getFromDB($followup->fields['items_id'])) {
+      return;
+   }
+
+   $validationStatus = PluginFormcreatorCommon::getTicketStatusForIssue($item);
+   $issue = new PluginFormcreatorIssue();
+   $issue->getFromDBByCrit([
+      'AND' => [
+         'sub_itemtype' => $itemtype,
+         'original_id'  => $item->getID(),
+      ]
+   ]);
+   if ($issue->isNewItem()) {
+      return;
+   }
+   $issue->update([
+      'id'           => $issue->getID(),
+      'sub_itemtype' => $itemtype,
+      'original_id'  => $item->getID(),
+   'status'          => $validationStatus['status'],
+      'date_mod'     => $item->fields['date_mod'],
+   ]);
+}
+
 function plugin_formcreator_dynamicReport($params) {
    switch ($params['item_type']) {
       case PluginFormcreatorFormAnswer::class;

--- a/setup.php
+++ b/setup.php
@@ -133,7 +133,8 @@ function plugin_init_formcreator() {
 
    // hook to update issues when an operation occurs on a ticket
    $PLUGIN_HOOKS['item_add']['formcreator'] = [
-      Ticket::class => 'plugin_formcreator_hook_add_ticket'
+      Ticket::class => 'plugin_formcreator_hook_add_ticket',
+      ITILFollowup::class => 'plugin_formcreator_hook_update_itilFollowup',
    ];
    $PLUGIN_HOOKS['item_update']['formcreator'] = [
       Ticket::class => 'plugin_formcreator_hook_update_ticket',


### PR DESCRIPTION
internal ref: 21727

When a user adds a followup to a ticket GLPI updates themodification date of the ticket in a way which does not triggers the item_update hook.

Then the PR use the item_add hook on the followup.