### PR TITLE
WIP: Performance problem in sync issue query

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -211,13 +211,19 @@ class PluginFormcreatorIssue extends CommonDBTM {
       ];
 
       // assistance requests having only one generated ticket (reuse query2)
-      $query3 = $query2;
-      // replace LEFT JOIN with INNER JOIN to exclude tickets not linked to a Formanswer object
-      $query3['INNER JOIN'][$itemTicketTable] = $query3['LEFT JOIN'][$itemTicketTable];
-      unset($query3['LEFT JOIN'][$itemTicketTable]);
-      // Only 1 relation to a Formanswer object
-      $query3['GROUPBY'] = ["$itemTicketTable.items_id"];
-      $query3['HAVING'] = new QueryExpression("COUNT(`$itemTicketTable`.`items_id`) = 1");
+      $query3 = [
+         'SELECT'     => $query2['SELECT'],
+         'FROM'       => $query2['FROM'],
+         'INNER JOIN' => [$itemTicketTable => $query2['LEFT JOIN'][$itemTicketTable]],
+         'LEFT JOIN'  => [
+            $query2['LEFT JOIN'][0], // This is the TABLE => [...] subquery
+            $ticketValidationTable => $query2['LEFT JOIN'][$ticketValidationTable],
+         ],
+         'WHERE'      => $query2['WHERE'],
+         'GROUPBY'    => ["$itemTicketTable.items_id"],
+         // Only 1 relation to a Formanswer object
+         'HAVING'     => new QueryExpression("COUNT(`$itemTicketTable`.`items_id`) = 1"),
+      ];
 
       // Union of the 3 previous queries
       $union = new QueryUnion([


### PR DESCRIPTION
Here is a descrpition of the query

```text
+------+-----------------+-------------------------------------+--------+--------------------+------------+---------+---------------------------------------------------------------+--------+-----------------------------------------------------------+
| id   | select_type     | table                               | type   | possible_keys      | key        | key_len | ref                                                           | rows   | Extra                                                     |
+------+-----------------+-------------------------------------+--------+--------------------+------------+---------+---------------------------------------------------------------+--------+-----------------------------------------------------------+
|    1 | PRIMARY         | <derived2>                          | ALL    | NULL               | NULL       | NULL    | NULL                                                          | 285309 |                                                           |
|    2 | DERIVED         | glpi_plugin_formcreator_formanswers | index  | NULL               | PRIMARY    | 4       | NULL                                                          | 126861 |                                                           |
|    2 | DERIVED         | glpi_items_tickets                  | ref    | unicity            | unicity    | 772     | const,assistanceng-dev.glpi_plugin_formcreator_formanswers.id |      1 | Using where; Using index                                  |
|    3 | UNION           | glpi_tickets                        | ref    | is_deleted         | is_deleted | 1       | const                                                         |  37214 | Using where                                               |
|    3 | UNION           | glpi_items_tickets                  | ref    | unicity,tickets_id | tickets_id | 4       | assistanceng-dev.glpi_tickets.id                              |      1 | Using where                                               |
|    3 | UNION           | <derived4>                          | ref    | key0               | key0       | 5       | assistanceng-dev.glpi_tickets.id                              |      2 |                                                           |
|    3 | UNION           | glpi_ticketvalidations              | ref    | tickets_id         | tickets_id | 4       | assistanceng-dev.glpi_tickets.id                              |      1 |                                                           |
|    4 | LATERAL DERIVED | glpi_tickets_users                  | ref    | unicity            | unicity    | 4       | assistanceng-dev.glpi_tickets.id                              |      1 | Using where; Using index                                  |
|    5 | UNION           | glpi_items_tickets                  | ref    | unicity,tickets_id | unicity    | 768     | const                                                         |  42010 | Using where; Using index; Using temporary; Using filesort |
|    5 | UNION           | glpi_tickets                        | eq_ref | PRIMARY,is_deleted | PRIMARY    | 4       | assistanceng-dev.glpi_items_tickets.tickets_id                |      1 | Using where                                               |
|    5 | UNION           | <derived6>                          | ref    | key0               | key0       | 5       | assistanceng-dev.glpi_items_tickets.tickets_id                |      2 |                                                           |
|    5 | UNION           | glpi_ticketvalidations              | ref    | tickets_id         | tickets_id | 4       | assistanceng-dev.glpi_items_tickets.tickets_id                |      1 |                                                           |
|    6 | LATERAL DERIVED | glpi_tickets_users                  | ref    | unicity            | unicity    | 4       | assistanceng-dev.glpi_items_tickets.tickets_id                |      1 | Using where; Using index                                  |
| NULL | UNION RESULT    | <union2,3,5>                        | ALL    | NULL               | NULL       | NULL    | NULL                                                          |   NULL |                                                           |
+------+-----------------+-------------------------------------+--------+--------------------+------------+---------+---------------------------------------------------------------+--------+-----------------------------------------------------------+
```

To prevent usage of temporary and filesort, I have to move the LEFT JOIN with glpi_items_tickets at 1st position of joined tables, remove the distinct keyword. 

