### PR TITLE
Do not give access to tickets list

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -423,6 +423,10 @@ function plugin_formcreator_redirect() {
       return;
    }
 
+   if (strpos($_SERVER['REQUEST_URI'], "front/ticket.php") !== false) {
+      Html::redirect(PluginFormcreatorIssue::getSearchURL());
+   }
+
    if (strpos($_SERVER['REQUEST_URI'], "front/ticket.form.php") !== false) {
       if (!isset($_POST['update'])) {
          $decodedUrl = [];


### PR DESCRIPTION
In Formcreator 2.13 direct acess to tickets list is no longer useful. If a user types the URL to this page the plugin should redirect to the issues list page.