### PR TITLE
Do no show refused tickets in the "New" category

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -873,7 +873,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
    }
 
    static function getNewStatusArray() {
-      return [Ticket::INCOMING, PluginFormcreatorFormAnswer::STATUS_WAITING, PluginFormcreatorFormAnswer::STATUS_ACCEPTED, PluginFormcreatorFormAnswer::STATUS_REFUSED];
+      return [Ticket::INCOMING, PluginFormcreatorFormAnswer::STATUS_WAITING, PluginFormcreatorFormAnswer::STATUS_ACCEPTED];
    }
 
    static function getProcessStatusArray() {


### PR DESCRIPTION
Internal ref: https://support.teclib.com/front/ticket.form.php?id=24344

Refused forms shouldn't be shown when searching for "New" tickets

![image](https://user-images.githubusercontent.com/42734840/176195269-5eafb9de-32b4-4308-a78a-c46de701a73b.png)
