### PR TITLE
Use GLPI nightly build instead of git repo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   GLPI_SOURCE: "https://github.com/glpi-project/glpi"
+  GLPI_PACKAGE_URL: "https://nightly.glpi-project.org/glpi/master.tar.gz"
   CS: 7.4
   DB_HOST: 127.0.0.1
   MYSQL_ROOT_USER: root

--- a/tests/script-functions.sh
+++ b/tests/script-functions.sh
@@ -20,13 +20,17 @@ init_databases() {
 install_glpi() {
    echo Installing GLPI
    rm -rf ../glpi
-   git clone --depth=35 $GLPI_SOURCE -b $GLPI_BRANCH ../glpi && cd ../glpi
-   composer install --no-dev --no-interaction
-   php bin/console dependencies install composer-options=--no-dev
-   php bin/console locales:compile
-   php bin/console glpi:build:compile_scss
-   php bin/console glpi:system:check_requirements
-   rm .atoum.php
+   # git clone --depth=35 $GLPI_SOURCE -b $GLPI_BRANCH ../glpi
+   # cd ../glpi
+   # composer install --no-dev --no-interaction
+   # php bin/console dependencies install composer-options=--no-dev
+   # php bin/console locales:compile
+   # php bin/console glpi:build:compile_scss
+   # php bin/console glpi:system:check_requirements
+   # rm .atoum.php
+   curl $GLPI_PACKAGE_URL --output /tmp/glpi.tar.gz
+   tar xf /tmp/glpi.tar.gz --directory ../
+   cd ../glpi
    mkdir -p tests/files/_cache
    cp -r ../$PLUGINNAME plugins/$PLUGINNAME
 }


### PR DESCRIPTION
Reduce tests duration from 13 minutes to 7 minutes (6 minutes saved)

### before 
![image](https://user-images.githubusercontent.com/14139801/161713592-75e3627a-6481-4b5f-aa33-c07370633f1b.png)

### after
![image](https://user-images.githubusercontent.com/14139801/161713371-db7f2ba3-48a8-4902-b5ed-a30e11ee4fad.png)
