### PR TITLE
Display "formcreator_insert_header" even if the form itself has no header defined

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -526,7 +526,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       echo '</h1>';
 
       // Form Header
-      if (!empty($this->fields['content'])) {
+      if (!empty($this->fields['content'] || !empty($form->getExtraHeader()))) {
          echo '<div class="form_header">';
          echo html_entity_decode($this->fields['content']);
          echo html_entity_decode($form->getExtraHeader());

--- a/templates/pages/userform.html.twig
+++ b/templates/pages/userform.html.twig
@@ -50,7 +50,7 @@
 		        {{ __(item.fields['name'], options.domain) }}
 			<i class="fas fa-print" style="cursor: pointer;" onclick="window.print();"></i>
 		</h1>
-        {% if item.fields['content'] != '' %}
+        {% if item.fields['content'] != '' or item.getExtraHeader() != "" %}
             <div class="form_header">
             {{ __(item.fields['content'], options.domain)|safe_html }}
             {{ item.getExtraHeader()|safe_html }}


### PR DESCRIPTION
### Changes description

Following #2626, loosen some conditions so that the extra headers can be displayed even if the form itself has no header.

