### PR TITLE
html rendering in targets

### DIFF
--- a/inc/field/actorfield.class.php
+++ b/inc/field/actorfield.class.php
@@ -35,7 +35,6 @@ namespace GlpiPlugin\Formcreator\Field;
 use PluginFormcreatorAbstractField;
 use Html;
 use User;
-use Toolbox;
 use Session;
 use GlpiPlugin\Formcreator\Exception\ComparisonException;
 
@@ -218,6 +217,7 @@ class ActorField extends PluginFormcreatorAbstractField
 
       if ($richText) {
          $value = '<br />' . implode('<br />', $value);
+         $value = Html::entities_deep($value);
       } else {
          $value = implode(', ', $value);
       }

--- a/inc/field/checkboxesfield.class.php
+++ b/inc/field/checkboxesfield.class.php
@@ -300,6 +300,7 @@ class CheckboxesField extends PluginFormcreatorAbstractField
 
       if ($richText) {
          $value = '<br />' . implode('<br />', $value);
+         $value = Html::entities_deep($value);
       } else {
          $value = implode(', ', $value);
       }

--- a/inc/field/textareafield.class.php
+++ b/inc/field/textareafield.class.php
@@ -239,7 +239,10 @@ class TextareaField extends TextField
 
    public function getValueForTargetText($domain, $richText): ?string {
       $value = $this->value;
-      if (!$richText) {
+      if ($richText) {
+         $value = Sanitizer::unsanitize($value);
+         $value = Html::entities_deep($value);
+      } else {
          $value = Sanitizer::unsanitize($value);
          $value = strip_tags($value);
       }

--- a/inc/field/textareafield.class.php
+++ b/inc/field/textareafield.class.php
@@ -38,6 +38,8 @@ use Html;
 use Session;
 use Toolbox;
 use Glpi\RichText\RichText;
+use Glpi\Toolbox\Sanitizer;
+
 class TextareaField extends TextField
 {
    /** @var array uploaded files on form submit */
@@ -238,16 +240,9 @@ class TextareaField extends TextField
    public function getValueForTargetText($domain, $richText): ?string {
       $value = $this->value;
       if (!$richText) {
-         if (class_exists(\Glpi\Toolbox\Sanitizer::class)) {
-            // GLPI 10
-            $value = \Glpi\Toolbox\Sanitizer::unsanitize($value);
-         } else {
-            $value = Toolbox::unclean_cross_side_scripting_deep($value);
-         }
+         $value = Sanitizer::unsanitize($value);
          $value = strip_tags($value);
       }
-      // $value = Toolbox::convertTagToImage($this->value, $this->getQuestion());
-      // $value = Toolbox::getHtmlToDisplay($value);
 
       return $value;
    }

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -29,6 +29,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
 use GlpiPlugin\Formcreator\Field\DropdownField;
 
 if (!defined('GLPI_ROOT')) {
@@ -1191,6 +1192,12 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          if ($this->questionFields[$questionId] instanceof DropdownField) {
             $content = $this->questionFields[$questionId]->parseObjectProperties($field->getValueForDesign(), $content);
          }
+      }
+
+      if ($richText) {
+         // convert sanitization from old style GLPI ( up to 9.5 to modern style)
+         $content = Sanitizer::unsanitize($content);
+         $content = Sanitizer::sanitize($content);
       }
 
       return $content;

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/CheckboxesField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/CheckboxesField.php
@@ -278,21 +278,21 @@ class CheckboxesField extends CommonTestCase {
                'values' => "[]"
             ]),
             'value' => json_encode(['a']),
-            'expected' => '<br />'
+            'expected' => '&lt;br /&gt;'
          ],
          [
             'question' => $this->getQuestion([
                'values' => json_encode(['a', 'b', 'c'])
             ]),
             'value' => json_encode(['a']),
-            'expected' => '<br />a'
+            'expected' => '&lt;br /&gt;a'
          ],
          [
             'question' => $this->getQuestion([
                'values' => json_encode(['a', 'b', 'c'])
             ]),
             'value' => json_encode(['a', 'c']),
-            'expected' => '<br />a<br />c'
+            'expected' => '&lt;br /&gt;a&lt;br /&gt;c'
          ],
       ];
    }


### PR DESCRIPTION
Closes #2568

By the way, this PR ensures the ITIL objects are created with the same scaping scheme as GLPI does internally.

