### PR TITLE
Better template support for request source

### DIFF
--- a/install/mysql/plugin_formcreator_empty.sql
+++ b/install/mysql/plugin_formcreator_empty.sql
@@ -193,6 +193,8 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_formcreator_targettickets` (
   `name`                        varchar(255) NOT NULL DEFAULT '',
   `plugin_formcreator_forms_id` int(11) NOT NULL DEFAULT '0',
   `target_name`                 varchar(255) NOT NULL DEFAULT '',
+  `source_rule`                 int(11) NOT NULL DEFAULT '0',
+  `source_question`             int(11) NOT NULL DEFAULT '0',
   `type_rule`                   int(11) NOT NULL DEFAULT '0',
   `type_question`               int(11) NOT NULL DEFAULT '0',
   `tickettemplates_id`          int(11) NOT NULL DEFAULT '0',

--- a/install/upgrade_to_2.12.5.php
+++ b/install/upgrade_to_2.12.5.php
@@ -60,7 +60,7 @@ class PluginFormcreatorUpgradeTo2_12_5 {
 
       $table = 'glpi_plugin_formcreator_targettickets';
 
-      if (!$DB->fieldExists($table, 'request_source')) {
+      if (!$DB->fieldExists($table, 'source_rule')) {
          $this->migration->addField($table, 'source_rule', 'integer', ['after' => 'target_name']);
          $this->migration->addField($table, 'source_question', 'integer', ['after' => 'source_rule']);
          $this->migration->migrationOneTable($table);

--- a/tests/3-unit/PluginFormcreatorTargetTicket.php
+++ b/tests/3-unit/PluginFormcreatorTargetTicket.php
@@ -1417,7 +1417,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
       ];
    }
 
-   public function providerSetRequestSource_specific(): array{
+   public function providerSetRequestSource_specific(): array {
       $form = $this->getForm();
       $formanswer = new \PluginFormcreatorFormanswer();
       $formanswer->add([

--- a/tests/src/PluginFormcreatorTargetTicketDummy.php
+++ b/tests/src/PluginFormcreatorTargetTicketDummy.php
@@ -92,4 +92,8 @@ class PluginFormcreatorTargetTicketDummy extends \PluginFormcreatorTargetTicket
    public function publicGetDefaultData($formanswer) {
       return $this->getDefaultData($formanswer);
    }
+
+   public function publicSetTargetSource($data, $formanswer): array {
+      return $this->setTargetSource($data, $formanswer);
+   }
 }


### PR DESCRIPTION
when generating a ticket GLPI always sets a request source from general setting, or user preferences. 

With Formcreator 2.12.4 the request source "Formcreator" was not applied due to the presence of a source from GLPI defaults (one of those mentionned above).

This PR addresses the problem by adding a new setting in target  tickets, like many others 
- from template or default
- Formcreator
This PR changes the behaviour of the plugin then I plan to merge only in 2.13 to avoid to see admins lost.

internal ref 23403