### PR TITLE
Do not force add a requester to tickets

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1284,6 +1284,11 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       $validationStatus = PluginFormcreatorCommon::getTicketStatusForIssue($ticket);
 
       $ticketUserRow = array_pop($ticketUserRow);
+      if ($ticketUserRow === null) {
+         $requesterId = 0;
+      } else {
+         $requesterId = $ticketUserRow['users_id'];
+      }
       $issueName = $ticket->fields['name'] != '' ? addslashes($ticket->fields['name']) : '(' . $ticket->getID() . ')';
       $issue->add([
          'items_id'           => $ticketId,
@@ -1294,7 +1299,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          'date_mod'           => $ticket->fields['date_mod'],
          'entities_id'        => $ticket->fields['entities_id'],
          'is_recursive'       => '0',
-         'requester_id'       => $ticketUserRow['users_id'],
+         'requester_id'       => $requesterId,
          'users_id_validator' => '',
          'groups_id_validator'=> '',
          'comment'            => addslashes($ticket->fields['content']),

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -744,7 +744,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractTarget
       $this->prepareActors($form, $formanswer);
 
       if (count($this->requesters['_users_id_requester']) == 0) {
-         $this->addActor(PluginFormcreatorTarget_Actor::ACTOR_ROLE_REQUESTER, $formanswer->fields['requester_id'], true);
+         // $this->addActor(PluginFormcreatorTarget_Actor::ACTOR_ROLE_REQUESTER, $formanswer->fields['requester_id'], true);
          $requesters_id = $formanswer->fields['requester_id'];
       } else {
          $requesterAccounts = array_filter($this->requesters['_users_id_requester'], function($v) {


### PR DESCRIPTION
When a target ticket does not sets any requester, the curent user was added anyway.

Removing this behaviour