### PR TITLE
fix(fieldsfield): instanciation error when fields plugin disabled

### DIFF
--- a/inc/field/tagfield.class.php
+++ b/inc/field/tagfield.class.php
@@ -46,6 +46,16 @@ class TagField extends DropdownField
    }
 
    public function showForm(array $options): void {
+      if (!\Plugin::isPluginActive('tag')) {
+         $options['error'] = __('Warning: Tag plugin is disabled or missing', 'formcreator');
+         $template = '@formcreator/field/undefinedfield.html.twig';
+         TemplateRenderer::getInstance()->display($template, [
+            'item' => $this->question,
+            'params' => $options,
+         ]);
+         return;
+      }
+
       $template = '@formcreator/field/' . $this->question->fields['fieldtype'] . 'field.html.twig';
       $this->question->fields['default_values'] = Html::entities_deep($this->question->fields['default_values']);
       $this->deserializeValue($this->question->fields['default_values']);

--- a/inc/field/undefinedfield.class.php
+++ b/inc/field/undefinedfield.class.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * Formcreator is a plugin which allows creation of custom forms of
+ * easy access.
+ * ---------------------------------------------------------------------
+ * LICENSE
+ *
+ * This file is part of Formcreator.
+ *
+ * Formcreator is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Formcreator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Formcreator. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ * @copyright Copyright © 2011 - 2020 Teclib'
+ * @license   http://www.gnu.org/licenses/gpl.txt GPLv3+
+ * @link      https://github.com/pluginsGLPI/formcreator/
+ * @link      https://pluginsglpi.github.io/formcreator/
+ * @link      http://plugins.glpi-project.org/#/plugin/formcreator
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Formcreator\Field;
+
+use PluginFormcreatorAbstractField;
+use Html;
+use GlpiPlugin\Formcreator\Exception\ComparisonException;
+use Glpi\Application\View\TemplateRenderer;
+
+class UndefinedField extends PluginFormcreatorAbstractField
+{
+   public static function getName(): string {
+      return __('Undefined', 'formcreator');
+   }
+
+   public static function canRequire(): bool {
+      return false;
+   }
+
+   public function serializeValue(): string {
+      return '';
+   }
+
+   public function deserializeValue($value) {
+   }
+
+   public function getValueForDesign(): string {
+      return '';
+   }
+
+   public function getValueForTargetText($domain, $richText): ?string {
+      return null;
+   }
+
+   public function getValueForApi() {
+      return '';
+   }
+
+   public function moveUploads() {
+   }
+
+   public function getDocumentsForTarget(): array {
+      return [];
+   }
+
+   public function isPrerequisites(): bool {
+       return true;
+   }
+
+   public function isPublicFormCompatible(): bool {
+      return true;
+   }
+
+   public function showForm(array $options): void {
+      $template = '@formcreator/field/undefinedfield.html.twig';
+      $this->question->fields['default_values'] = Html::entities_deep($this->question->fields['default_values']);
+      $this->deserializeValue($this->question->fields['default_values']);
+      TemplateRenderer::getInstance()->display($template, [
+         'item' => $this->question,
+         'params' => $options,
+      ]);
+   }
+   public function isValid(): bool {
+       return true;
+   }
+   public function isValidValue($value): bool {
+       return true;
+   }
+
+   public function hasInput($input): bool {
+      return false;
+   }
+
+   public function parseAnswerValues($input, $nonDestructive = false): bool {
+      return true;
+   }
+
+   public function isEditableField(): bool {
+      return true;
+   }
+
+   public function getHtmlIcon(): string {
+      return '<i class="fa fa-question" aria-hidden="true"></i>';
+   }
+
+   public function equals($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
+   public function notEquals($value): bool {
+       throw new ComparisonException('Meaningless comparison');
+   }
+
+   public function greaterThan($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
+   public function lessThan($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
+   public function regex($value): bool {
+      throw new ComparisonException('Meaningless comparison');
+   }
+
+   public function isVisibleField(): bool {
+      return false;
+   }
+}

--- a/inc/fields.class.php
+++ b/inc/fields.class.php
@@ -30,6 +30,7 @@
  */
 
 use GlpiPlugin\Formcreator\Exception\ComparisonException;
+use GlpiPlugin\Formcreator\Field\UndefinedField;
 use Xylemical\Expressions\Math\BcMath;
 use Xylemical\Expressions\Context;
 use Xylemical\Expressions\ExpressionFactory;
@@ -107,7 +108,7 @@ class PluginFormcreatorFields
       // Get localized names of field types
       foreach (PluginFormcreatorFields::getClasses() as $field_type => $classname) {
          $classname = self::getFieldClassname($field_type);
-         if ($classname == PluginFormcreatorTagField::class && !$plugin->isActivated('tag')) {
+         if ($classname == UndefinedField::class) {
             continue;
          }
 

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -31,6 +31,7 @@
 
 use GlpiPlugin\Formcreator\Exception\ImportFailureException;
 use GlpiPlugin\Formcreator\Exception\ExportFailureException;
+use GlpiPlugin\Formcreator\Field\UndefinedField;
 use Glpi\Application\View\TemplateRenderer;
 
 if (!defined('GLPI_ROOT')) {
@@ -205,6 +206,7 @@ PluginFormcreatorTranslatableInterface
       $questionId = $this->getID();
       $sectionId = $this->fields[PluginFormcreatorSection::getForeignKeyField()];
       $fieldType = PluginFormcreatorFields::getFieldClassname($this->fields['fieldtype']);
+      /** @var PluginFormcreatorFieldInterface $field */
       $field = new $fieldType($this);
 
       $html .= '<div class="grid-stack-item"'
@@ -725,7 +727,7 @@ PluginFormcreatorTranslatableInterface
       $options['target'] = "javascript:;";
       $options['formoptions'] = sprintf('onsubmit="plugin_formcreator.submitQuestion(this)" data-itemtype="%s" data-id="%s"', self::getType(), $this->getID());
 
-      $template = '@formcreator/field/undefined.html.twig';
+      $template = '@formcreator/field/undefinedfield.html.twig';
       if (!$this->loadField($this->fields['fieldtype'])) {
          TemplateRenderer::getInstance()->display($template, [
             'item' => $this,
@@ -1186,7 +1188,7 @@ PluginFormcreatorTranslatableInterface
    }
 
    /**
-    * load instance if field associated to the question
+    * load instance of field associated to the question
     *
     * @return bool true on sucess, false otherwise
     */

--- a/templates/field/undefinedfield.html.twig
+++ b/templates/field/undefinedfield.html.twig
@@ -36,4 +36,5 @@
 {% import '@formcreator/components/form/fields_macros.html.twig' as formcreatorFields %}
 
 {% block questionFields %}
+    {{ fields.smallTitle(params.error) }}
 {% endblock %}


### PR DESCRIPTION
We cannot instanciate classes from Fields plugin in constructor. This throws a fatal error.

I added a lazy loading of the instance of  the class, and provided a way to edit a fields question anyway.