### PR TITLE
Add form headers hook

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -2495,8 +2495,7 @@ PluginFormcreatorTranslatableInterface
     *
     * @return string
     */
-   public function getExtraHeader(): string
-   {
+   public function getExtraHeader(): string {
       global $PLUGIN_HOOKS;
 
       $extra_header = "";

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -2489,4 +2489,34 @@ PluginFormcreatorTranslatableInterface
 
       return $condition;
    }
+
+   /**
+    * Get the extra content from other plugins to be added to the form header
+    *
+    * @return string
+    */
+   public function getExtraHeader(): string
+   {
+      global $PLUGIN_HOOKS;
+
+      $extra_header = "";
+
+      $callbacks = $PLUGIN_HOOKS['formcreator_insert_header'] ?? [];
+      foreach ($callbacks as $plugin => $callback) {
+         // Make sure the supplied hook is a valid callback
+         if (!is_callable($callback)) {
+            trigger_error(
+               "Invalid 'formcreator_insert_header' hook for '$plugin' plugin",
+               E_USER_WARNING
+            );
+         }
+
+         // Insert extra plugin header if not empty
+         if ($extra_plugin_header = call_user_func($callback, $this)) {
+            $extra_header .= $extra_plugin_header;
+         }
+      }
+
+      return $extra_header;
+   }
 }

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -530,6 +530,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       if (!empty($this->fields['content'])) {
          echo '<div class="form_header">';
          echo html_entity_decode($this->fields['content']);
+         echo html_entity_decode($form->getExtraHeader());
          echo '</div>';
       }
 

--- a/templates/pages/userform.html.twig
+++ b/templates/pages/userform.html.twig
@@ -52,6 +52,7 @@
         {% if item.fields['content'] != '' %}
             <div class="form_header">
             {{ __(item.fields['content'], domain)|safe_html }}
+            {{ item.getExtraHeader()|safe_html }}
             </div>
         {% endif %}
         <ol>


### PR DESCRIPTION
### Changes description

Allow plugin to insert extra content in the form headers.

Example:
```php
$PLUGIN_HOOKS['formcreator_insert_header']['demo'] = function ($form) {
  return "<b> my header </b>";
};
```
![image](https://user-images.githubusercontent.com/42734840/156549284-e52e0dde-f28b-4072-96fd-684f32fa1d84.png)
