### PR TITLE
Improve browser tabs names

### DIFF
--- a/front/issue.form.php
+++ b/front/issue.form.php
@@ -73,7 +73,7 @@ if ($issue) {
       $_GET['id'] = "f_$_GET[tickets_id]";
    }
 
-   $header = __($itemtype::getTypeName(1), 'formcreator');
+   $header = $itemtype::getTypeName(1);
    if (Session::getCurrentInterface() == "helpdesk") {
       Html::helpHeader($header);
    } else {

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -806,7 +806,9 @@ class PluginFormcreatorIssue extends CommonDBTM {
             $link = self::getFormURLWithID($data['id']);
 
             // Show "final" item id in the URL
-            $link .= "&" . $subItemtype::getForeignKeyField() . "=$id";
+            if (Toolbox::isCommonDBTM($subItemtype)) {
+               $link .= "&" . $subItemtype::getForeignKeyField() . "=$id";
+            }
 
             $key = 'id';
             $tooltip = Html::showToolTip(nl2br(RichText::getTextFromHtml($content)), [

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -803,8 +803,11 @@ class PluginFormcreatorIssue extends CommonDBTM {
                default:
                   $content = '';
             }
-            $link = self::getFormURLWithID($id) . "&itemtype=".$data['raw']['itemtype'];
-            $link =  self::getFormURLWithID($data['id']);
+            $link = self::getFormURLWithID($data['id']);
+
+            // Show "final" item id in the URL
+            $link .= "&" . $subItemtype::getForeignKeyField() . "=$id";
+
             $key = 'id';
             $tooltip = Html::showToolTip(nl2br(RichText::getTextFromHtml($content)), [
                'applyto' => $itemtype.$data['raw'][$key],


### PR DESCRIPTION
### Changes description

#### Issues tabs rework:
* Replace "Service desk" by the target itemtype
* Replace the issue id by the display id (`t_XXXX` or `f_XXXX`).
* Add the foreign key to the url (`&tickets_id=xxxx`)

#### Examples:

![image](https://user-images.githubusercontent.com/42734840/146152810-e315149f-148b-4937-9ffb-6419548872dc.png)

These tabs match the following urls: 
- http://localhost/gmaster/plugins/formcreator/front/issue.form.php?id=4&tickets_id=5 (a simple ticket)
- http://localhost/gmaster/plugins/formcreator/front/issue.form.php?id=3&plugin_formcreator_formanswers_id=2 (a multi ticket answer)
- http://localhost/gmaster/plugins/formcreator/front/issue.form.php?id=3&tickets_id=4 (the first ticket of the previous multi ticket answer)

This way the displayed tab name match the search results:
![image](https://user-images.githubusercontent.com/42734840/146159722-d0e83ee5-ad26-4cf2-81dc-f9a297b28de0.png)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

!23062