### PR TITLE
Null not alowed fir requesters_id

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -162,7 +162,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
                'entities_id                              as entities_id'
             ],
             new QueryExpression('0                       as is_recursive'),
-            "$ticketUserTable.users_id                   as requester_id",
+            new QueryExpression("COALESCE($ticketUserTable.users_id, 0) as requester_id"),
             new QueryExpression("IF(`$ticketValidationTable`.`users_id_validate` IS NULL, 0, `$ticketValidationTable`.`users_id_validate`)  as users_id_validator"),
             new QueryExpression('0                       as groups_id_validator'),
             "$ticketTable.content                        as comment",


### PR DESCRIPTION
fix a "Column requester_id cannot be null" when installing the plugin (might also happen on upgtrade)