### PR TITLE
fix(category): bad load event

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -240,7 +240,6 @@ function updateCategoriesView() {
          function (event) {
             $('#plugin_formcreator_wizard_categories .category_active').removeClass('category_active');
             $(this).addClass('category_active');
-            updateWizardFormsView(event.target.getAttribute('data-category-id'));
          }
       );
    });


### PR DESCRIPTION
when clicking on the text of a category, all forms are displayed isntead of those in the category.
Clicking on the background works

fox #2313 