### PR TITLE
Count forms must take into account visibility

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1541,6 +1541,7 @@ PluginFormcreatorTranslatableInterface
          'WHERE' => [
             "$formTable.is_active" => '1',
             "$formTable.is_deleted" => '0',
+            "$formTable.is_visible" => '1',
             'OR' => [
                "$formTable.language" => [$_SESSION['glpilanguage'], '0', '', null],
                "$formLanguage.name"  => $_SESSION['glpilanguage'],


### PR DESCRIPTION
When counting forms to show or not the menu entry in "Assistance", the new columns is_visible is not taken into account.

is_visible allows the form to be accessible from assistance (or service catalog), whereas is_visible = 0 means the form is only acessible from its direct URL.