### PR TITLE
Disable auto install on marketplace deploy

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -475,3 +475,9 @@ function plugin_formcreator_redirect() {
       }
    }
 }
+
+function plugin_formcreator_options() {
+   return [
+      Plugin::OPTION_AUTOINSTALL_DISABLED => true,
+   ];
+}


### PR DESCRIPTION
installing  this plugin on huge database (100K tickets or more) may be slow.

Using the incoming option in GLPI core to not install immediately the plugin after a deployment via the marketplace