### PR TITLE
feat(dashboard): shorter card labels

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -658,15 +658,15 @@ function plugin_formcreator_hook_dashboard_cards($cards) {
    }
 
    $counters = [
-      'all'        => __('All issues', 'formcreator'),
-      'incoming'   => __('New issues', 'formcreator'),
-      'assigned'   => __('Assigned issues', 'formcreator'),
-      'waiting'    => __('Waiting issues', 'formcreator'),
-      'validate'   => __('Issues to validate', 'formcreator'),
-      'solved'     => __('Solved issues', 'formcreator'),
-      'closed'     => __('Closed issues', 'formcreator'),
+      'all'        => __('All', 'formcreator'),
+      'incoming'   => __('New', 'formcreator'),
+      'assigned'   => __('Assigned', 'formcreator'),
+      'waiting'    => __('Waiting', 'formcreator'),
+      'validate'   => __('To validate', 'formcreator'),
+      'solved'     => __('Solved', 'formcreator'),
+      'closed'     => __('Closed', 'formcreator'),
       // Aggregaterd statuses
-      'old'        => __('Old issues', 'formcreator'), // Solved + closed
+      'old'        => __('Old', 'formcreator'), // Solved + closed
    ];
    foreach ($counters as $key => $label) {
       $cards['plugin_formcreator_' . $key . '_issues'] = [


### PR DESCRIPTION
Dashboard cards have too long labels, especially in french. Remove the common "Issues" word. 

### before
![image](https://user-images.githubusercontent.com/14139801/167594393-ffe43fe9-e7c8-4387-ac3f-f701f5fa7799.png)

### after
![image](https://user-images.githubusercontent.com/14139801/167594292-86da7f12-2989-464d-9914-44cc1592020b.png)
