### PR TITLE
Manage documents in initial notifications

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1572,4 +1572,41 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
       return PluginFormcreatorFields::isVisible($this->questionFields[$id]->getQuestion(), $this->questionFields);
    }
+
+//KKK
+   public function getFileName($questionId,$index) {
+      $doc = new Document();
+      $doc->getFromDB($this->questionFields[$questionId]->getDocumentsForTarget()[$index]);
+      return $doc->fields['filepath'];
+   }
+
+   public function getFileFields() : Array {
+      $filefields=[];
+      $form = $this->getForm();
+      foreach ($this->getQuestionFields($form) as $questionId => $field) {
+	 $question = $field->getQuestion();
+	 if ($question->fields['fieldtype'] === 'file') 
+	    $filefields[] = $questionId;
+      }
+
+      return $filefields;
+   }
+
+   public function getFileProperties() : Array {
+      $form = $this->getForm();
+      foreach ($this->getFileFields() as $questionId) {
+	 foreach ($this->getQuestionFields($form)[$questionId]->getDocumentsForTarget() as $key => $documentId){
+	    $doc = new Document();
+	    $doc->getFromDB($documentId);
+	    $formcreator_field[]= $doc->fields['filename'];
+	    $tag_formcreator_field[]= $doc->fields['tag'];
+	 }
+	 $formcreator_field_array[$questionId] = $formcreator_field;
+	 $tag_formcreator_field_array[$questionId] = $tag_formcreator_field;
+      }
+
+      return [ "_filename" => $formcreator_field_array,
+	       "_tag_filename" => $tag_formcreator_field_array];
+   }
+
 }

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -816,6 +816,32 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractTarget
          $data['_tag_content'][] = $document['tag'];
       }
 
+   //KKK
+   $saved_documents = $formanswer->getFileProperties();
+
+   if ($saved_documents) {
+      foreach ($formanswer->getFileFields() as $questionId) {
+	 $data["_filename"]=array_merge($data["_filename"],$saved_documents["_filename"][$questionId]);
+	 $data["_tag_filename"]=array_merge($data["_tag_filename"],$saved_documents["_tag_filename"][$questionId]);
+
+	 foreach ( $saved_documents["_filename"][$questionId] as $key => $filename) {
+	    $uploaded_filename=$formanswer->getFileName($questionId,$key);
+	    copy(GLPI_DOC_DIR . '/' . $uploaded_filename, GLPI_TMP_DIR . '/' . $filename);
+	 }
+      }
+
+   } else {
+      foreach ($formanswer->getFileFields() as $questionId) {
+	 $data["_filename"]=array_merge($data["_filename"],$formanswer->input["_formcreator_field_".$questionId]);
+	 $data["_prefix_filename"]=array_merge($data["_prefix_filename"],$formanswer->input["_prefix_formcreator_field_".$questionId]);
+	 $data["_tag_filename"]=array_merge($data["_tag_filename"],$formanswer->input["_tag_formcreator_field_".$questionId]);
+	 foreach ( $formanswer->input["_formcreator_field_".$questionId] as $key => $filename) {
+	    $uploaded_filename=$formanswer->getFileName($questionId,$key);
+	    copy(GLPI_DOC_DIR . '/' . $uploaded_filename, GLPI_TMP_DIR . '/' . $filename);
+	 }
+      }
+   }
+
       // Create the target ticket
       $data['_auto_import'] = true;
       if (!$ticketID = $ticket->add($data)) {
@@ -832,7 +858,6 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractTarget
          'tickets_id' => $ticketID,
       ]);
 
-      $this->attachDocument($formanswer->getID(), Ticket::class, $ticketID);
 
       // Attach validation message as first ticket followup if validation is required and
       // if is set in ticket target configuration

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,1 @@
+Manage documents in initial notifications


### PR DESCRIPTION
### Changes description

Manage documents in initial notifications. Before this changes, target tickets are created and notifications are sent before documents get attached to the ticket. So initial notifications by e-mail don't contain references to them.
With these changes, documents are attached during ticket creation following standard creation procedure. It also works for forms requiring validation. 

The disadvantage of the proposed solution is that it manages document insertion twice (but using standard glpi duplication detection, files are not duplicated).

 !-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #2614 