### PR TITLE
Replace obsolete method

### DIFF
--- a/inc/abstractfield.class.php
+++ b/inc/abstractfield.class.php
@@ -270,8 +270,7 @@ abstract class PluginFormcreatorAbstractField implements PluginFormcreatorFieldI
 
       $question = new PluginFormcreatorQuestion();
       $question->getFromDB($this->question->getID());
-      $form = PluginFormcreatorCommon::getForm();
-      $form->getByQuestionId($question->getID());
+      $form = PluginFormcreatorForm::getByItem($question);
 
       /** @var integer $column 0 for 2 first columns, 1 for 2 right ones */
       $column = 0;

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1264,38 +1264,6 @@ PluginFormcreatorTranslatableInterface
       ]);
    }
 
-   /**
-    * gets a form from database from a question
-    *
-    * @param int $questionId
-    */
-   public function getByQuestionId(int $questionId) : void {
-      $formTable = PluginFormcreatorForm::getTable();
-      $formFk = PluginFormcreatorForm::getForeignKeyField();
-      $sectionTable = PluginFormcreatorSection::getTable();
-      $sectionFk = PluginFormcreatorSection::getForeignKeyField();
-      $questionTable = PluginFormcreatorQuestion::getTable();
-      $this->getFromDBByRequest([
-         'INNER JOIN' => [
-            $sectionTable => [
-               'FKEY' => [
-                  $formTable    => 'id',
-                  $sectionTable => $formFk,
-               ]
-            ],
-            $questionTable => [
-               'FKEY' => [
-                  $questionTable => $sectionFk,
-                  $sectionTable  => 'id'
-               ]
-            ]
-         ],
-         'WHERE' => [
-            $questionTable . '.id' => $questionId,
-         ]
-      ]);
-   }
-
    public function duplicate(array $options = []) {
       $linker = new PluginFormcreatorLinker($options);
 

--- a/tests/3-unit/PluginFormcreatorForm.php
+++ b/tests/3-unit/PluginFormcreatorForm.php
@@ -390,17 +390,6 @@ class PluginFormcreatorForm extends CommonTestCase {
       $this->integer((int) $form->fields['usage_count'])->isEqualTo(1);
    }
 
-   public function testGetByQuestionId() {
-      $question = $this->getQuestion();
-      $section = new \PluginFormcreatorSection();
-      $section->getFromDB($question->fields['plugin_formcreator_sections_id']);
-      $expected = $section->fields['plugin_formcreator_forms_id'];
-      $form = $this->newTestedInstance();
-      $form->getByQuestionId($question->getID());
-
-      $this->integer((int) $form->getID())->isEqualTo($expected);
-   }
-
    public function testCreateValidationNotification() {
       global $DB, $CFG_GLPI;
 

--- a/tests/3-unit/PluginFormcreatorTargetTicket.php
+++ b/tests/3-unit/PluginFormcreatorTargetTicket.php
@@ -970,8 +970,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
          'fieldtype' => 'glpiselect',
          'glpi_objects' => \Computer::class,
       ]);
-      $form = new \PluginFormcreatorForm();
-      $form->getByQuestionId($question->getID());
+      $form = \PluginFormcreatorForm::getByItem($question);
 
       // Have an item to associate
       $computer = new \Computer();
@@ -1049,8 +1048,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
          'fieldtype' => 'glpiselect',
          'glpi_objects' => $validItemtype,
       ]);
-      $form1 = new \PluginFormcreatorForm();
-      $form1->getByQuestionId($question1->getID());
+      $form1 = \PluginFormcreatorForm::getByItem($question1);
       $sectionId = $question1->fields['plugin_formcreator_sections_id'];
       $question2 = $this->getQuestion([
          'plugin_formcreator_sections_id' => $sectionId,
@@ -1079,8 +1077,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
          'fieldtype' => 'glpiselect',
          'glpi_objects' => $validItemtype,
       ]);
-      $form2 = new \PluginFormcreatorForm();
-      $form2->getByQuestionId($question3->getID());
+      $form2 = \PluginFormcreatorForm::getByItem($question3);
       $sectionId = $question3->fields['plugin_formcreator_sections_id'];
       $question4 = $this->getQuestion([
          'plugin_formcreator_sections_id' => $sectionId,
@@ -1112,8 +1109,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
          'fieldtype' => 'glpiselect',
          'glpi_objects' => $invalidItemtype,
       ]);
-      $form3 = new \PluginFormcreatorForm();
-      $form3->getByQuestionId($question5->getID());
+      $form3 = \PluginFormcreatorForm::getByItem($question5);
       $sectionId = $question5->fields['plugin_formcreator_sections_id'];
       $question6 = $this->getQuestion([
          'plugin_formcreator_sections_id' => $sectionId,
@@ -1146,8 +1142,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
          'fieldtype' => 'glpiselect',
          'glpi_objects' => $validItemtype,
       ]);
-      $form4 = new \PluginFormcreatorForm();
-      $form4->getByQuestionId($question7->getID());
+      $form4 = \PluginFormcreatorForm::getByItem($question7);
       $sectionId = $question7->fields['plugin_formcreator_sections_id'];
       $question8 = $this->getQuestion([
          'plugin_formcreator_sections_id' => $sectionId,


### PR DESCRIPTION
Remove old method; having a better implementation in getByItem()