### PR TITLE
Make import resilient against missing parameters

### DIFF
--- a/inc/abstractfield.class.php
+++ b/inc/abstractfield.class.php
@@ -185,6 +185,11 @@ abstract class PluginFormcreatorAbstractField implements PluginFormcreatorFieldI
       return [];
    }
 
+   /**
+    * Undocumented function
+    *
+    * @return PluginFormcreatorAbstractQuestionParameter[]
+    */
    public final function getParameters() : array {
       $parameters = $this->getEmptyParameters();
       foreach ($parameters as $fieldname => $parameter) {

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -946,7 +946,17 @@ PluginFormcreatorConditionnableInterface
       if (isset($input['_parameters'])) {
          $parameters = $field->getParameters();
          foreach ($parameters as $fieldName => $parameter) {
-            $parameter::import($linker, $input['_parameters'][$input['fieldtype']][$fieldName], $itemId);
+            if (is_array($input['_parameters'][$input['fieldtype']][$fieldName])) {
+               /** @var PluginFormcreatorExportableInterface $parameter */
+               $parameter::import($linker, $input['_parameters'][$input['fieldtype']][$fieldName], $itemId);
+            } else {
+               // Import data incomplete, parameter not defined
+               // Adding an empty parameter (assuming the question is actually added or updated in DB)
+               $parameterInput = $parameter->fields;
+               $parameterInput['plugin_formcreator_questions_id'] = $itemId;
+               unset($parameterInput['id']);
+               $parameter->add($parameterInput);
+            }
          }
       }
 


### PR DESCRIPTION
An old bug may persist in recent versions of Formcreator because of missing data in DB.

Importing forms without those data (because they are not saved) causes a failure. This patch makes import feature resilient against the missing data, using default values instead. 

This does not causes any data loss in  the import because the default values are used in place of missing data.