### PR TITLE
feat(dashboard): enable label

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -1032,3 +1032,7 @@ a.plugin_formcreator_formTile_title {
       max-width: 400px;
    }
 }
+
+.formcreator_dashboard_container .dashboard .big-number .label {
+   font-size: 12px !important;
+}

--- a/hook.php
+++ b/hook.php
@@ -678,7 +678,7 @@ function plugin_formcreator_hook_dashboard_cards($cards) {
          'args'       => [
             'params' => [
                'status' => $key,
-               'label'  => "", //$label
+               'label'  => $label,
             ]
          ],
          'cache'      => false,

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -839,7 +839,9 @@ JAVASCRIPT;
 
       if (PluginFormcreatorEntityconfig::getUsedConfig('is_dashboard_visible', Session::getActiveEntity()) == PluginFormcreatorEntityconfig::CONFIG_DASHBOARD_VISIBLE) {
          $dashboard = new Glpi\Dashboard\Grid('plugin_formcreator_issue_counters', 33, 0, 'mini_core');
+         echo "<div class='formcreator_dashboard_container'>";
          $dashboard->show(true);
+         echo "</div>";
       }
    }
 }


### PR DESCRIPTION
### Changes description

Enable dashboard label 
and adapt font-size (option not available from GLPI core)

Before (without ```CSS``` adaptation): 
![image](https://user-images.githubusercontent.com/7335054/167384815-84a05712-d820-4970-a609-3ffa20a7371f.png)

After
![image](https://user-images.githubusercontent.com/7335054/167384856-f0384ad4-7d76-4922-879d-82854e427afb.png)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A