### PR TITLE
Add hook before targets are generated

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1055,8 +1055,6 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
    }
 
    public function post_addItem() {
-      global $PLUGIN_HOOKS;
-
       // Save questions answers
       $formAnswerId = $this->getID();
       $formId = $this->input[PluginFormcreatorForm::getForeignKeyField()];
@@ -1083,16 +1081,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       $this->sendNotification();
       $formAnswer = clone $this;
       if ($this->input['status'] == self::STATUS_ACCEPTED) {
-
-         foreach ($PLUGIN_HOOKS['formcreator_before_generate_target'] ?? [] as $plugin => $callable) {
-            // Skip if invalid hook
-            if (!is_callable($callable)) {
-               trigger_error("formcreator_before_generate_target[$plugin]: not a callable", E_USER_WARNING);
-               continue;
-            }
-
-            call_user_func($callable, $this);
-         }
+         Plugin::doHookFunction('formcreator_before_generate_target', $this);
 
          if (!$this->generateTarget()) {
             Session::addMessageAfterRedirect(__('Cannot generate targets!', 'formcreator'), true, ERROR);

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1055,6 +1055,8 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
    }
 
    public function post_addItem() {
+      global $PLUGIN_HOOKS;
+
       // Save questions answers
       $formAnswerId = $this->getID();
       $formId = $this->input[PluginFormcreatorForm::getForeignKeyField()];
@@ -1081,6 +1083,17 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       $this->sendNotification();
       $formAnswer = clone $this;
       if ($this->input['status'] == self::STATUS_ACCEPTED) {
+
+         foreach ($PLUGIN_HOOKS['formcreator_before_generate_target'] ?? [] as $plugin => $callable) {
+            // Skip if invalid hook
+            if (!is_callable($callable)) {
+               trigger_error("formcreator_before_generate_target[$plugin]: not a callable", E_USER_WARNING);
+               continue;
+            }
+
+            call_user_func($callable, $this);
+         }
+
          if (!$this->generateTarget()) {
             Session::addMessageAfterRedirect(__('Cannot generate targets!', 'formcreator'), true, ERROR);
 


### PR DESCRIPTION
I need a hook that run after a PluginFormAnswer was saved to base **and** before the form targets were generated.
GLPI core only offers the `item_add` hook, which will run after both of this events.

It isn't really a bugfix but integrating it into the 2.13 branch will make things easier for the related internal ref (advanced forms).
