### PR TITLE
Bad label when searching KB items

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -452,7 +452,7 @@ function buildTiles(list) {
    var html = '';
    if (list.length == 0) {
       html = '<p id="plugin_formcreator_formlist">'
-      + i18n.textdomain('formcreator').__('No form yet in this category', 'formcreator')
+      + i18n.textdomain('formcreator').__('No item yet in this category', 'formcreator')
       + '</p>'
       +'<p id="plugin_formcreator_faqlist"></p>';
    } else {


### PR DESCRIPTION
The same code is used to show forms, KB items or both. The "not found" message is not accurate.

see #2634 