### PR TITLE
Allow plugins to add extra tags to forms

### DIFF
--- a/inc/abstracttarget.class.php
+++ b/inc/abstracttarget.class.php
@@ -197,6 +197,15 @@ abstract class PluginFormcreatorAbstractTarget extends CommonDBChild implements
          $template = str_replace('##FULLFORM##', $formAnswer->getFullForm($richText), $template);
       }
 
+      $extra_tags_values = Plugin::doHookFunction('formcreator_prepare_extra_tags', [
+         'formanswer' => $formAnswer,
+         'values' => [],
+         'richtext' => $richText,
+      ]);
+      foreach ($extra_tags_values['values'] as $tag => $value) {
+         $template = str_replace($tag, $value, $template);
+      }
+
       if ($richText) {
          $template = str_replace(['<p>', '</p>'], ['<div>', '</div>'], $template);
          $template = Sanitizer::sanitize($template);

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -2533,7 +2533,13 @@ PluginFormcreatorTranslatableInterface
    }
 
    public function showTagsList() {
+      $extra_tags = Plugin::doHookFunction('formcreator_add_extra_tags', [
+         'tags' => [],
+         'form' => $this,
+      ]);
+
       TemplateRenderer::getInstance()->display('@formcreator/components/form/form_taglist.html.twig', [
+         'extra_tags' => $extra_tags['tags'],
          'item'   => $this,
       ]);
 

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1223,7 +1223,14 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          $content = Sanitizer::sanitize($content);
       }
 
-      return $content;
+      $hook_data = Plugin::doHookFunction('formcreator_parse_extra_tags', [
+         'formanswer' => $this,
+         'content'    => $content,
+         'target'     => $target,
+         'richtext'   => $richText,
+      ]);
+
+      return $hook_data['content'];
    }
 
    /**

--- a/templates/components/form/form_taglist.html.twig
+++ b/templates/components/form/form_taglist.html.twig
@@ -49,6 +49,14 @@
                         <td><strong>##FULLFORM##</strong></td>
                         <td>-</td>
                     </tr>
+                     {% for tag in extra_tags %}
+                        <tr>
+                            <td colspan="2"><strong>{{ tag.question }}</strong></td>
+                            <td>{{ tag.title }}</td>
+                            <td><strong>{{ tag.answer }}</strong></td>
+                            <td>{{ tag.section }}</td>
+                        </tr>
+                    {% endfor %}
                     {% set sections = call('PluginFormcreatorQuestion::getQuestionsFromFormBySection', [item]) %}
                     {% for sectionName, questions in sections %}
                         {% for questionId, questionName in questions %}


### PR DESCRIPTION
Add three new hooks to handle extra tags.

1\) `formcreator_add_extra_tags`

Allow to display extra tags in the "List of available tags" part.

Example: 
![image](https://user-images.githubusercontent.com/42734840/168768180-3f4cff39-3a75-4e85-85fb-746b8dbc42ea.png)

2\) `formcreator_prepare_extra_tags`

Just like the native "##FULLFORM##" tag, some extra tags may need to be "prepared".

3\) `formcreator_parse_extra_tags`

Parse extra tags values.

Using these 3 hooks, we may do something like loading multiple forms results (advanced form workflow) like this:

![image](https://user-images.githubusercontent.com/42734840/168769665-78cc08dd-0744-4869-8160-319aac689cb0.png)


