### PR TITLE
Allow plugins to define their own targets

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -461,7 +461,6 @@ PluginFormcreatorTranslatableInterface
       echo '</tr>';
 
       $allTargets = $this->getTargetsFromForm();
-      $token = Session::getNewCSRFToken();
       $i = 0;
       foreach ($allTargets as $targetType => $targets) {
          foreach ($targets as $targetId => $target) {
@@ -474,8 +473,15 @@ PluginFormcreatorTranslatableInterface
             echo '</a></td>';
 
             echo '<td align="center" width="32">';
-            echo '<i class="far fa-trash-alt" alt="*" title="'.__('Delete', 'formcreator').'"
-               onclick="plugin_formcreator_deleteTarget(\''. $target->getType() . '\', '.$targetId.', \''.$token.'\')" align="absmiddle" style="cursor: pointer"></i> ';
+            echo '<i
+               class="far fa-trash-alt formcreator_delete_target"
+               alt="*"
+               title="' . __('Delete', 'formcreator') . '"
+               data-itemtype="' . get_class($target) . '"
+               data-items-id="' . $targetId . '"
+               align="absmiddle"
+               style="cursor: pointer"
+            ></i>';
             echo '</td>';
 
             echo '</tr>';
@@ -485,7 +491,7 @@ PluginFormcreatorTranslatableInterface
       // Display add target link...
       echo '<tr class="tab_bg_'.(($i + 1) % 2).' id="add_target_row">';
       echo '<td colspan="3">';
-      echo '<a href="javascript:plugin_formcreator_addTarget('.$ID.', \''.$token.'\');">
+      echo '<a href="javascript:plugin_formcreator_addTarget('.$ID.');">
                 <i class="fa fa-plus"></i>
                 '.__('Add a target', 'formcreator').'
             </a>';
@@ -1994,11 +2000,19 @@ PluginFormcreatorTranslatableInterface
     * @return array
     */
    public static function getTargetTypes() : array {
-      return [
+      global $PLUGIN_HOOKS;
+
+      $targets = [
          PluginFormcreatorTargetTicket::class,
          PluginFormcreatorTargetChange::class,
          PluginFormcreatorTargetProblem::class,
       ];
+
+      foreach ($PLUGIN_HOOKS['formcreator_add_targets'] ?? [] as $plugin_targets) {
+         array_push($targets, ...$plugin_targets);
+      }
+
+      return $targets;
    }
 
    /**

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1326,14 +1326,14 @@ function plugin_formcreator_addTarget(items_id) {
    });
 }
 
-function plugin_formcreator_deleteTarget(itemtype, target_id) {
-   if(confirm(i18n.textdomain('formcreator').__('Are you sure you want to delete this destination:', 'formcreator'))) {
+$(document).on('click', '.formcreator_delete_target', function() {
+   if(confirm(i18n.textdomain('formcreator').__('Are you sure you want to delete this target:', 'formcreator'))) {
       $.post({
         url: formcreatorRootDoc + '/ajax/form_delete_target.php',
         data: {
             action: 'delete_target',
-            itemtype: itemtype,
-            items_id: target_id,
+            itemtype: $(this).data('itemtype'),
+            items_id: $(this).data('items-id'),
          }
       }).done(function () {
          reloadTab();
@@ -1341,7 +1341,7 @@ function plugin_formcreator_deleteTarget(itemtype, target_id) {
          displayAjaxMessageAfterRedirect();
       });
    }
-}
+});
 
 // DESTINATION
 function plugin_formcreator_formcreatorChangeDueDate(value) {


### PR DESCRIPTION
Allow plugin to add additional targets.
This is done through a `add_formcreator_targets` hook like this:

```php
$PLUGIN_HOOKS['add_formcreator_targets']['plugin_demo'] = [
      EmailTarget::class
];
```
