### PR TITLE
Show plugin menus in service catalog

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -798,12 +798,11 @@ JAVASCRIPT;
          }
 
          // Add plugins menus
-          $plugin_menus = $menus['plugins']['content'] ?? [];
-          foreach ($plugin_menus as $menu_name => $menu_data) {
-             $menu_data['default'] = $menu_data['page'] ?? '#';
-             $newMenu[$menu_name] = $menu_data;
-          }
-
+         $plugin_menus = $menus['plugins']['content'] ?? [];
+         foreach ($plugin_menus as $menu_name => $menu_data) {
+            $menu_data['default'] = $menu_data['page'] ?? '#';
+            $newMenu[$menu_name] = $menu_data;
+       }
 
          return $newMenu;
       }

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -796,6 +796,15 @@ JAVASCRIPT;
                'icon'    => 'fa-fw ti ti-rss',
             ];
          }
+
+         // Add plugins menus
+          $plugin_menus = $menus['plugins']['content'] ?? [];
+          foreach ($plugin_menus as $menu_name => $menu_data) {
+             $menu_data['default'] = $menu_data['page'] ?? '#';
+             $newMenu[$menu_name] = $menu_data;
+          }
+
+
          return $newMenu;
       }
 


### PR DESCRIPTION
### Changes description

Adds menu items added by plugins (Under Plugins menu) to the menu in the service catalog.
Some plugins like FusionInventory add a menu option for the simplified interface that currently wouldn't show when using the service catalog.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Ref !23387