### PR TITLE
Redirect technicians to correct URL

### DIFF
--- a/front/issue.form.php
+++ b/front/issue.form.php
@@ -37,6 +37,15 @@ if (!(new Plugin())->isActivated('formcreator')) {
    Html::displayNotFoundError();
 }
 
+// Accessing an issue from a tech profile, redirect to ticket page
+if (isset($_REQUEST['id']) && Session::getCurrentInterface() == 'central') {
+   /** @var PluginFormcreatorIssue $issue */
+   $issue = PluginFormcreatorIssue::getById((int) $_REQUEST['id']);
+   $id = $issue->fields['items_id'];
+   $itemtype = strtolower($issue->fields['itemtype']);
+   Html::redirect($CFG_GLPI['root_doc'] . "/front/$itemtype.form.php?id=$id");
+}
+
 // Show issue only if service catalog is enabled
 if (!plugin_formcreator_replaceHelpdesk()) {
    Html::redirect($CFG_GLPI['root_doc']."/front/helpdesk.public.php");


### PR DESCRIPTION
### Changes description

It is common for requesters to reference other tickets in their tickets description or followups.
These references will be links like this one: `http://localhost/g95x/plugins/formcreator/front/issue.form.php?id=282`.

This is an issue because this link cannot be used by a technician: they are given an error and have no clue how to get the real linked ticket.

To fix this, I've added a redirect for any user coming from the 'central' interface.

### References

!22442