### PR TITLE
Use Generators instead of arrays

### DIFF
--- a/ajax/load_questions.php
+++ b/ajax/load_questions.php
@@ -36,10 +36,9 @@ if (!isset($_REQUEST['section_id'])) {
     http_response_code(400);
     exit();
 }
- $sectionId = (int) $_REQUEST['section_id'];
+$sectionId = (int) $_REQUEST['section_id'];
 
- $questions = (new PluginFormcreatorQuestion)->getQuestionsFromSection($sectionId);
- $json = [];
-foreach ($questions as $question) {
+$json = [];
+foreach (PluginFormcreatorQuestion::getQuestionsFromSection($sectionId) as $question) {
     $json[] = $question->getDesignHtml();
 }

--- a/ajax/question_get.php
+++ b/ajax/question_get.php
@@ -38,10 +38,9 @@ if (!isset($_REQUEST['id'])) {
    exit();
 }
 $sectionId = (int) $_REQUEST['id'];
-$questions = PluginFormcreatorQuestion::getQuestionsFromSection($sectionId);
 
 $json = [];
-foreach ($questions as $question) {
+foreach (PluginFormcreatorQuestion::getQuestionsFromSection($sectionId) as $question) {
     $json[$question->getID()] = [
         'y'      => $question->fields['row'],
         'x'      => $question->fields['col'],

--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -751,14 +751,14 @@ PluginFormcreatorTranslatableInterface
       );
 
       $questionTable = PluginFormcreatorQuestion::getTable();
-      $questions = PluginFormcreatorQuestion::getQuestionsFromForm(
+      $questionsGenerator = PluginFormcreatorQuestion::getQuestionsFromForm(
          $this->getForm()->getID(),
          [
             "$questionTable.fieldtype" => ['date', 'datetime'],
          ]
       );
       $questions_list = [];
-      foreach ($questions as $question) {
+      foreach ($questionsGenerator as $question) {
          $questions_list[$question->getID()] = $question->fields['name'];
       }
       // List questions

--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -751,7 +751,7 @@ PluginFormcreatorTranslatableInterface
       );
 
       $questionTable = PluginFormcreatorQuestion::getTable();
-      $questions = (new PluginFormcreatorQuestion)->getQuestionsFromForm(
+      $questions = PluginFormcreatorQuestion::getQuestionsFromForm(
          $this->getForm()->getID(),
          [
             "$questionTable.fieldtype" => ['date', 'datetime'],

--- a/inc/abstracttarget.class.php
+++ b/inc/abstracttarget.class.php
@@ -263,8 +263,7 @@ abstract class PluginFormcreatorAbstractTarget extends CommonDBChild implements
     * @return array all fields of the object wih converted template fields
     */
    protected function convertTags($input) {
-      $question = new PluginFormcreatorQuestion();
-      $questions = $question->getQuestionsFromForm($this->getForm()->getID());
+      $questions = PluginFormcreatorQuestion::getQuestionsFromForm($this->getForm()->getID());
 
       $taggableFields = $this->getTaggableFields();
 

--- a/inc/abstracttarget.class.php
+++ b/inc/abstracttarget.class.php
@@ -263,14 +263,14 @@ abstract class PluginFormcreatorAbstractTarget extends CommonDBChild implements
     * @return array all fields of the object wih converted template fields
     */
    protected function convertTags($input) {
-      $questions = PluginFormcreatorQuestion::getQuestionsFromForm($this->getForm()->getID());
+      $questionsGenerator = PluginFormcreatorQuestion::getQuestionsFromForm($this->getForm()->getID());
 
       $taggableFields = $this->getTaggableFields();
 
       // Prepare array of search / replace
       $ids = [];
       $uuids = [];
-      foreach ($questions as $question) {
+      foreach ($questionsGenerator as $question) {
          $id      = $question->fields['id'];
          $uuid    = $question->fields['uuid'];
          $ids[]   = "##question_$id##";

--- a/inc/condition.class.php
+++ b/inc/condition.class.php
@@ -319,10 +319,10 @@ class PluginFormcreatorCondition extends CommonDBChild implements PluginFormcrea
          case PluginFormcreatorSection::class:
             if ($item->isNewItem()) {
                $formFk = PluginFormcreatorForm::getForeignKeyField();
-               $sections = (new PluginFormcreatorSection())->getSectionsFromForm($item->fields[$formFk]);
+               $sectionsGenerator = PluginFormcreatorSection::getSectionsFromForm($item->fields[$formFk]);
                $sectionsList = [];
-               foreach ($sections as $section) {
-                  $sectionsList[] = $section->getID();
+               foreach ($sectionsGenerator as $sectionId => $section) {
+                  $sectionsList[] = $sectionId;
                }
                $questionListExclusion = [];
                if (count($sectionsList) > 0) {

--- a/inc/fields.class.php
+++ b/inc/fields.class.php
@@ -382,9 +382,10 @@ class PluginFormcreatorFields
 
       // Get the visibility result of sections
       $sectionToShow = [];
-      $sections = (new PluginFormcreatorSection)->getSectionsFromForm($form->getID());
-      foreach ($sections as $section) {
-         $sectionToShow[$section->getID()] = PluginFormcreatorFields::isVisible($section, $fields);
+      $sectionsGenerator = PluginFormcreatorSection::getSectionsFromForm($form->getID());
+      /** @var PluginFormcreatorSection $section */
+      foreach ($sectionsGenerator as $sectionId => $section) {
+         $sectionToShow[$sectionId] = PluginFormcreatorFields::isVisible($section, $fields);
       }
 
       return [

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -2056,8 +2056,8 @@ PluginFormcreatorTranslatableInterface
          return $fields;
       }
 
-      $foundQuestions = PluginFormcreatorQuestion::getQuestionsFromForm($this->getID());
-      foreach ($foundQuestions as $id => $question) {
+      $questionsGenerator = PluginFormcreatorQuestion::getQuestionsFromForm($this->getID());
+      foreach ($questionsGenerator as $id => $question) {
          $fields[$id] = $question->getSubField();
       }
 
@@ -2310,7 +2310,7 @@ PluginFormcreatorTranslatableInterface
 
       $strings = $this->getMyTranslatableStrings($options);
 
-      foreach ((new PluginFormcreatorSection())->getSectionsFromForm($this->getID()) as $section) {
+      foreach (PluginFormcreatorSection::getSectionsFromForm($this->getID()) as $section) {
          foreach ($section->getTranslatableStrings($options) as $type => $subStrings) {
             $strings[$type] = array_merge($strings[$type], $subStrings);
          }

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -2056,9 +2056,8 @@ PluginFormcreatorTranslatableInterface
          return $fields;
       }
 
-      $question = new PluginFormcreatorQuestion();
-      $found_questions = $question->getQuestionsFromForm($this->getID());
-      foreach ($found_questions as $id => $question) {
+      $foundQuestions = PluginFormcreatorQuestion::getQuestionsFromForm($this->getID());
+      foreach ($foundQuestions as $id => $question) {
          $fields[$id] = $question->getSubField();
       }
 

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -277,22 +277,21 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
       if ($display_for_form) {
          $optindex = self::SOPTION_ANSWER;
-         $question = new PluginFormcreatorQuestion;
-         $questions = $question->getQuestionsFromForm($_SESSION['formcreator']['form_search_answers']);
+         $questions = PluginFormcreatorQuestion::getQuestionsFromForm($_SESSION['formcreator']['form_search_answers']);
 
-         foreach ($questions as $current_question) {
-            $questions_id = $current_question->getID();
+         foreach ($questions as $question) {
+            $questionId = $question->getID();
             $tab[] = [
                'id'            => $optindex,
                'table'         => PluginFormcreatorAnswer::getTable(),
                'field'         => 'answer',
-               'name'          => $current_question->fields['name'],
+               'name'          => $question->fields['name'],
                'datatype'      => 'string',
                'massiveaction' => false,
                'nosearch'      => false,
                'joinparams'    => [
                   'jointype'  => 'child',
-                  'condition' => "AND NEWTABLE.`plugin_formcreator_questions_id` = $questions_id",
+                  'condition' => "AND NEWTABLE.`plugin_formcreator_questions_id` = $questionId",
                ]
             ];
 

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -581,8 +581,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
          // Display all fields of the section
          $lastQuestion = null;
-         $questions = (new PluginFormcreatorQuestion)->getQuestionsFromSection($sectionId);
-         foreach ($questions as $question) {
+         foreach (PluginFormcreatorQuestion::getQuestionsFromSection($sectionId) as $question) {
             if ($lastQuestion !== null) {
                if ($lastQuestion->fields['row'] < $question->fields['row']) {
                   // the question begins a new line

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -277,10 +277,9 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
       if ($display_for_form) {
          $optindex = self::SOPTION_ANSWER;
-         $questions = PluginFormcreatorQuestion::getQuestionsFromForm($_SESSION['formcreator']['form_search_answers']);
+         $questionsGenerator = PluginFormcreatorQuestion::getQuestionsFromForm($_SESSION['formcreator']['form_search_answers']);
 
-         foreach ($questions as $question) {
-            $questionId = $question->getID();
+         foreach ($questionsGenerator as $questionId => $question) {
             $tab[] = [
                'id'            => $optindex,
                'table'         => PluginFormcreatorAnswer::getTable(),
@@ -561,10 +560,8 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       $this->answers['plugin_formcreator_forms_id'] = $form->getID();
       $visibility = PluginFormcreatorFields::updateVisibility($this->answers);
 
-      $sections = (new PluginFormcreatorSection)->getSectionsFromForm($form->getID());
-      foreach ($sections as $section) {
-         $sectionId = $section->getID();
-
+      $sectionsGenerator = PluginFormcreatorSection::getSectionsFromForm($form->getID());
+      foreach ($sectionsGenerator as $sectionId => $section) {
          // Section header
          $hiddenAttribute = $visibility[$section->getType()][$sectionId] ? '' : 'hidden=""';
          echo '<li'

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -958,12 +958,11 @@ PluginFormcreatorTranslatableInterface
     *
     * @param int $sectionId
     *
-    * @return PluginFormcreatorQuestion[]
+    * @return \Generator
     */
-   public static function getQuestionsFromSection($sectionId) {
+   public static function getQuestionsFromSection($sectionId): \Generator {
       global $DB;
 
-      $questions = [];
       $rows = $DB->request([
          'SELECT' => ['id'],
          'FROM'   => self::getTable(),
@@ -973,12 +972,10 @@ PluginFormcreatorTranslatableInterface
          'ORDER'  => ['row ASC', 'col ASC']
       ]);
       foreach ($rows as $row) {
-            $question = new self();
-            $question->getFromDB($row['id']);
-            $questions[$row['id']] = $question;
+         $question = new self();
+         $question->getFromDB($row['id']);
+         yield $row['id'] => $question;
       }
-
-      return $questions;
    }
 
    /**

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -916,9 +916,9 @@ PluginFormcreatorTranslatableInterface
     * return array of question objects belonging to a form
     * @param int $formId
     * @param array $crit array for the WHERE clause
-    * @return PluginFormcreatorQuestion[]
+    * @return \Generator
     */
-   public static function getQuestionsFromForm($formId, $crit = []) {
+   public static function getQuestionsFromForm($formId, $crit = []): \Generator {
       global $DB;
 
       $table_question = PluginFormcreatorQuestion::getTable();
@@ -946,14 +946,11 @@ PluginFormcreatorTranslatableInterface
          ]
       ]);
 
-      $questions = [];
       foreach ($result as $row) {
          $question = new self();
          $question->getFromDB($row['id']);
-         $questions[$row['id']] = $question;
+         yield $row['id'] => $question;
       }
-
-      return $questions;
    }
 
    /**

--- a/inc/questiondependency.class.php
+++ b/inc/questiondependency.class.php
@@ -76,7 +76,7 @@ extends PluginFormcreatorAbstractQuestionParameter
       // get questions of type text in the form
       $eligibleQuestions = [];
       $criteria = ['fieldtype' => $this->fieldtype];
-      foreach ($question->getQuestionsFromForm($form->getID(), $criteria) as $item) {
+      foreach (PluginFormcreatorQuestion::getQuestionsFromForm($form->getID(), $criteria) as $item) {
          $eligibleQuestions[$item->getID()] = $item->getField('name');
       }
 

--- a/inc/section.class.php
+++ b/inc/section.class.php
@@ -577,7 +577,7 @@ PluginFormcreatorTranslatableInterface
 
       $strings = $this->getMyTranslatableStrings($options);
 
-      foreach ((new PluginFormcreatorQuestion())->getQuestionsFromSection($this->getID()) as $question) {
+      foreach (PluginFormcreatorQuestion::getQuestionsFromSection($this->getID()) as $question) {
          foreach ($question->getTranslatableStrings($options) as $type => $subStrings) {
             $strings[$type] = array_merge($strings[$type], $subStrings);
          }

--- a/inc/section.class.php
+++ b/inc/section.class.php
@@ -429,12 +429,11 @@ PluginFormcreatorTranslatableInterface
    /**
     * gets all sections in a form
     * @param int $formId ID of a form
-    * @return self[] sections in a form
+    * @return \Generator Generator of sections in a form
     */
-   public static function getSectionsFromForm($formId) {
+   public static function getSectionsFromForm($formId): \Generator {
       global $DB;
 
-      $sections = [];
       $rows = $DB->request([
          'SELECT' => ['id'],
          'FROM'   => self::getTable(),
@@ -446,10 +445,8 @@ PluginFormcreatorTranslatableInterface
       foreach ($rows as $row) {
          $section = new self();
          $section->getFromDB($row['id']);
-         $sections[$row['id']] = $section;
+         yield $row['id'] => $section;
       }
-
-      return $sections;
    }
 
    public function showForm($ID, $options = []) {

--- a/tests/3-unit/PluginFormcreatorForm.php
+++ b/tests/3-unit/PluginFormcreatorForm.php
@@ -853,48 +853,58 @@ class PluginFormcreatorForm extends CommonTestCase {
 
       // check that all sections uuid are new
       $uuids = $new_uuids = [];
-      $count = 0;
+      $all_sections_count = 0;
+      $all_new_sections_count = 0;
       foreach ($all_sections as $section) {
-         $count++;
+         $all_sections_count++;
          $uuids[] = $section->fields['uuid'];
       }
-      $this->integer($count)->isEqualTo(count($section_ids));
-      $count = 0;
       foreach ($all_new_sections as $section) {
-         $count++;
+         $all_new_sections_count++;
          $new_uuids[] = $section->fields['uuid'];
       }
-      $this->integer($count)->isEqualTo(count($section_ids));
+      $this->integer($all_sections_count)->isEqualTo(count($section_ids));
+      $this->integer($all_new_sections_count)->isEqualTo(count($section_ids));
       $this->integer(count(array_diff($new_uuids, $uuids)))->isEqualTo(count($new_uuids));
 
       // check target tickets
       $all_targetTickets = (new \PluginFormcreatorTargetTicket())->getTargetsForForm($form->getID());
-      $this->integer(count($all_sections))->isEqualTo(count($section_ids));
       $all_new_targetTickets = (new \PluginFormcreatorTargetTicket())->getTargetsForForm($new_form->getID());
-      $this->integer(count($all_sections))->isEqualTo(count($section_ids));
 
-      // check that all sections uuid are new
+      // check that all target tickets uuid are new
+      $uuids = $new_uuids = [];
+      $all_targetTickets_count = 0;
+      $all_new_targetTickets_count = 0;
       foreach ($all_targetTickets as $targetTicket) {
+         $all_targetTickets_count++;
          $uuids[] = $targetTicket->fields['uuid'];
       }
       foreach ($all_new_targetTickets as $targetTicket) {
+         $all_new_targetTickets_count++;
          $new_uuids[] = $targetTicket->fields['uuid'];
       }
+      $this->integer($all_targetTickets_count)->isEqualTo(count($targetTicket_ids));
+      $this->integer($all_new_targetTickets_count)->isEqualTo(count($targetTicket_ids));
       $this->integer(count(array_diff($new_uuids, $uuids)))->isEqualTo(count($new_uuids));
 
       // check target changes
       $all_targetChanges = (new \PluginFormcreatorTargetChange())->getTargetsForForm($form->getID());
-      $this->integer(count($all_sections))->isEqualTo(count($section_ids));
       $all_new_targetChanges = (new \PluginFormcreatorTargetChange())->getTargetsForForm($new_form->getID());
-      $this->integer(count($all_sections))->isEqualTo(count($section_ids));
 
-      // check that all sections uuid are new
+      // check that all target changes uuid are new
+      $all_target_changes_count = 0;
+      $all_new_target_changes_count = 0;
+      $uuids = $new_uuids = [];
       foreach ($all_targetChanges as $targetChange) {
+         $all_target_changes_count++;
          $uuids[] = $targetChange->fields['uuid'];
       }
       foreach ($all_new_targetChanges as $targetChange) {
+         $all_new_target_changes_count++;
          $new_uuids[] = $targetChange->fields['uuid'];
       }
+      $this->integer($all_target_changes_count)->isEqualTo(count($targetChange_ids));
+      $this->integer($all_new_target_changes_count)->isEqualTo(count($targetChange_ids));
       $this->integer(count(array_diff($new_uuids, $uuids)))->isEqualTo(count($new_uuids));
    }
 

--- a/tests/3-unit/PluginFormcreatorForm.php
+++ b/tests/3-unit/PluginFormcreatorForm.php
@@ -848,19 +848,23 @@ class PluginFormcreatorForm extends CommonTestCase {
       $this->string($new_form->getField('uuid'))->isNotEqualTo($form->getField('uuid'));
 
       // check sections
-      $all_sections = (new \PluginFormcreatorSection())->getSectionsFromForm($form->getID());
-      $this->integer(count($all_sections))->isEqualTo(count($section_ids));
-      $all_new_sections = (new \PluginFormcreatorSection())->getSectionsFromForm($new_form->getID());
-      $this->integer(count($all_sections))->isEqualTo(count($section_ids));
+      $all_sections = \PluginFormcreatorSection::getSectionsFromForm($form->getID());
+      $all_new_sections = \PluginFormcreatorSection::getSectionsFromForm($new_form->getID());
 
       // check that all sections uuid are new
       $uuids = $new_uuids = [];
+      $count = 0;
       foreach ($all_sections as $section) {
+         $count++;
          $uuids[] = $section->fields['uuid'];
       }
+      $this->integer($count)->isEqualTo(count($section_ids));
+      $count = 0;
       foreach ($all_new_sections as $section) {
+         $count++;
          $new_uuids[] = $section->fields['uuid'];
       }
+      $this->integer($count)->isEqualTo(count($section_ids));
       $this->integer(count(array_diff($new_uuids, $uuids)))->isEqualTo(count($new_uuids));
 
       // check target tickets

--- a/tests/3-unit/PluginFormcreatorQuestion.php
+++ b/tests/3-unit/PluginFormcreatorQuestion.php
@@ -1133,7 +1133,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
       $this->array(array_intersect($questionIds, $expectedQuestionIds))->hasSize(2);
    }
 
-   public function testGetQuestionsBySection() {
+   public function testGetQuestionsFromSection() {
       $section = $this->getSection();
       $sectionFk = \PluginFormcreatorSection::getForeignKeyField();
       $question1 = $this->getQuestion([
@@ -1143,10 +1143,10 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          $sectionFk => $section->getID(),
       ]);
 
-      $questions = \PluginFormcreatorQuestion::getQuestionsFromSection($section->getID());
+      $questionsGenerator = \PluginFormcreatorQuestion::getQuestionsFromSection($section->getID());
       $questionIds = [];
-      foreach ($questions as $item) {
-         $questionIds[] = $item->getID();
+      foreach ($questionsGenerator as $itemId => $item) {
+         $questionIds[] = $itemId;
       }
       $expectedQuestionIds = [
          $question1->getID(),

--- a/tests/3-unit/PluginFormcreatorQuestion.php
+++ b/tests/3-unit/PluginFormcreatorQuestion.php
@@ -1116,13 +1116,15 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          $sectionFk => $section2->getID(),
       ]);
 
-      $questions = \PluginFormcreatorQuestion::getQuestionsFromForm($form->getID());
-      $this->array($questions)->hasSize(2);
-
+      $questionsGenerator = \PluginFormcreatorQuestion::getQuestionsFromForm($form->getID());
       $questionIds = [];
-      foreach ($questions as $item) {
+      $count = 0;
+      foreach ($questionsGenerator as $itemId => $item) {
+         $count++;
          $questionIds[] = $item->getID();
+         $this->integer((int) $itemId)->isEqualTo($item->getID());
       }
+      $this->integer($count)->isEqualTo(2);
       $expectedQuestionIds = [
          $question1->getID(),
          $question2->getID(),

--- a/tests/3-unit/PluginFormcreatorSection.php
+++ b/tests/3-unit/PluginFormcreatorSection.php
@@ -530,6 +530,7 @@ class PluginFormcreatorSection extends CommonTestCase {
       }
       $this->integer($count)->isEqualTo(2);
 
+      $output = \PluginFormcreatorSection::getSectionsFromForm($form->getID());
       $found = 0;
       foreach ($output as $section) {
          foreach ($sections as $search) {

--- a/tests/3-unit/PluginFormcreatorSection.php
+++ b/tests/3-unit/PluginFormcreatorSection.php
@@ -504,7 +504,11 @@ class PluginFormcreatorSection extends CommonTestCase {
       $this->boolean($form->isNewItem())->isFalse();
 
       $output = \PluginFormcreatorSection::getSectionsFromForm($form->getID());
-      $this->array($output)->hasSize(0);
+      $count = 0;
+      foreach ($output as $section) {
+         $count++;
+      }
+      $this->integer($count)->IsEqualTo(0);
 
       $sections = [];
       $section = $this->getSection([
@@ -520,7 +524,11 @@ class PluginFormcreatorSection extends CommonTestCase {
       $sections[] = $section;
 
       $output = \PluginFormcreatorSection::getSectionsFromForm($form->getID());
-      $this->array($output)->hasSize(2);
+      $count = 0;
+      foreach ($output as $section) {
+         $count++;
+      }
+      $this->integer($count)->isEqualTo(2);
 
       $found = 0;
       foreach ($output as $section) {

--- a/tests/src/CommonQuestionTest.php
+++ b/tests/src/CommonQuestionTest.php
@@ -78,7 +78,7 @@ trait CommonQuestionTest
       }
 
       // test the question is created in DB
-      $questions = (new \PluginFormcreatorQuestion())->getQuestionsFromForm($form->getID());
+      $questions = \PluginFormcreatorQuestion::getQuestionsFromForm($form->getID());
       $question = array_pop($questions);
       $this->variable($question)->isNotNull();
 

--- a/tests/src/CommonQuestionTest.php
+++ b/tests/src/CommonQuestionTest.php
@@ -3,6 +3,8 @@
 namespace GlpiPlugin\Formcreator\Tests;
 
 use Plugin;
+use PluginFormcreatorQuestion;
+
 trait CommonQuestionTest
 {
 
@@ -78,8 +80,9 @@ trait CommonQuestionTest
       }
 
       // test the question is created in DB
-      $questions = \PluginFormcreatorQuestion::getQuestionsFromForm($form->getID());
-      $question = array_pop($questions);
+      $questionsGenerator = \PluginFormcreatorQuestion::getQuestionsFromForm($form->getID());
+      /** @var PluginFormcreatorQuestion $question */
+      $question = $questionsGenerator->current(); // Get the 1st item
       $this->variable($question)->isNotNull();
 
       // test the question is displayed


### PR DESCRIPTION
Introduce generators in some methods. Should reduce memory usage when getting objects, mostly CommonDBChild

There are more methods which may be converted as well.