### PR TITLE
Embedded images in target ticket

### DIFF
--- a/inc/abstractfield.class.php
+++ b/inc/abstractfield.class.php
@@ -88,7 +88,15 @@ abstract class PluginFormcreatorAbstractField implements PluginFormcreatorFieldI
          $html .= '</label>';
       }
       if ($this->isEditableField() && !empty($this->question->fields['description'])) {
-         $html .= '<div class="help-block">' . html_entity_decode(__($this->question->fields['description'], $domain)) . '</div>';
+         $description = $this->question->fields['description'];
+         foreach (PluginFormcreatorCommon::getDocumentsFromTag($description) as $document) {
+            $prefix = uniqid('', true);
+            $filename = $prefix . 'image_paste.' . pathinfo($document['filename'], PATHINFO_EXTENSION);
+            if (!copy(GLPI_DOC_DIR . '/' . $document['filepath'], GLPI_TMP_DIR . '/' . $filename)) {
+               continue;
+            }
+         }
+         $html .= '<div class="help-block">' . html_entity_decode(__($description, $domain)) . '</div>';
       }
       $html .= '<div class="form_field">';
       $html .= $this->getRenderedHtml($domain, $canEdit);

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -585,4 +585,44 @@ JAVASCRIPT;
 
       return $isValid;
    }
+
+   /**
+    * Find documents data matching the tags found in the string
+    * Tags are deduplicated
+    *
+    * @param string $content_text String to search tags from
+    *
+    * @return array data from documents having tags found
+    */
+   public static function getDocumentsFromTag(string $content_text): array {
+      preg_match_all('/'.Document::getImageTag('(([a-z0-9]+|[\.\-]?)+)').'/', $content_text,
+                     $matches, PREG_PATTERN_ORDER);
+      if (!isset($matches[1]) || count($matches[1]) == 0) {
+         return [];
+      }
+
+      $document = new Document();
+      return $document->find(['tag' => array_unique($matches[1])]);
+   }
+
+   /**
+    * find a document with a file attached, with respect of blacklisting
+    *
+    * @param integer $entity    entity of the document
+    * @param string  $path      path of the searched file
+    *
+    * @return false|Document
+    */
+   public static function getDuplicateOf(int $entities_id, string $filename) {
+      $document = new Document();
+      if (!$document->getFromDBbyContent($entities_id, $filename)) {
+         return false;
+      }
+
+      if ($document->fields['is_blacklisted']) {
+         return false;
+      }
+
+      return $document;
+   }
 }

--- a/inc/field/textareafield.class.php
+++ b/inc/field/textareafield.class.php
@@ -34,6 +34,7 @@ namespace GlpiPlugin\Formcreator\Field;
 
 use PluginFormcreatorAbstractField;
 use PluginFormcreatorCommon;
+use Document;
 use Html;
 use Session;
 use Toolbox;
@@ -86,7 +87,8 @@ class TextareaField extends TextField
 
    public function getRenderedHtml($domain, $canEdit = true): string {
       if (!$canEdit) {
-         return Toolbox::getHtmlToDisplay($this->value);
+         $value = Toolbox::convertTagToImage($this->value, $this->getQuestion());
+         return Toolbox::getHtmlToDisplay($value);
       }
 
       $id           = $this->question->getID();
@@ -131,14 +133,30 @@ class TextareaField extends TextField
       }
 
       $key = 'formcreator_field_' . $this->question->getID();
-      $this->value = $this->question->addFiles(
-         [$key => $this->value] + $this->uploads,
+      foreach ($this->uploads['_' . $key] as $id => $filename) {
+         $document  = new Document();
+         if ($document->getDuplicateOf(Session::getActiveEntity(), GLPI_TMP_DIR . '/' . $filename)) {
+            $this->value = str_replace('id="' .  $this->uploads['_tag_' . $key][$id] . '"', $document->fields['tag'], $this->value);
+            $this->uploads['_tag_' . $key][$id] = $document->fields['tag'];
+         }
+      }
+      $input = [$key => $this->value] + $this->uploads;
+      $input = $this->question->addFiles(
+         $input,
          [
             'force_update'  => true,
-            'content_field' => $key,
+            // 'content_field' => $key,
+            'content_field' => null,
             'name'          => $key,
          ]
-      )[$key];
+      );
+      $this->value = $input[$key];
+      $this->value = Html::entity_decode_deep($this->value);
+      foreach ($input['_tag'] as $tag) {
+         $regex = '/<img[^>]+' . preg_quote($tag, '/') . '[^<]+>/im';
+         $this->value = preg_replace($regex, "#$tag#", $this->value);
+      }
+      $this->value = Html::entities_deep($this->value);
 
       return Toolbox::addslashes_deep($this->value);
    }
@@ -221,6 +239,9 @@ class TextareaField extends TextField
          $value = Toolbox::unclean_cross_side_scripting_deep($value);
          $value = strip_tags($value);
       }
+      // $value = Toolbox::convertTagToImage($this->value, $this->getQuestion());
+      // $value = Toolbox::getHtmlToDisplay($value);
+
       return $value;
    }
 

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -440,6 +440,34 @@ PluginFormcreatorTranslatableInterface
          }
       }
 
+      // handle description field and its inline pictures
+      if (isset($input['_description'])) {
+         foreach ($input['_description'] as $id => $filename) {
+            // TODO :replace PluginFormcreatorCommon::getDuplicateOf by Document::getDuplicateOf
+            // when is merged https://github.com/glpi-project/glpi/pull/9335
+            if ($document = PluginFormcreatorCommon::getDuplicateOf(Session::getActiveEntity(), GLPI_TMP_DIR . '/' . $filename)) {
+               $this->value = str_replace('id="' .  $input['_tag_description'] . '"', $document->fields['tag'], $this->value);
+               $input['_tag_description'][$id] = $document->fields['tag'];
+            }
+         }
+
+         $input = $this->addFiles(
+            $input,
+            [
+               'force_update'  => true,
+               'content_field' => null,
+               'name'          => 'description',
+            ]
+         );
+
+         $input['description'] = Html::entity_decode_deep($input['description']);
+         foreach ($input['_tag_description'] as $tag) {
+            $regex = '/<img[^>]+' . preg_quote($tag, '/') . '[^<]+>/im';
+            $input['description'] = preg_replace($regex, "#$tag#", $input['description']);
+         }
+         $input['description'] = Html::entities_deep($input['description']);
+      }
+
       // generate a unique id
       if (!isset($input['uuid'])
           || empty($input['uuid'])) {
@@ -467,6 +495,34 @@ PluginFormcreatorTranslatableInterface
 
       if (!is_array($input) || count($input) == 0) {
          return false;
+      }
+
+      // handle description field and its inline pictures
+      if (isset($input['_description'])) {
+         foreach ($input['_description'] as $id => $filename) {
+            // TODO :replace PluginFormcreatorCommon::getDuplicateOf by Document::getDuplicateOf
+            // when is merged https://github.com/glpi-project/glpi/pull/9335
+            if ($document = PluginFormcreatorCommon::getDuplicateOf(Session::getActiveEntity(), GLPI_TMP_DIR . '/' . $filename)) {
+               $this->value = str_replace('id="' .  $input['_tag_description'] . '"', $document->fields['tag'], $this->value);
+               $input['_tag_description'][$id] = $document->fields['tag'];
+            }
+         }
+
+         $input = $this->addFiles(
+            $input,
+            [
+               'force_update'  => true,
+               'content_field' => null,
+               'name'          => 'description',
+            ]
+         );
+
+         $input['description'] = Html::entity_decode_deep($input['description']);
+         foreach ($input['_tag_description'] as $tag) {
+            $regex = '/<img[^>]+' . preg_quote($tag, '/') . '[^<]+>/im';
+            $input['description'] = preg_replace($regex, "#$tag#", $input['description']);
+         }
+         $input['description'] = Html::entities_deep($input['description']);
       }
 
       // generate a unique id
@@ -831,7 +887,7 @@ PluginFormcreatorTranslatableInterface
       echo Html::textarea([
          'name'    => 'description',
          'id'      => 'description',
-         'value'   => $this->fields['description'],
+         'value'   => Toolbox::convertTagToImage($this->fields['description'], $this),
          'enable_richtext' => true,
          'filecontainer'   => 'description_info',
          'display' => false,

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -766,6 +766,22 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractTarget
          $data = $this->assignedGroups + $data;
       }
 
+      // emulate file uploads of inline images
+      $data['_content'] = [];
+      $data['_prefix_content'] = [];
+      $data['_tag_content'] = [];
+      foreach (Toolbox::getDocumentsFromTag($data['content']) as $document) {
+         $prefix = uniqid('', true);
+         $filename = $prefix . 'image_paste.' . pathinfo($document['filename'], PATHINFO_EXTENSION);
+         if (!copy(GLPI_DOC_DIR . '/' . $document['filepath'], GLPI_TMP_DIR . '/' . $filename)) {
+            continue;
+         }
+
+         $data['_content'][] = $filename;
+         $data['_prefix_content'][] = $prefix;
+         $data['_tag_content'][] = $document['tag'];
+      }
+
       // Create the target ticket
       $data['_auto_import'] = true;
       if (!$ticketID = $ticket->add($data)) {

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -32,6 +32,8 @@
 use GlpiPlugin\Formcreator\Exception\ImportFailureException;
 use GlpiPlugin\Formcreator\Exception\ExportFailureException;
 
+use PluginFormcreatorCommon;
+
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
@@ -770,7 +772,9 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractTarget
       $data['_content'] = [];
       $data['_prefix_content'] = [];
       $data['_tag_content'] = [];
-      foreach (Toolbox::getDocumentsFromTag($data['content']) as $document) {
+      // TODO: replace PluginFormcreatorCommon::getDocumentsFromTag by Toolbox::getDocumentsFromTag
+      // when is merged https://github.com/glpi-project/glpi/pull/9335
+      foreach (PluginFormcreatorCommon::getDocumentsFromTag($data['content']) as $document) {
          $prefix = uniqid('', true);
          $filename = $prefix . 'image_paste.' . pathinfo($document['filename'], PATHINFO_EXTENSION);
          if (!copy(GLPI_DOC_DIR . '/' . $document['filepath'], GLPI_TMP_DIR . '/' . $filename)) {

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -32,8 +32,6 @@
 use GlpiPlugin\Formcreator\Exception\ImportFailureException;
 use GlpiPlugin\Formcreator\Exception\ExportFailureException;
 
-use PluginFormcreatorCommon;
-
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }


### PR DESCRIPTION
When an embedded image in the content of a ticket is displayed, GLPI generates a link to the document to download it. The URL contains a document ID and also a ticket ID. This ticket ID is required to allow viewing the document when the user does not has READ right on the itemtype.