### PR TITLE
Drop again getFromDbByQuestion

### DIFF
--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -34,6 +34,7 @@ namespace GlpiPlugin\Formcreator\Field;
 
 use PluginFormcreatorAbstractField;
 use PluginFormcreatorCommon;
+use PluginFormcreatorForm;
 use Html;
 use Toolbox;
 use Session;
@@ -212,8 +213,7 @@ class DropdownField extends PluginFormcreatorAbstractField
       $fieldName = 'formcreator_field_' . $id;
       $itemtype = $this->getSubItemtype();
 
-      $form = PluginFormcreatorCommon::getForm();
-      $form->getFromDBByQuestion($this->getQuestion());
+      $form = PluginFormcreatorForm::getByItem($this->getQuestion());
       $dparams = [
          'name'     => $fieldName,
          'value'    => $this->value,
@@ -253,15 +253,13 @@ class DropdownField extends PluginFormcreatorAbstractField
             $ancestorEntities = getAncestorsOf(Entity::getTable(), $currentEntity);
             switch ($decodedValues['entity_restrict']) {
                case self::ENTITY_RESTRICT_FORM:
-                  $form = new PluginFormcreatorForm();
-                  $form->getFromDBByQuestion($this->getQuestion());
+                  $form = PluginFormcreatorForm::getByItem($this->getQuestion());
                   $currentEntity = $form->fields['entities_id'];
                   $ancestorEntities = getAncestorsOf(Entity::getTable(), $currentEntity);
                   break;
 
                case self::ENTITY_RESTRICT_BOTH:
-                  $form = new PluginFormcreatorForm();
-                  $form->getFromDBByQuestion($this->getQuestion());
+                  $form = PluginFormcreatorForm::getByItem($this->getQuestion());
                   $currentEntity = [$currentEntity, $form->fields['entities_id']];
                   $ancestorEntities = array_merge($ancestorEntities, getAncestorsOf(Entity::getTable(), $currentEntity));
                   break;
@@ -953,8 +951,7 @@ class DropdownField extends PluginFormcreatorAbstractField
       $restrictionPolicy = $decodedValues['entity_restrict'] ?? self::ENTITY_RESTRICT_FORM;
       switch ($restrictionPolicy) {
          case self::ENTITY_RESTRICT_FORM:
-            $form = PluginFormcreatorCommon::getForm();
-            $form->getFromDBByQuestion($this->getQuestion());
+            $form = PluginFormcreatorForm::getByItem($this->getQuestion());
             $formEntities = [$form->fields['entities_id']];
             if ($form->fields['is_recursive']) {
                $formEntities = $formEntities + (new DBUtils())->getSonsof(Entity::getTable(), $form->fields['entities_id']);
@@ -963,8 +960,7 @@ class DropdownField extends PluginFormcreatorAbstractField
             break;
 
          case self::ENTITY_RESTRICT_BOTH:
-            $form = PluginFormcreatorCommon::getForm();
-            $form->getFromDBByQuestion($this->getQuestion());
+            $form = PluginFormcreatorForm::getByItem($this->getQuestion());
             $formEntities = [$form->fields['entities_id']];
             if ($form->fields['is_recursive']) {
                $formEntities = $formEntities + (new DBUtils())->getSonsof(Entity::getTable(), $form->fields['entities_id']);

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -2471,36 +2471,6 @@ PluginFormcreatorTranslatableInterface
       return true;
    }
 
-
-   public function getFromDBByQuestion(PluginFormcreatorQuestion $question) {
-      global $DB;
-
-      if ($question->isNewItem()) {
-         return false;
-      }
-      $questionTable = PluginFormcreatorQuestion::getTable();
-      $sectionTable = PluginFormcreatorSection::getTable();
-      $iterator = $DB->request([
-         'SELECT' => self::getForeignKeyField(),
-         'FROM' => PluginFormcreatorSection::getTable(),
-         'INNER JOIN' => [
-            $questionTable => [
-               'FKEY' => [
-                  $sectionTable => PluginFormcreatorSection::getIndexName(),
-                  $questionTable => PluginFormcreatorSection::getForeignKeyField()
-               ]
-            ]
-         ],
-         'WHERE' => [
-            $questionTable . '.' . PluginFormcreatorQuestion::getIndexName() => $question->getID()
-         ]
-      ]);
-      if ($iterator->count() !== 1) {
-         return false;
-      }
-      return $this->getFromDB($iterator->next()[self::getForeignKeyField()]);
-   }
-
    /**
     * get the SQL joins and conditions to select the forms available for the current user
     */


### PR DESCRIPTION
getFromDbByQuestion has been removed a while ago, but calls were not fully replaced (or a PR was not up to date at  time of merge).

This PR drops again the obsolete method and ensure that all calls are replaced.