### PR TITLE
test: better tests isolation

### DIFF
--- a/tests/2-integration/PluginFormcreatorFormAnswer.php
+++ b/tests/2-integration/PluginFormcreatorFormAnswer.php
@@ -153,7 +153,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
          'password2'             => 'superadmin',
          '_profiles_id'          => '4', // super admin profile
          '_entities_id'          => 0,
-         '_is_recursive'         => 1,
+         '_is_recursive'         => 0,
       ]);
       $this->boolean($user->isNewItem())
          ->isFalse(json_encode(

--- a/tests/3-unit/PluginFormcreatorForm.php
+++ b/tests/3-unit/PluginFormcreatorForm.php
@@ -617,7 +617,7 @@ class PluginFormcreatorForm extends CommonTestCase {
       $input = [
          'name' => $this->getUniqueString(),
          '_entity' => 'Root entity',
-         'is_recursive' => '1',
+         'is_recursive' => '0',
          'access_rights' => \PluginFormcreatorForm::ACCESS_RESTRICTED,
          'description' => '',
          'content' => '',


### PR DESCRIPTION
help to fix randon test failure 

> There is 1 failure:

=> tests\units\PluginFormcreatorForm::testCountAvailableForm():
In file /home/runner/work/formcreator/glpi/plugins/formcreator/tests/3-unit/PluginFormcreatorForm.php on line 1375, integer() failed: integer(4) is not equal to integer(2)
-Expected
+Actual
@@ -1 +1 @@
-int(2)
+int(4)