### PR TITLE
Restrict access to entity config

### DIFF
--- a/front/entityconfig.form.php
+++ b/front/entityconfig.form.php
@@ -31,7 +31,7 @@
 
 include ('../../../inc/includes.php');
 
-Session::checkRight("entity", UPDATE);
+Session::checkRight('entity', UPDATE);
 
 // Check if plugin is activated...
 if (!(new Plugin())->isActivated('formcreator')) {

--- a/inc/entityconfig.class.php
+++ b/inc/entityconfig.class.php
@@ -65,7 +65,7 @@ class PluginFormcreatorEntityconfig extends CommonDBTM {
    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
       $tabNames = [];
       if (!$withtemplate) {
-         if ($item->getType() == 'Entity') {
+         if (Session::haveRight(Entity::$rightname, UPDATE) && $item->getType() == Entity::getType()) {
             $tabNames[1] = _n('Form', 'Forms', 2, 'formcreator');
          }
       }

--- a/tests/3-unit/PluginFormcreatorEntityConfig.php
+++ b/tests/3-unit/PluginFormcreatorEntityConfig.php
@@ -32,6 +32,13 @@ namespace tests\units;
 use GlpiPlugin\Formcreator\Tests\CommonTestCase;
 
 class PluginFormcreatorEntityconfig extends CommonTestCase {
+   public function beforeTestMethod($method) {
+      switch ($method) {
+         case 'testGetTabNameForItem':
+            $this->login('glpi', 'glpi');
+      }
+   }
+
    public function providerGetTabNameForItem() {
       return [
          [


### PR DESCRIPTION
Bad right check when showing formcreator's settings for the entity