### PR TITLE
Fix dropdown questions

### DIFF
--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -87,12 +87,10 @@ class DropdownField extends PluginFormcreatorAbstractField
       $label .= _n('Dropdown', 'Dropdowns', 1);
       $label .= '</label>';
 
-      $itemtype = $this->question->fields['values'];
-      $decodedValues = json_decode($this->question->fields['values'], JSON_OBJECT_AS_ARRAY);
-      if ($decodedValues !== null) {
-         $itemtype = $decodedValues['itemtype'];
-      }
+      $itemtype = $this->question->fields['itemtype'];
 
+      // Parse json values (show_tree_root, show_tree_depth and selectable_tree_root)
+      $decodedValues = json_decode($this->question->fields['values'], JSON_OBJECT_AS_ARRAY);
       $root = $decodedValues['show_tree_root'] ?? Dropdown::EMPTY_VALUE;
       $maxDepth = $decodedValues['show_tree_depth'] ?? Dropdown::EMPTY_VALUE;
       $selectableRoot = $decodedValues['selectable_tree_root'] ?? '0';

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1418,7 +1418,7 @@ function plugin_formcreator_hideAssignedForm() {
 
 function plugin_formcreator_changeDropdownItemtype(rand) {
    var dropdown_type = $('[data-itemtype="PluginFormcreatorQuestion"] [name="dropdown_values"]').val();
-   var dropdown_id   = $('[data-itemtype="PluginFormcreatorQuestion"] [name="id"]').val();
+   var dropdown_id   = $('[data-itemtype="PluginFormcreatorQuestion"][name="asset_form"]').data('id');
 
    $.post({
       url: formcreatorRootDoc + '/ajax/dropdown_values.php',
@@ -1719,7 +1719,7 @@ function pluginFormcreatorInitializeUrgency(fieldName, rand) {
 }
 
 function plugin_formcreator_changeQuestionType(rand) {
-   var questionId = $('form[name="asset_form"][data-itemtype="PluginFormcreatorQuestion"] [name="id"]').val() || 0;
+   var questionId = $('[data-itemtype="PluginFormcreatorQuestion"][name="asset_form"]').data('id') || 0;
    var questionType = $('form[name="asset_form"][data-itemtype="PluginFormcreatorQuestion"] [name="fieldtype"]').val();
 
    $.post({


### PR DESCRIPTION
### Changes description

Drop question were broken (see https://github.com/pluginsGLPI/formcreator/issues/2598).

Seems like there were two issues:
- Two invalids js selectors (I suppose the HTML side was modified without updating these selectors properly).
- Trying to read the itemtype of a dropdown from the json 'values' field (the itemtype was moved out into it's own specific field a while ago).
