### PR TITLE
Unloadded objects when validating

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -980,8 +980,9 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
    public function post_addItem() {
       // Save questions answers
       $formAnswerId = $this->getID();
+      $formId = $this->input[PluginFormcreatorForm::getForeignKeyField()];
       /** @var PluginFormcreatorAbstractField $field */
-      foreach ($this->questionFields as $questionId => $field) {
+      foreach ($this->getQuestionFields($formId) as $questionId => $field) {
          $field->moveUploads();
          $answer = new PluginFormcreatorAnswer();
          $answer->add([
@@ -1020,8 +1021,9 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
    public function post_updateItem($history = 1) {
       // Save questions answers
       $formAnswerId = $this->getID();
+      $formId = $this->input[PluginFormcreatorForm::getForeignKeyField()];
       /** @var PluginFormcreatorAbstractField $field */
-      foreach ($this->questionFields as $questionId => $field) {
+      foreach ($this->getQuestionFields($formId) as $questionId => $field) {
          $field->moveUploads();
          $answer = new PluginFormcreatorAnswer();
          $answer->getFromDBByCrit([


### PR DESCRIPTION
fix warning

[2021-09-28 11:13:40] glpiphplog.WARNING:   *** PHP Warning (2): Invalid argument supplied for foreach() in .../glpi/plugins/formcreator/inc/formanswer.class.php at line 1025
  Backtrace :
  inc/commondbtm.class.php:1588                      PluginFormcreatorFormAnswer->post_updateItem()
  plugins/formcreator/front/formanswer.form.php:53   CommonDBTM->update()
