### PR TITLE
Resequencing entityconfigs

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -273,8 +273,8 @@ class PluginFormcreatorInstall {
                   IF(ent.id = 0, 0, -2)
                 FROM glpi_entities ent
                 LEFT JOIN glpi_plugin_formcreator_entityconfigs conf
-                  ON ent.id = conf.id
-                WHERE conf.id IS NULL";
+                  ON ent.id = conf.entities_id
+                WHERE conf.entities_id IS NULL";
       $result = $DB->query($query);
       if (!$result) {
          Toolbox::logInFile('sql-errors', $DB->error());

--- a/install/upgrade_to_2.13.php
+++ b/install/upgrade_to_2.13.php
@@ -230,6 +230,22 @@ class PluginFormcreatorUpgradeTo2_13 {
       }
 
       $table = 'glpi_plugin_formcreator_entityconfigs';
+      $rows = $DB->request([
+         'COUNT' => 'c',
+         'FROM' => $table,
+         'WHERE' => ['id' => 0]
+      ]);
+      $count = $rows !== null ?$rows->current()['c'] : null;
+      if ($count !== null) {
+         if ($count == 1) {
+            $rows = $DB->request([
+               'SELECT' => ['MAX' => 'id AS max_id'],
+               'FROM' => $table,
+            ]);
+            $newId = (int) ($rows->current()['max_id'] + 1);
+            $DB->query("UPDATE `$table` SET `id`='$newId' WHERE `id` = 0");
+         }
+      }
       $this->migration->changeField($table, 'id', 'id', 'int ' . DBConnection::getDefaultPrimaryKeySignOption() . ' not null auto_increment');
    }
 }


### PR DESCRIPTION
2 problems here

* When converting glpi_plugin_formcreator_entitycinfigs's column ID into autoincrement, there is usually a column with ID = 0. Autoincrement does not allows this value, then we must find an other ID.

* the SQL query which populates the table was not properly updated to use the new foeign key to glpi_entities