### PR TITLE
Possible SQL error

### DIFF
--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -870,6 +870,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractTarget
    protected function setTargetLocation($data, $formanswer) {
       global $DB;
 
+      $location = null;
       switch ($this->fields['location_rule']) {
          case self::LOCATION_RULE_ANSWER:
             $location = $DB->request([
@@ -880,13 +881,13 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractTarget
                   'plugin_formcreator_questions_id'   => $this->fields['location_question']
                ]
             ])->next();
-            $location = $location['answer'];
+            if (ctype_digit($location['answer'])) {
+               $location = $location['answer'];
+            }
             break;
          case self::LOCATION_RULE_SPECIFIC:
             $location = $this->fields['location_question'];
             break;
-         default:
-            $location = null;
       }
       if (!is_null($location)) {
          $data['locations_id'] = $location;


### PR DESCRIPTION
With a form configured to set location of a target ticket from a question, changing the question type to a text field causes attempt to set location from a string
    instead of an ID. If the string contains a single quote, then the INSERT query is broken. This check the value is an integer. If not, lets ignore the value.
    
    May need to lock questions when they are linked to a target.

see internal ref 23326