### PR TITLE
WIP : Add documents to targets before creating them

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1993,4 +1993,73 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          'items_id' => $this->getID(),
       ]);
    }
+
+   /**
+    * Get the filename of a document for a question of this formanswer
+    *
+    * @param int $questionId
+    * @param int $index
+    *
+    * @return string
+    */
+   public function getFileName($questionId, $index): string {
+      $document = Document::getById($this->questionFields[$questionId]->getDocumentsForTarget()[$index]);
+      if (!is_object($document)) {
+         return '';
+      }
+
+      return $document->fields['filepath'];
+   }
+
+   /**
+    * Get ID of questions of type 'file'
+    *
+    * @return int[]
+    */
+   public function getFileFields(): array {
+      $filefields = [];
+
+      $form = $this->getForm();
+      foreach ($this->getQuestionFields($form) as $questionId => $field) {
+         $question = $field->getQuestion();
+         if ($question->fields['fieldtype'] != 'file') {
+            continue;
+         }
+         $filefields[] = $questionId;
+      }
+
+      return $filefields;
+   }
+
+   /**
+    * get properties of file uploads
+    *
+    * @return array
+    *
+    */
+   public function getFileProperties(): array {
+      $file_names = [];
+      $file_tags = [];
+
+      foreach ($this->getQuestionFields($this->getForm()->getID()) as $question_id => $field) {
+         if ($field->getQuestion()->fields['fieldtype'] != 'file') {
+            continue;
+         }
+
+         foreach ($field->getDocumentsForTarget() as $question_id) {
+            $document = Document::getById($question_id);
+            if (!is_object($document)) {
+               // If the document no longer exists
+               continue;
+            }
+            $file_names[$question_id][] = $document->fields['filename'];
+            $file_tags[$question_id][] = $document->fields['tag'];
+         }
+      }
+
+      return [
+         "_filename" => $file_names,
+         "_tag_filename" => $file_tags
+      ];
+   }
 }

--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -722,6 +722,8 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
       $data = $this->requesters + $this->observers + $this->assigned + $this->assignedSuppliers + $data;
       $data = $this->requesterGroups + $this->observerGroups + $this->assignedGroups + $data;
 
+      $data = $this->prepareUploadedFiles($data, $formanswer);
+
       // Create the target change
       if (!$changeID = $change->add($data)) {
          return null;
@@ -736,8 +738,6 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
          'items_id'     => $formanswer->fields['id'],
          'changes_id'  => $changeID,
       ]);
-
-      $this->attachDocument($formanswer->getID(), Change::class, $changeID);
 
       return $change;
    }

--- a/inc/targetproblem.class.php
+++ b/inc/targetproblem.class.php
@@ -219,6 +219,8 @@ class PluginFormcreatorTargetProblem extends PluginFormcreatorAbstractItilTarget
       $data = $this->requesters + $this->observers + $this->assigned + $this->assignedSuppliers + $data;
       $data = $this->requesterGroups + $this->observerGroups + $this->assignedGroups + $data;
 
+      $data = $this->prepareUploadedFiles($data, $formanswer);
+
       // Create the target problem
       if (!$problemID = $problem->add($data)) {
          return null;
@@ -233,8 +235,6 @@ class PluginFormcreatorTargetProblem extends PluginFormcreatorAbstractItilTarget
          'items_id'     => $formanswer->fields['id'],
          'problems_id'  => $problemID,
       ]);
-
-      $this->attachDocument($formanswer->getID(), Problem::class, $problem);
 
       return $problem;
    }

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -902,6 +902,8 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
          $data['_tag_content'][] = $document['tag'];
       }
 
+      $data = $this->prepareUploadedFiles($data, $formanswer);
+
       // Create the target ticket
       $data['_auto_import'] = true;
       if (!$ticketID = $ticket->add($data)) {
@@ -917,8 +919,6 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
          'items_id'   => $formanswer->fields['id'],
          'tickets_id' => $ticketID,
       ]);
-
-      $this->attachDocument($formanswer->getID(), Ticket::class, $ticketID);
 
       // Attach validation message as first ticket followup if validation is required and
       // if is set in ticket target configuration


### PR DESCRIPTION
This is a port of #2646 to version 2.13, with additional support for changes and problems.

It must solve an old limitation in Formcreator impacting the notifications of a generated ticket : the notification does not contains the documents of the generated ticket. The cause was the documents are added to the ticket after its creation.

This PR adds the documents at creation time.