### PR TITLE
Run sync issues only once when if several upgrade steps require it

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -78,6 +78,9 @@ class PluginFormcreatorInstall {
       '2.12.5' => '2.13',
    ];
 
+
+   protected bool $resyncIssues = false;
+
    /**
     * Install the plugin
     * @param Migration $migration
@@ -171,6 +174,11 @@ class PluginFormcreatorInstall {
       $this->createMiniDashboard();
       Config::setConfigurationValues('formcreator', ['schema_version' => PLUGIN_FORMCREATOR_SCHEMA_VERSION]);
 
+      if ($this->resyncIssues) {
+         // An upgrade step requires a resync of the issues
+         $task = new CronTask();
+         PluginFormcreatorIssue::cronSyncIssues($task);
+      }
       return true;
    }
 
@@ -192,6 +200,7 @@ class PluginFormcreatorInstall {
          $upgradeStep = new $updateClass();
          $upgradeStep->upgrade($this->migration);
          $this->migration->executeMigration();
+         $this->resyncIssues = $this->resyncIssues || $upgradeStep->isResyncIssuesRequiresd();
       }
    }
 

--- a/install/upgrade_to_2.10.2.php
+++ b/install/upgrade_to_2.10.2.php
@@ -36,107 +36,10 @@ class PluginFormcreatorUpgradeTo2_10_2 {
     * @param Migration $migration
     */
    public function upgrade(Migration $migration) {
-      global $DB;
-
       $this->migration = $migration;
-
-      // Versioin 2.10.2 contains fixes on counters requiring repopulation of issues table
-      $table = 'glpi_plugin_formcreator_issues';
-      $DB->query("TRUNCATE `$table`");
-      $this->syncIssues(new CronTask());
    }
 
-   /**
-    * This is a copy of PluginFormcreatorIssue::cronSyncIssues as it is in 2.10.2
-    *
-    * @param CronTask $task
-    * @return void
-    */
-   public function syncIssues(CronTask $task) {
-      global $DB;
-
-      $task->log("Sync issues from forms answers and tickets");
-      $volume = 0;
-
-      // Request which merges tickets and formanswers
-      // 1 ticket not linked to a formanswer => 1 issue which is the ticket sub_itemtype
-      // 1 form_answer not linked to a ticket => 1 issue which is the formanswer sub_itemtype
-      // 1 ticket linked to 1 form_answer => 1 issue which is the ticket sub_itemtype
-      // several tickets linked to the same form_answer => 1 issue which is the form_answer sub_itemtype
-      $query = "SELECT DISTINCT
-                  NULL                            AS `id`,
-                  `f`.`name`                      AS `name`,
-                  CONCAT('f_',`fanswer`.`id`)     AS `display_id`,
-                  `fanswer`.`id`                  AS `original_id`,
-                  'PluginFormcreatorFormAnswer'   AS `sub_itemtype`,
-                  `fanswer`.`status`              AS `status`,
-                  `fanswer`.`request_date`        AS `date_creation`,
-                  `fanswer`.`request_date`        AS `date_mod`,
-                  `fanswer`.`entities_id`         AS `entities_id`,
-                  `fanswer`.`is_recursive`        AS `is_recursive`,
-                  `fanswer`.`requester_id`        AS `requester_id`,
-                  `fanswer`.`users_id_validator`  AS `users_id_validator`,
-                  `fanswer`.`groups_id_validator` AS `groups_id_validator`,
-                  `fanswer`.`comment`             AS `comment`
-               FROM `glpi_plugin_formcreator_formanswers` AS `fanswer`
-               LEFT JOIN `glpi_plugin_formcreator_forms` AS `f`
-                  ON`f`.`id` = `fanswer`.`plugin_formcreator_forms_id`
-               LEFT JOIN `glpi_items_tickets` AS `itic`
-                  ON `itic`.`items_id` = `fanswer`.`id`
-                  AND `itic`.`itemtype` = 'PluginFormcreatorFormAnswer'
-               GROUP BY `original_id`
-               HAVING COUNT(`itic`.`tickets_id`) != 1
-               UNION
-               SELECT DISTINCT
-                  NULL                          AS `id`,
-                  `tic`.`name`                  AS `name`,
-                  CONCAT('t_',`tic`.`id`)       AS `display_id`,
-                  `tic`.`id`                    AS `original_id`,
-                  'Ticket'                      AS `sub_itemtype`,
-                  if(`tv`.`status` IS NULL,`tic`.`status`, if(`tv`.`status` = 2, 101, if(`tv`.`status` = 3, `tic`.`status`, 102))) AS `status`,
-                  `tic`.`date`                  AS `date_creation`,
-                  `tic`.`date_mod`              AS `date_mod`,
-                  `tic`.`entities_id`           AS `entities_id`,
-                  0                             AS `is_recursive`,
-                  `tu`.`users_id`               AS `requester_id`,
-                  `tv`.`users_id_validate`      AS `users_id_validator`,
-                  0                             AS `groups_id_validator`,
-                  `tic`.`content`               AS `comment`
-               FROM `glpi_tickets` AS `tic`
-               LEFT JOIN `glpi_items_tickets` AS `itic`
-                  ON `itic`.`tickets_id` = `tic`.`id`
-                  AND `itic`.`itemtype` = 'PluginFormcreatorFormAnswer'
-               LEFT JOIN (
-                  SELECT DISTINCT `users_id`, `tickets_id`
-                  FROM `glpi_tickets_users` AS `tu`
-                  WHERE `tu`.`type` = '"  . CommonITILActor::REQUESTER . "'
-                  ORDER BY `id` ASC
-               ) AS `tu` ON (`tic`.`id` = `tu`.`tickets_id`)
-               LEFT JOIN `glpi_ticketvalidations` as `tv`
-                  ON (`tic`.`id` = `tv`.`tickets_id`)
-               WHERE `tic`.`is_deleted` = 0
-               GROUP BY `original_id`
-               HAVING COUNT(`itic`.`items_id`) <= 1";
-
-      $countQuery = "SELECT COUNT(*) AS `cpt` FROM ($query) AS `issues`";
-      $result = $DB->query($countQuery);
-      if ($result !== false) {
-         if (version_compare(GLPI_VERSION, '9.5') < 0) {
-            $fa = 'fetch_assoc';
-         } else {
-            $fa = 'fetchAssoc';
-         }
-         $count = $DB->$fa($result);
-         $table = 'glpi_plugin_formcreator_issues';
-         if (countElementsInTable($table) != $count['cpt']) {
-            if ($DB->query("TRUNCATE `$table`")) {
-               $DB->query("INSERT INTO `$table` SELECT * FROM ($query) as `dt`");
-               $volume = 1;
-            }
-         }
-      }
-      $task->setVolume($volume);
-
-      return 1;
+   public function isResyncIssuesRequiresd() {
+      return true;
    }
 }

--- a/install/upgrade_to_2.10.php
+++ b/install/upgrade_to_2.10.php
@@ -72,4 +72,8 @@ class PluginFormcreatorUpgradeTo2_10 {
       $migration->addKey($table, 'users_id_validator');
       $migration->addKey($table, 'groups_id_validator');
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.11.3.php
+++ b/install/upgrade_to_2.11.3.php
@@ -48,4 +48,8 @@ class PluginFormcreatorUpgradeTo2_11_3 {
       $migration->changeField($table, 'date_creation', 'date_creation', 'datetime'. ' NOT NULL');
       $migration->changeField($table, 'date_mod', 'date_mod', 'datetime'. ' NOT NULL');
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.11.php
+++ b/install/upgrade_to_2.11.php
@@ -317,5 +317,8 @@ class PluginFormcreatorUpgradeTo2_11 {
          'state' => '0'
       ]);
    }
-}
 
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
+}

--- a/install/upgrade_to_2.12.1.php
+++ b/install/upgrade_to_2.12.1.php
@@ -76,4 +76,8 @@ class PluginFormcreatorUpgradeTo2_12_1 {
       $table = 'glpi_plugin_formcreator_questions';
       $this->migration->changeField($table, 'description', 'description', 'MEDIUMTEXT');
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.12.5.php
+++ b/install/upgrade_to_2.12.5.php
@@ -48,14 +48,10 @@ class PluginFormcreatorUpgradeTo2_12_5 {
       $table = 'glpi_plugin_formcreator_issues';
       if (!$DB->fieldExists($table, 'users_id_recipient')) {
          $this->migration->addField($table, 'users_id_recipient', 'integer', ['after' => 'comment']);
-
-         // Update issues
-         $this->migration->migrationOneTable($table);
-         if (PLUGIN_FORMCREATOR_SCHEMA_VERSION == '2.12') {
-            // sync only if this version is 2.12.5. If the table changes later, this will fail
-            $DB->query("TRUNCATE `$table`");
-            PluginFormcreatorIssue::syncIssues();
-         }
       }
+   }
+
+   public function isResyncIssuesRequiresd() {
+      return true;
    }
 }

--- a/install/upgrade_to_2.12.php
+++ b/install/upgrade_to_2.12.php
@@ -147,4 +147,8 @@ class PluginFormcreatorUpgradeTo2_12 {
       $this->migration->dropKey($table, 'original_id_sub_itemtype');
       $this->migration->addKey($table, ['itemtype', 'items_id'], 'item');
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.13.php
+++ b/install/upgrade_to_2.13.php
@@ -316,4 +316,8 @@ class PluginFormcreatorUpgradeTo2_13 {
 
       $this->migration->addPostQuery("UPDATE `glpi_plugin_formcreator_entityconfigs` SET `default_form_list_mode`=0 WHERE `entities_id`=0");
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.6.1.php
+++ b/install/upgrade_to_2.6.1.php
@@ -64,4 +64,8 @@ class PluginFormcreatorUpgradeTo2_6_1 {
          $DB->query("UPDATE `glpi_plugin_formcreator_questions` SET `name`='$name' WHERE `id` = '$id'");
       }
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.6.3.php
+++ b/install/upgrade_to_2.6.3.php
@@ -85,4 +85,8 @@ class PluginFormcreatorUpgradeTo2_6_3 {
          $DB->query("UPDATE `$table` SET `name`='$name' WHERE `id` = '$id'");
       }
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.6.php
+++ b/install/upgrade_to_2.6.php
@@ -206,4 +206,8 @@ class PluginFormcreatorUpgradeTo2_6 {
 
       $migration->executeMigration();
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.7.php
+++ b/install/upgrade_to_2.7.php
@@ -308,4 +308,8 @@ class PluginFormcreatorUpgradeTo2_7 {
          $DB->query("UPDATE `glpi_plugin_formcreator_forms` SET `name` = '$name', `description` = '$description', `content` = '$content' WHERE `id` = '$id'");
       }
    }
+
+   public function isResyncIssuesRequiresd() {
+      return true;
+   }
 }

--- a/install/upgrade_to_2.8.1.php
+++ b/install/upgrade_to_2.8.1.php
@@ -36,4 +36,8 @@ class PluginFormcreatorUpgradeTo2_8_1 {
       $table = 'glpi_plugin_formcreator_issues';
       $migration->changeField($table, 'name', 'name', 'string', ['after' => 'id', 'value' => '']);
    }
+
+   public function isResyncIssuesRequiresd() {
+      return true;
+   }
 }

--- a/install/upgrade_to_2.8.php
+++ b/install/upgrade_to_2.8.php
@@ -61,4 +61,8 @@ class PluginFormcreatorUpgradeTo2_8 {
          'name' => 'Form Creator',
       ]);
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }

--- a/install/upgrade_to_2.9.php
+++ b/install/upgrade_to_2.9.php
@@ -374,4 +374,8 @@ class PluginFormcreatorUpgradeTo2_9 {
          );
       }
    }
+
+   public function isResyncIssuesRequiresd() {
+      return false;
+   }
 }


### PR DESCRIPTION
If an upgrade occurs from very old version synchronizing issues may happen several times and this is a long task. 

This PR ensures the synchronization occurs only when needed, and once. This also solve the risk to run the synchronization with a not up to date table (less columns than expected in the query).