### PR TITLE
Fix form display

### DIFF
--- a/inc/abstractfield.class.php
+++ b/inc/abstractfield.class.php
@@ -59,14 +59,14 @@ abstract class PluginFormcreatorAbstractField implements PluginFormcreatorFieldI
       $this->question = $question;
    }
 
-   public function setFormAnswer(PluginFormcreatorFormAnswer $form_answer): void {
+   public function setFormAnswer(?PluginFormcreatorFormAnswer $form_answer): void {
       $this->form_answer = $form_answer;
-      if ($this->hasInput($this->form_answer->getAnswers())) {
+      if ($form_answer && $this->hasInput($this->form_answer->getAnswers())) {
          // Parse an HTML input
          $this->parseAnswerValues($this->form_answer->getAnswers());
       } else {
          // Deserialize the default value from DB
-         $this->deserializeValue($this->fields['default_values']);
+         $this->deserializeValue($this->question->fields['default_values']);
       }
    }
 

--- a/inc/field/floatfield.class.php
+++ b/inc/field/floatfield.class.php
@@ -43,6 +43,10 @@ use Glpi\Application\View\TemplateRenderer;
 
 class FloatField extends PluginFormcreatorAbstractField
 {
+   public static function getInputType(): string {
+      return "text";
+   }
+
    public function isPrerequisites(): bool {
       return true;
    }
@@ -75,7 +79,8 @@ class FloatField extends PluginFormcreatorAbstractField
       $defaultValue = Html::cleanInputText($this->value);
       $html .= Html::input($fieldName, [
          'id'    => $domId,
-         'value' => $defaultValue
+         'value' => $defaultValue,
+         'type'  => static::getInputType(),
       ]);
       $html .= Html::scriptBlock("$(function() {
          pluginFormcreatorInitializeField('$fieldName', '$rand');

--- a/inc/field/integerfield.class.php
+++ b/inc/field/integerfield.class.php
@@ -38,6 +38,10 @@ use PluginFormcreatorCommon;
 
 class IntegerField extends FloatField
 {
+   public static function getInputType(): string {
+      return "number";
+   }
+
    public function serializeValue(): string {
       if ($this->value === null || $this->value === '') {
          return '';

--- a/inc/fieldinterface.class.php
+++ b/inc/fieldinterface.class.php
@@ -307,8 +307,8 @@ interface PluginFormcreatorFieldInterface
    /**
     * Set the form answer containing the value of the field
     *
-    * @param PluginFormcreatorFormAnswer $form_answer
+    * @param PluginFormcreatorFormAnswer|null $form_answer
     * @return void
     */
-   public function setFormAnswer(PluginFormcreatorFormAnswer $form_answer): void;
+   public function setFormAnswer(?PluginFormcreatorFormAnswer $form_answer): void;
 }

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1850,12 +1850,13 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       /** @var PluginFormcreatorTargetInterface $targetType */
       $this->targetList = [];
       foreach (PluginFormcreatorForm::getTargetTypes() as $targetType) {
+         if (!$targetType instanceof ITILTargetInterface) {
+            continue;
+         }
+
          $targetItem = new $targetType();
          $generatedType = $targetItem->getTargetItemtypeName();
          $relationType = $targetItem->getItem_Item();
-         if ($relationType === null) {
-            continue;
-         }
          $relationTable = $relationType::getTable();
          $generatedTypeFk = $generatedType::getForeignKeyField();
          $generatedTypeTable = $generatedType::getTable();

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1850,13 +1850,12 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       /** @var PluginFormcreatorTargetInterface $targetType */
       $this->targetList = [];
       foreach (PluginFormcreatorForm::getTargetTypes() as $targetType) {
-         if (!$targetType instanceof ITILTargetInterface) {
-            continue;
-         }
-
          $targetItem = new $targetType();
          $generatedType = $targetItem->getTargetItemtypeName();
          $relationType = $targetItem->getItem_Item();
+         if ($relationType === null) {
+            continue;
+         }
          $relationTable = $relationType::getTable();
          $generatedTypeFk = $generatedType::getForeignKeyField();
          $generatedTypeTable = $generatedType::getTable();

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -1226,7 +1226,6 @@ PluginFormcreatorTranslatableInterface
             $this
          );
       }
-
       return $this->field;
    }
 

--- a/templates/pages/userform.html.twig
+++ b/templates/pages/userform.html.twig
@@ -47,12 +47,12 @@
     {% set formName = 'plugin_formcreator_form' %}
 	<form name="{{ formName }}" method="post" role="form" enctype="multipart/form-data" class="plugin_formcreator_form" action={{ item.getFormURL() }} id="plugin_formcreator_form" data-itemtype="PluginFormcreatorForm" data-id="{{ item.fields['id'] }}">
 		<h1 class='form-title'>
-		        {{ __(item.fields['name'], domain) }}
+		        {{ __(item.fields['name'], options.domain) }}
 			<i class="fas fa-print" style="cursor: pointer;" onclick="window.print();"></i>
 		</h1>
         {% if item.fields['content'] != '' %}
             <div class="form_header">
-            {{ __(item.fields['content'], domain)|safe_html }}
+            {{ __(item.fields['content'], options.domain)|safe_html }}
             {{ item.getExtraHeader()|safe_html }}
             </div>
         {% endif %}
@@ -68,7 +68,7 @@
                         {% if section.fields['name'] == '' %}
                             ({{ sectionId }})
                         {% else %}
-                            {{ __(section.fields['name'], domain) }}
+                            {{ __(section.fields['name'], options.domain) }}
                         {% endif %}
                     </h2>
                 </div>
@@ -91,7 +91,7 @@
                         {% endif %}
                         {% if not options.public or question.getSubField().isPublicFormCompatible() %}
                             {% set sessionData = session('formcreator') %}
-                            {{ question.getRenderedHtml(domain, true, sessionData.data)|raw }}
+                            {{ question.getRenderedHtml(options.domain, true, null)|raw }}
                         {% endif %}
                         {% set lastQuestion = question %}
                     {% endfor %}

--- a/tests/3-unit/PluginFormcreatorForm.php
+++ b/tests/3-unit/PluginFormcreatorForm.php
@@ -30,6 +30,7 @@
  */
 namespace tests\units;
 use GlpiPlugin\Formcreator\Tests\CommonTestCase;
+use PluginFormcreatorSection;
 
 class PluginFormcreatorForm extends CommonTestCase {
 
@@ -1389,5 +1390,17 @@ class PluginFormcreatorForm extends CommonTestCase {
       }
 
       $this->integer($output)->isEqualTo(2);
+   }
+
+   public function testDisplayForm(): void {
+      // Create test form
+      $question = $this->getQuestion([]);
+      $section = PluginFormcreatorSection::getById($question->fields['plugin_formcreator_sections_id']);
+      $form = \PluginFormcreatorForm::getById($section->fields['plugin_formcreator_forms_id']);
+
+      // Check for any warning/errors while displaying the form
+      ob_start();
+      $form->displayUserForm();
+      ob_end_clean();
    }
 }

--- a/tests/3-unit/PluginFormcreatorFormAnswer.php
+++ b/tests/3-unit/PluginFormcreatorFormAnswer.php
@@ -48,7 +48,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
          case 'testIsFieldVisible':
          case 'testPost_UpdateItem':
          case 'testPrepareInputForAdd':
-         case 'testGetTartgets':
+         case 'testGetTargets':
          case 'testGetGeneratedTargets':
          case 'testGetAggregatedStatus':
             $this->login('glpi', 'glpi');
@@ -605,7 +605,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
       $this->string($answer->fields['answer'])->isEqualTo('bar');
    }
 
-   public function testGetTartgets() {
+   public function testGetTargets() {
       global $CFG_GLPI;
 
       $CFG_GLPI['use_notifications'] = 0;

--- a/tests/src/CommonTestCase.php
+++ b/tests/src/CommonTestCase.php
@@ -225,7 +225,7 @@ abstract class CommonTestCase extends atoum
          'required'                       => '0',
          'show_empty'                     => '0',
          'default_values'                 => '',
-         'desription'                     => '',
+         'description'                    => '',
          'row'                            => '0',
          'col'                            => '0',
          'width'                          => '4',


### PR DESCRIPTION
### Changes description

Main issue was that https://github.com/pluginsGLPI/formcreator/commit/152ba276e17605308bde409d47cdd3c45d9c88d4 changed the `getRenderedHtml` method signature but the associated code in templates was not updated.
Also a few variables were not referenced properly (`$this->fields` instead of `$this->question->fields` and `domain` instead of `options.domain`).

There is a few bonus fixes regarding other issues I encountered while testing this feature.

Full changes:
* Fix form display
* Set input type to "number" for integer questions
* Fix targets (`getItem_Item` is not always defined)
* Add simple test to ensure displaying a form doesn't trigger any errors
