### PR TITLE
Cleanup menu definition / update service catalog menu

### DIFF
--- a/front/formlist.php
+++ b/front/formlist.php
@@ -43,20 +43,9 @@ if (Session::getCurrentInterface() == 'helpdesk') {
       Html::redirect('issue.php');
    } else {
       Html::helpHeader(__('Form list', 'formcreator'));
-      // Html::helpHeader(
-      //    __('Form list', 'formcreator'),
-      //    $_SERVER['PHP_SELF']
-      // );
    }
 } else {
-   // Html::header(
-   //    __('Form list', 'formcreator'),
-   //    $_SERVER['PHP_SELF'],
-   //    'helpdesk',
-   //    PluginFormcreatorFormlist::class
-   // );
    Html::header(__('Form list', 'formcreator'));
-
 }
 
 $form = PluginFormcreatorCommon::getForm();

--- a/hook.php
+++ b/hook.php
@@ -521,12 +521,34 @@ function plugin_formcreator_redefine_menus($menus) {
    }
 
    if (plugin_formcreator_replaceHelpdesk() !== false) {
-      if (isset($menus['create_ticket'])) {
-         unset($menus['create_ticket']);
+      $newMenu = [];
+      $newMenu['seek_assistance'] = [
+         'default' => Plugin::getWebDir('formcreator', false) . '/front/wizard.php',
+         'title'   => __('Seek assistance', 'formcreator'),
+         'icon'    => 'fa fa-paper-plane',
+      ];
+      $newMenu['my_assistance_requests'] = [
+         'default' => PluginFormcreatorIssue::getSearchURL(false),
+         'title'   => __('My requests for assistance', 'formcreator'),
+         'icon'    => 'fa fa-list',
+      ];
+      if (PluginFormcreatorEntityConfig::getUsedConfig('is_kb_separated', Session::getActiveEntity()) == PluginFormcreatorEntityConfig::CONFIG_KB_DISTINCT
+         && Session::haveRight('knowbase', KnowbaseItem::READFAQ)
+      ) {
+         $newMenu['faq'] = $menus['faq'];
       }
-      $menus['faq']['default'] = Plugin::getWebDir('formcreator', false) . '/front/knowbaseitem.php';
-
-      return $menus;
+      $newMenu['faq']['default'] = Plugin::getWebDir('formcreator', false) . '/front/knowbaseitem.php';
+      if (Session::haveRight("reservation", ReservationItem::RESERVEANITEM)) {
+         $newMenu['reservation'] = $menus['reservation'];
+      }
+      if (RSSFeed::canView()) {
+         $newMenu['feeds'] = [
+            'default' => Plugin::getWebDir('formcreator', false) . '/front/wizardfeeds.php',
+            'title'   => __('Consult feeds', 'formcreator'),
+            'icon'    => 'fa fa-rss',
+         ];
+      }
+      return $newMenu;
    }
 
    // Using GLPI's helpdesk interface; then just modify the menu

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -117,7 +117,7 @@ PluginFormcreatorTranslatableInterface
       $menu['icon'] = 'fas fa-edit';
       $validation_image = '<i class="fa fa-check-square"
                                 title="' . __('Forms waiting for validation', 'formcreator') . '"></i>';
-      $import_image     = '<i class="fas fa-upload"
+      $import_image     = '<i class="fas fa-download"
                                 title="' . __('Import forms', 'formcreator') . '"></i>';
       $menu['links']['search']          = PluginFormcreatorFormList::getSearchURL(false);
       $menu['links']['config']          = PluginFormcreatorForm::getSearchURL(false);

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -120,7 +120,6 @@ PluginFormcreatorTranslatableInterface
       $import_image     = '<i class="fas fa-download"
                                 title="' . __('Import forms', 'formcreator') . '"></i>';
       $menu['links']['search']          = PluginFormcreatorFormList::getSearchURL(false);
-      $menu['links']['config']          = PluginFormcreatorForm::getSearchURL(false);
       $menu['links'][$validation_image] = PluginFormcreatorFormAnswer::getSearchURL(false);
       $menu['links'][$import_image]     = PluginFormcreatorForm::getFormURL(false)."?import_form=1";
 

--- a/inc/formlist.class.php
+++ b/inc/formlist.class.php
@@ -48,7 +48,7 @@ class PluginFormcreatorFormList extends CommonGLPI
 
    public static function getMenuContent() {
       $menu = parent::getMenuContent();
-      $menu['title'] = static::getTypeName(2);
+      $menu['title'] = static::getTypeName(Session::getPluralNumber());
       $menu['page'] = PluginFormcreatorFormList::getSearchURL(false);
       $menu['icon'] = 'fas fa-edit';
 

--- a/inc/formlist.class.php
+++ b/inc/formlist.class.php
@@ -46,21 +46,11 @@ class PluginFormcreatorFormList extends CommonGLPI
       return _n('Form', 'Forms', $nb, 'formcreator');
    }
 
-   static function getMenuContent() {
+   public static function getMenuContent() {
       $menu = parent::getMenuContent();
       $menu['title'] = static::getTypeName(2);
-      $menu['page'] = '/' . Plugin::getWebDir('formcreator', false) . '/front/formlist.php';
+      $menu['page'] = PluginFormcreatorFormList::getSearchURL(false);
       $menu['icon'] = 'fas fa-edit';
-      $image = '<i class="fa fa-check-square"
-                  title="' . __('Forms waiting for validation', 'formcreator') . '"
-                  alt="' . __('Forms waiting for validation', 'formcreator') . '"></i>';
-
-      $menu['links']['search'] = PluginFormcreatorFormList::getSearchURL(false);
-      if (PluginFormcreatorForm::canCreate()) {
-         $menu['links']['add'] = PluginFormcreatorForm::getFormURL(false);
-      }
-      $menu['links']['config'] = PluginFormcreatorForm::getSearchURL(false);
-      $menu['links'][$image]   = PluginFormcreatorFormAnswer::getSearchURL(false);
 
       return $menu;
    }

--- a/setup.php
+++ b/setup.php
@@ -387,27 +387,10 @@ function plugin_formcreator_hook() {
    $PLUGIN_HOOKS['redefine_menus']['formcreator'] = "plugin_formcreator_redefine_menus";
 
    // Config page
-   $links  = [];
    if (Session::haveRight('entity', UPDATE)) {
-      $PLUGIN_HOOKS['config_page']['formcreator']         = 'front/form.php';
       $PLUGIN_HOOKS['menu_toadd']['formcreator']['admin'] = 'PluginFormcreatorForm';
-      $links['config'] = FORMCREATOR_ROOTDOC . '/front/form.php';
-      $links['add']    = FORMCREATOR_ROOTDOC . '/front/form.form.php';
    }
-   $img = '<i class="fa fa-check-square"
-            title="' . __('Forms waiting for validation', 'formcreator') . '" alt="Waiting forms list"></i>';
 
-   $links[$img] = FORMCREATOR_ROOTDOC . '/front/formanswer.php';
-
-   // Set options for pages (title, links, buttons...)
-   $links['search'] = FORMCREATOR_ROOTDOC . '/front/formlist.php';
-   $PLUGIN_HOOKS['submenu_entry']['formcreator']['options'] = [
-      'config'       => ['title'  => __('Setup'),
-                           'page'   => FORMCREATOR_ROOTDOC . '/front/form.php',
-                           'links'  => $links],
-      'options'      => ['title'  => _n('Form', 'Forms', 2, 'formcreator'),
-                           'links'  => $links],
-   ];
 }
 
 function plugin_formcreator_registerClasses() {

--- a/setup.php
+++ b/setup.php
@@ -387,10 +387,10 @@ function plugin_formcreator_hook() {
    $PLUGIN_HOOKS['redefine_menus']['formcreator'] = "plugin_formcreator_redefine_menus";
 
    // Config page
+   $links  = [];
    if (Session::haveRight('entity', UPDATE)) {
-      $PLUGIN_HOOKS['menu_toadd']['formcreator']['admin'] = 'PluginFormcreatorForm';
+      $PLUGIN_HOOKS['menu_toadd']['formcreator']['admin'] = PluginFormcreatorForm::class;
    }
-
 }
 
 function plugin_formcreator_registerClasses() {

--- a/tests/3-unit/PluginFormcreatorFormList.php
+++ b/tests/3-unit/PluginFormcreatorFormList.php
@@ -65,14 +65,8 @@ class PluginFormcreatorFormList extends CommonTestCase {
    public function testGetMenuContent() {
       $output = \PluginFormcreatorFormList::getMenuContent();
       $plugindir = '/' . basename(dirname(dirname(dirname(__DIR__))));
-      $this->string($output['links']['search'])->isEqualTo($plugindir . '/formcreator/front/formlist.php');
-      $this->array($output['links'])->notHasKey('add');
-      $this->string($output['links']['config'])->isEqualTo($plugindir . '/formcreator/front/form.php');
-
-      $this->login('glpi', 'glpi');
-      $output = \PluginFormcreatorFormList::getMenuContent();
-      $this->string($output['links']['search'])->isEqualTo($plugindir . '/formcreator/front/formlist.php');
-      $this->string($output['links']['add'])->isEqualTo($plugindir . '/formcreator/front/form.form.php');
-      $this->string($output['links']['config'])->isEqualTo($plugindir . '/formcreator/front/form.php');
+      $this->string($output['title'])->isEqualTo('Forms');
+      $this->string($output['page'])->isEqualTo($plugindir . '/formcreator/front/formlist.php');
+      $this->string($output['icon'])->isEqualTo('fas fa-edit');
    }
 }


### PR DESCRIPTION
### Remove useless elements 

#### changes from GLPI 9.5
The following link goes to forms list. This should be used for general specificities of the plugin. 
![image](https://user-images.githubusercontent.com/14139801/144396606-0923bb68-b58b-4c27-9ce3-72b07c57af2e.png)

the following also redirects to forms list.. but we already are here or in a form (administration side). Useless
![image](https://user-images.githubusercontent.com/14139801/144396965-42512fcd-55a3-4e77-bd9f-9e832e053ff0.png)

Imports are represented by an upload icon. This is misleading, download icon is more representative
![image](https://user-images.githubusercontent.com/14139801/144397150-463b2efe-d349-4158-b09f-113b1d0d9bc1.png)

#### result

![image](https://user-images.githubusercontent.com/14139801/144399022-d2d7b8d9-62ae-4795-b712-69ad74f63750.png)


### service catalog menu

Make the menu similar to the old version

#### GLPI 10
![image](https://user-images.githubusercontent.com/14139801/144397419-53c01baa-9129-4a6e-924d-fd7e2c0b14db.png)

#### GLPI 9.5
![image](https://user-images.githubusercontent.com/14139801/144398819-f2c1685e-b2c0-4ed8-8d85-b5eb807857df.png)
