### PR TITLE
consistency to show refused issues with a similar search as acepted issues

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -235,6 +235,10 @@ function plugin_formcreator_addWhere($link, $nott, $itemtype, $ID, $val, $search
                   $tocheck = array_keys($item->getAllStatusArray());
                   break;
 
+               case Ticket::SOLVED:
+                  $tocheck = $item->getSolvedStatusArray();
+                  break;
+
                case Ticket::INCOMING:
                   $tocheck = $item->getNewStatusArray();
                   break;

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -868,7 +868,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
    }
 
    static function getSolvedStatusArray() {
-      return Ticket::getSolvedStatusArray();
+      return [...Ticket::getSolvedStatusArray(), PluginFormcreatorFormAnswer::STATUS_REFUSED];
    }
 
    static function getNewStatusArray() {
@@ -942,10 +942,6 @@ class PluginFormcreatorIssue extends CommonDBTM {
             'searchtype' => 'equals',
             'value'      => Ticket::SOLVED, // see Ticket::getAllStatusArray()
          ],
-         ['field' => 4,
-            'searchtype' => 'equals',
-            'value'      => PluginFormcreatorFormAnswer::STATUS_REFUSED,
-            'link'       => 'OR']
          ]],
       ],
       'reset'    => 'reset'];


### PR DESCRIPTION
consistency with #2860 

The above PR allows to search accepted issues with closed issues , with a single search criteria

![image](https://user-images.githubusercontent.com/14139801/176677726-3446c178-82da-4029-a376-d9681bff269c.png)

Then, refused issues shouls be visible by searching for solved issues.