### PR TITLE
Fix tech redirection if not logged-in

### DIFF
--- a/front/issue.form.php
+++ b/front/issue.form.php
@@ -32,12 +32,12 @@
 global $CFG_GLPI;
 require_once ('../../../inc/includes.php');
 
-Session::checkValidSessionId();
-
 // Check if plugin is activated...
 if (!(new Plugin())->isActivated('formcreator')) {
    Html::displayNotFoundError();
 }
+
+Session::checkValidSessionId();
 
 // Accessing an issue from a tech profile, redirect to ticket page
 if (isset($_REQUEST['id']) && Session::getCurrentInterface() == 'central') {


### PR DESCRIPTION
### Changes description

#2336 allowed technician to access `plugins/formcreator/front/issue.form.php` links and be redirected to the correct ticket's page on the technician interface.

However this wont work if the technician is not logged-in.
After logging-in, he will be redirected on `front/helpdesk.public.php` and given an error:

![image](https://user-images.githubusercontent.com/42734840/136522924-f0f9e7d0-37f7-4175-aae8-6fe080558a6b.png)

This is because `front/issue.form.php` does some controller check leading to redirection **before** checking if the current user have a valid session.
The code would be run like this:
-> Trying to access `issue.form.php`  
-> Checking if we need redirect to ticket page  
-> Fail as no session  
-> Checking if service catalog is enabled  
-> Fail as no session  
-> Redirect to `helpdesk.public.php`  
-> Checking session  
-> Fail, redirect to login page with another redirection on success to `helpdesk.public.php`  

These changes force a session check earlier in the code to avoid this issue.

Just in case, @btry do you know if  `plugins/formcreator/front/issue.form.php` have some valid use case for being accessed without a session (to make sure this doesn't break anything) ?
From my understanding of the code it doesn't seem so.

### References

!22442