### PR TITLE
Add data-id attribute to #plugin_formcreator_form

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1080,6 +1080,7 @@ PluginFormcreatorTranslatableInterface
       . ' class="plugin_formcreator_form"'
       . ' action="' . self::getFormURL() . '"'
       . ' id="plugin_formcreator_form"'
+      . ' data-id="' . $formId . '"'
       . '>';
 
       // load thanguage for the form, if any


### PR DESCRIPTION
### Changes description

This will allow form-specific CSS styling and overrides, using GLPI's built-in entity-specific UI customization mechanism.

For example:
```css
#plugin_formcreator_form[data-id="7"] h1.form-title {
  background: #3584e5;
  color: white;  
}
#plugin_formcreator_form[data-id="8"] h1.form-title {
  background: #5bd1d2;
  color: white;  
}

```