### PR TITLE
PHP warning when displaying form's historical

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -348,10 +348,14 @@ PluginFormcreatorTranslatableInterface
                $class = "plugin-forcreator-active";
                $title =  __('Active');
             }
-            $output = '<i class="fa fa-circle '
-            . $class
-            . '" aria-hidden="true" title="' . $title . '"></i>';
-            $output = '<div style="text-align: center" onclick="plugin_formcreator.toggleForm(' . $options['raw_data']['id']. ')">' . $output . '</div>';
+            if (isset($options['raw_data']['id'])) {
+               $output = '<i class="fa fa-circle '
+               . $class
+               . '" aria-hidden="true" title="' . $title . '"></i>';
+               $output = '<div style="text-align: center" onclick="plugin_formcreator.toggleForm(' . $options['raw_data']['id']. ')">' . $output . '</div>';
+            } else {
+               $output = $title;
+            }
             return $output;
             break;
 


### PR DESCRIPTION
raw_data key not available when viewing historical tab.