### PR TITLE
test: compatibility with PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         php-versions: [7.4]
         env:
-          - { GLPI_BRANCH: master }
+          - { GLPI_BRANCH: 10.0/bugfixes }
     services:
       db:
         image: mariadb:10.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
       matrix:
         php-versions: [7.4]
         env:
-          - { GLPI_BRANCH: 9.5/bugfixes }
+          - { GLPI_BRANCH: 10.0/bugfixes }
     name: "Code quality"
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: [7.4]
+        php-versions: [7.4, 8.1]
         env:
           - { GLPI_BRANCH: 10.0/bugfixes }
     services:
@@ -110,7 +110,7 @@ jobs:
   style:
     strategy:
       matrix:
-        php-versions: [7.4]
+        php-versions: [8.1]
         env:
           - { GLPI_BRANCH: 10.0/bugfixes }
     name: "Code quality"

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -2452,9 +2452,7 @@ PluginFormcreatorTranslatableInterface
       }
 
       if (count($availableLanguages) < 1) {
-         // Empty array does let \Locale::lookup return the default language
-         // @see https://www.php.net/manual/fr/locale.lookup.php#115459
-         $availableLanguages = [false];
+         return $defaultLanguage;
       }
       return \Locale::lookup($availableLanguages, $_SESSION['glpilanguage'], false, $defaultLanguage);
    }

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/ActorField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/ActorField.php
@@ -55,7 +55,7 @@ class ActorField extends CommonTestCase {
                'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => [''],
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -68,7 +68,7 @@ class ActorField extends CommonTestCase {
                'show_rule'       =>\PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => [''],
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -81,7 +81,7 @@ class ActorField extends CommonTestCase {
                'show_rule'       =>\PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => ['email@something.com'],
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -94,7 +94,7 @@ class ActorField extends CommonTestCase {
                'show_rule'       =>\PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => ['glpi', 'email@something.com'],
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
       ];
 

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/DateField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/DateField.php
@@ -47,7 +47,7 @@ class DateField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => null,
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'question'           => $this->getQuestion([
@@ -61,7 +61,7 @@ class DateField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => '2018-08-16',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'question'           => $this->getQuestion([
@@ -75,7 +75,7 @@ class DateField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => null,
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'question'           => $this->getQuestion([
@@ -89,7 +89,7 @@ class DateField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => '2018-08-16',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
       ];
 

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/DatetimeField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/DatetimeField.php
@@ -47,7 +47,7 @@ class DatetimeField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => null,
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'question'           => $this->getQuestion([
@@ -61,7 +61,7 @@ class DatetimeField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => '2018-08-16 08:12:34',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'question'           => $this->getQuestion([
@@ -75,7 +75,7 @@ class DatetimeField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => null,
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'question'           => $this->getQuestion([
@@ -89,7 +89,7 @@ class DatetimeField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => '2018-08-16 08:12:34',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
       ];
 

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/DropdownField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/DropdownField.php
@@ -159,7 +159,7 @@ class DropdownField extends CommonTestCase {
                'show_tree_depth' => '5',
                'show_tree_root' => '0',
             ],
-            'expected' => true,
+            'expectedValidity' => true,
          ],
          [
             'question' => $this->getQuestion([
@@ -174,7 +174,7 @@ class DropdownField extends CommonTestCase {
                'show_tree_depth' => '5',
                'show_tree_root' => '0',
             ],
-            'expected' => false,
+            'expectedValidity' => false,
          ],
          [
             'question' => $this->getQuestion([
@@ -190,7 +190,7 @@ class DropdownField extends CommonTestCase {
                'show_tree_depth' => '5',
                'show_tree_root' => '0',
             ],
-            'expected' => false,
+            'expectedValidity' => false,
          ],
          [
             'question' => $this->getQuestion([
@@ -206,7 +206,7 @@ class DropdownField extends CommonTestCase {
                'show_tree_depth' => '5',
                'show_tree_root' => '0',
             ],
-            'expected' => true,
+            'expectedValidity' => true,
          ],
       ];
    }
@@ -214,11 +214,11 @@ class DropdownField extends CommonTestCase {
    /**
     * @dataProvider providerIsValid
     */
-   public function testIsValid($question, $input, $expected) {
+   public function testIsValid($question, $input, $expectedValidity) {
       $instance = $this->newTestedInstance($question);
       $instance->deserializeValue($question->fields['default_values']);
       $output = $instance->isValid();
-      $this->boolean($output)->isEqualTo($expected);
+      $this->boolean($output)->isEqualTo($expectedValidity);
    }
 
    public function providerGetValueForTargetText() {

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/EmailField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/EmailField.php
@@ -50,19 +50,19 @@ class EmailField extends CommonTestCase {
    public function providerParseAnswerValue() {
       return [
          [
-            'input' => 42,
+            'value' => 42,
             'expected' => '',
          ],
          [
-            'input' => '',
+            'value' => '',
             'expected' => '',
          ],
          [
-            'input' => 'foo@bar.baz',
+            'value' => 'foo@bar.baz',
             'expected' => 'foo@bar.baz',
          ],
          [
-            'input' => 'not an email',
+            'value' => 'not an email',
             'expected' => 'not an email',
          ],
       ];
@@ -71,11 +71,11 @@ class EmailField extends CommonTestCase {
    /**
     * @dataProvider providerParseAnswerValue
     */
-   public function testParseAnswerValue($input, $expected) {
+   public function testParseAnswerValue($value, $expected) {
       $question = $this->getQuestion();
       $instance = $this->newTestedInstance($question);
       $output = $instance->parseAnswerValues([
-         'formcreator_field_' . $question->getID() => $input
+         'formcreator_field_' . $question->getID() => $value
       ]);
       $output = $instance->serializeValue();
       $this->string($output)->isEqualTo($expected);

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/FloatField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/FloatField.php
@@ -63,7 +63,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true,
+            'expectedValidity' => true,
             'expectedMessage' => '',
          ],
          'integer value' => [
@@ -87,7 +87,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '2',
-            'expectedIsValid' => true,
+            'expectedValidity' => true,
             'expectedMessage' => '',
          ],
          'too low value' => [
@@ -110,7 +110,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '2',
-            'expectedIsValid' => false,
+            'expectedValidity' => false,
             'expectedMessage' => 'The following number must be greater than 3: question',
           ],
          'too high value' => [
@@ -134,7 +134,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '5',
-            'expectedIsValid' => false,
+            'expectedValidity' => false,
             'expectedMessage' => 'The following number must be lower than 4: question',
          ],
          'float iin range' => [
@@ -158,7 +158,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '3.141592',
-            'expectedIsValid' => true,
+            'expectedValidity' => true,
             'expectedMessage' => '',
          ],
          'empty value and regex with backslash' => [
@@ -182,7 +182,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true,
+            'expectedValidity' => true,
             'expectedMessage' => '',
          ],
          'value not matching regex' => [
@@ -206,7 +206,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => false,
+            'expectedValidity' => false,
             'expectedMessage' => 'Specific format does not match: question',
          ],
          'value matching regex' => [
@@ -230,7 +230,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true,
+            'expectedValidity' => true,
             'expectedMessage' => '',
          ],
          [
@@ -254,7 +254,7 @@ class FloatField extends CommonTestCase {
                ]
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true,
+            'expectedValidity' => true,
             'expectedMessage' => '',
          ],
       ];

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/GlpiSelectField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/GlpiSelectField.php
@@ -80,7 +80,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => (new \DbUtils())->getUserName($user->getID()),
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -95,7 +95,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'fields'          => [
@@ -110,7 +110,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => (new \DbUtils())->getUserName($user->getID()),
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -125,7 +125,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
 
          [
@@ -141,7 +141,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => $computer->getName(),
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -156,7 +156,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => '&nbsp;',
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'fields'          => [
@@ -171,7 +171,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => $computer->getName(),
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -186,7 +186,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => '&nbsp;',
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'fields'          => [
@@ -201,7 +201,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => (new \Entity())->getFromDB(0),
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -216,7 +216,7 @@ class GlpiselectField extends CommonTestCase {
                '_parameters'     => [],
             ],
             'expectedValue'   => '&nbsp;',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
       ];
 

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/IntegerField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/IntegerField.php
@@ -63,7 +63,7 @@ class IntegerField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -86,7 +86,7 @@ class IntegerField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '2',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -108,7 +108,7 @@ class IntegerField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '2',
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'fields'          => [
@@ -131,7 +131,7 @@ class IntegerField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '5',
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'fields'          => [
@@ -154,7 +154,7 @@ class IntegerField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '3.4',
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'fields'          => [
@@ -177,7 +177,7 @@ class IntegerField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '4',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -199,9 +199,8 @@ class IntegerField extends CommonTestCase {
                   ]
                ],
             ],
-            'data'            => null,
             'expectedValue'   => '4',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -223,9 +222,8 @@ class IntegerField extends CommonTestCase {
                   ]
                ],
             ],
-            'data'            => null,
             'expectedValue'   => '4',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
       ];
 

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/MultiselectField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/MultiselectField.php
@@ -55,7 +55,7 @@ class MultiSelectField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => [],
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -77,7 +77,7 @@ class MultiSelectField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => ['3'],
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -99,7 +99,7 @@ class MultiSelectField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => ['3'],
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'fields'          => [
@@ -121,7 +121,7 @@ class MultiSelectField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => ['3', '4'],
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -143,7 +143,7 @@ class MultiSelectField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => ['3', '4', '2', '1', '6'],
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
       ];
 

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/SelectField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/SelectField.php
@@ -48,7 +48,7 @@ class SelectField extends CommonTestCase {
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => '1',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -62,7 +62,7 @@ class SelectField extends CommonTestCase {
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -76,7 +76,7 @@ class SelectField extends CommonTestCase {
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => '3',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -90,7 +90,7 @@ class SelectField extends CommonTestCase {
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => '1',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'fields'          => [
@@ -104,7 +104,7 @@ class SelectField extends CommonTestCase {
                   'show_rule'       => \PluginFormcreatorCondition::SHOW_RULE_ALWAYS
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
       ];
 

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/TextField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/TextField.php
@@ -58,7 +58,7 @@ class TextField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '1',
-            'expectedIsValid' => true,
+            'expectedValidity' => true,
             'expectedMessage' => '',
          ],
          [
@@ -84,7 +84,7 @@ class TextField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '1',
-            'expectedIsValid' => false,
+            'expectedValidity' => false,
             'expectedMessage' => 'The text is too short (minimum 5 characters): question',
          ],
          [
@@ -110,7 +110,7 @@ class TextField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '1',
-            'expectedIsValid' => false,
+            'expectedValidity' => false,
             'expectedMessage' => 'The text is too short (minimum 6 characters): question',
          ],
          [
@@ -136,7 +136,7 @@ class TextField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '1',
-            'expectedIsValid' => false,
+            'expectedValidity' => false,
             'expectedMessage' => 'The text is too long (maximum 8 characters): question',
          ],
          [
@@ -162,7 +162,7 @@ class TextField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '1',
-            'expectedIsValid' => false,
+            'expectedValidity' => false,
             'expectedMessage' => 'The text is too long (maximum 8 characters): question',
          ],
          'regex with escaped chars' => [
@@ -188,7 +188,7 @@ class TextField extends CommonTestCase {
                ],
             ],
             'expectedValue'   => '',
-            'expectedIsValid' => true,
+            'expectedValidity' => true,
             'expectedMessage' => '',
          ],
       ];

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/TimeField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/TimeField.php
@@ -47,7 +47,7 @@ class TimeField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => null,
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'question'           => $this->getQuestion([
@@ -61,7 +61,7 @@ class TimeField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => '08:12',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
          [
             'question'           => $this->getQuestion([
@@ -75,7 +75,7 @@ class TimeField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => null,
-            'expectedIsValid' => false
+            'expectedValidity' => false
          ],
          [
             'question'           => $this->getQuestion([
@@ -89,7 +89,7 @@ class TimeField extends CommonTestCase {
                '_parameters'     => [],
             ]),
             'expectedValue'   => '08:12:34',
-            'expectedIsValid' => true
+            'expectedValidity' => true
          ],
       ];
 

--- a/tests/3-unit/PluginFormcreatorAnswer.php
+++ b/tests/3-unit/PluginFormcreatorAnswer.php
@@ -44,15 +44,15 @@ class PluginFormcreatorAnswer extends CommonTestCase {
    public function providerGetTypeName() {
       return [
          [
-            'input' => 0,
+            'number' => 0,
             'expected' => 'Answers',
          ],
          [
-            'input' => 1,
+            'number' => 1,
             'expected' => 'Answer',
          ],
          [
-            'input' => 2,
+            'number' => 2,
             'expected' => 'Answers',
          ],
       ];

--- a/tests/3-unit/PluginFormcreatorForm.php
+++ b/tests/3-unit/PluginFormcreatorForm.php
@@ -201,7 +201,7 @@ class PluginFormcreatorForm extends CommonTestCase {
                'content'      => '',
             ],
             'expected' => false, // An empty name should be rejected
-            'message'  => 'The name cannot be empty!',
+            'expectedMessage'  => 'The name cannot be empty!',
          ],
          'html entities conversion' => [
             'input' => [
@@ -210,7 +210,7 @@ class PluginFormcreatorForm extends CommonTestCase {
                'content'      => '&lt;p&gt;être ou ne pas être&lt;/p&gt;',
             ],
             'expected' => true,
-            'message' => '',
+            'expectedMessage' => '',
          ],
          'quote escaping' => [
             'input' => [
@@ -219,7 +219,7 @@ class PluginFormcreatorForm extends CommonTestCase {
                'content'      => '&lt;p&gt;test d\\\'apostrophe&lt;/p&gt;',
             ],
             'expected' => true,
-            'message' => '',
+            'expectedMessage' => '',
          ],
       ];
    }
@@ -251,7 +251,7 @@ class PluginFormcreatorForm extends CommonTestCase {
             'name' => '',
          ],
          'expected' => false,
-         'message'  => 'The name cannot be empty!',
+         'expectedMessage'  => 'The name cannot be empty!',
       ];
 
       return $data;
@@ -633,7 +633,7 @@ class PluginFormcreatorForm extends CommonTestCase {
          [
             'item'         => $section,
             'expectedType' => \PluginFormcreatorForm::getType(),
-            'expectedId'   => true,
+            'expected'     => true,
          ],
          [
             'item'         => new \PluginFormcreatorSection(),
@@ -641,12 +641,12 @@ class PluginFormcreatorForm extends CommonTestCase {
             'expected'     => false,
          ],
          [
-            'question'     => $question,
+            'item'         => $question,
             'expectedType' => \PluginFormcreatorForm::getType(),
             'expected'     => true,
          ],
          [
-            'question'     => new \PluginFormcreatorQuestion(),
+            'item'         => new \PluginFormcreatorQuestion(),
             'expectedType' => \PluginFormcreatorForm::getType(),
             'expected'     => false,
          ],
@@ -657,7 +657,7 @@ class PluginFormcreatorForm extends CommonTestCase {
    /**
     * @dataProvider providerGetByItem
     */
-   public function testgetByItem($item, $expectedType, $expected) {
+   public function testGetByItem($item, $expectedType, $expected) {
       $output = \PluginFormcreatorForm::getByItem($item);
       if ($expected === false) {
          $this->variable($output)->isNull();

--- a/tests/3-unit/PluginFormcreatorFormAnswer.php
+++ b/tests/3-unit/PluginFormcreatorFormAnswer.php
@@ -68,7 +68,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
          'form FK required' => [
             'input' => [],
             'expected' => false,
-            'message' => '',
+            'expectedMessage' => '',
          ],
          'tags parsing in name' => [
             'input' => [
@@ -88,7 +88,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
                'request_date'                            => $_SESSION['glpi_currenttime'],
                'comment'                                 => '',
             ],
-            'message' => '',
+            'expectedMessage' => '',
          ],
       ];
 
@@ -124,7 +124,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
             'request_date'                            => $_SESSION['glpi_currenttime'],
             'comment'                                 => '',
          ],
-         'message' => '',
+         'expectedMessage' => '',
       ];
 
       return $data;
@@ -197,7 +197,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
       return [
          // fullForm matches all question and section names
          [
-            'answer' => [
+            'answers' => [
                \PluginFormcreatorForm::getForeignKeyField() => $form->getID(),
                'formcreator_field_' . $question1->getID() => 'yes',
                'formcreator_field_' . $question2->getID() => 'yes',
@@ -213,7 +213,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
          ],
          // fullForm matches only visible section names
          [
-            'answer' => [
+            'answers' => [
                \PluginFormcreatorForm::getForeignKeyField() => $form->getID(),
                'formcreator_field_' . $question1->getID() => 'no',
                'formcreator_field_' . $question2->getID() => 'yes',
@@ -229,7 +229,7 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
          ],
          // fullForm matches only visible question names
          [
-            'answer' => [
+            'answers' => [
                \PluginFormcreatorForm::getForeignKeyField() => $form->getID(),
                'formcreator_field_' . $question1->getID() => 'yes',
                'formcreator_field_' . $question2->getID() => 'no',

--- a/tests/3-unit/PluginFormcreatorQuestion.php
+++ b/tests/3-unit/PluginFormcreatorQuestion.php
@@ -94,15 +94,15 @@ class PluginFormcreatorQuestion extends CommonTestCase {
    public function providerGetTypeName() {
       return [
          [
-            'input' => 0,
+            'number' => 0,
             'expected' => 'Questions',
          ],
          [
-            'input' => 1,
+            'number' => 1,
             'expected' => 'Question',
          ],
          [
-            'input' => 2,
+            'number' => 2,
             'expected' => 'Questions',
          ],
       ];
@@ -503,7 +503,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
       $data = [
          'actor' => [
             'questionType' => 'actor',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '8c647f55ac463429f736aea1ad64d318' => "actors question",
@@ -524,7 +524,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'checkboxes' => [
             'questionType' => 'checkboxes',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  'de1ece2a98dacb86a2b65334373ccb99' => "checkboxes question",
@@ -551,7 +551,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'date' => [
             'questionType' => 'date',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  'e121a8d9e19bf923a648d6bfb33094d8' => "date question",
@@ -572,7 +572,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'datetime' =>[
             'questionType' => 'datetime',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '7d3246feb9616461eee152642ad9f1fb' => "datetime question",
@@ -593,7 +593,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'description' => [
             'questionType' => 'description',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '824d1cc309c56586a33b52858cbc146b' => "description question",
@@ -614,7 +614,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'dropdown' => [
             'questionType' => 'dropdown',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '8347ce048fc3fe8b954dbc6cd9c4b716' => "dropdown question",
@@ -635,7 +635,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'email' => [
             'questionType' => 'email',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '895472a7be51fe6b1b9591a150fb55d8' => "email question",
@@ -656,7 +656,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'file' => [
             'questionType' => 'file',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '75c4f52e98ebd4a57410d882780353db' => "file question",
@@ -677,7 +677,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'float' => [
             'questionType' => 'float',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '037cad549bb834c2fab44fe14480f9a9' => "float question",
@@ -698,7 +698,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'glpiselect' => [
             'questionType' => 'glpiselect',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '97ee07194ba5af1c81eb5a9b22141241' => "GLPI object question",
@@ -719,7 +719,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'hidden' => [
             'questionType' => 'hidden',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '74b8be9aff59bf5ddd149248d6156baa' => "hidden question",
@@ -742,7 +742,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'hostname' => [
             'questionType' => 'hostname',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '0550a71495224d60dfcd00826345f0fa' => "hostname question",
@@ -763,7 +763,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'integer' => [
             'questionType' => 'integer',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  'b5c09bbe5587577a8c86ada678664877' => "integer question",
@@ -784,7 +784,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'ip' => [
             'questionType' => 'ip',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  'd767bdc805e010bfd2302c2516501ffb' => "IP address question",
@@ -805,7 +805,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'ldapselect' => [
             'questionType' => 'ldapselect',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '5b3ebb576a3977eaa267f0769bdd8e98' => "LDAP question",
@@ -826,7 +826,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'multiselect' => [
             'questionType' => 'multiselect',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '35226e073fabdcce01c547c5bce62d14' => "multiselect question",
@@ -853,7 +853,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'radios' => [
             'questionType' => 'radios',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '58e2a2355ba7ac135d42f558591d6a6a' => "radio question",
@@ -880,7 +880,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'requesttype' => [
             'questionType' => 'requesttype',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '2637b4d11281dffbaa2e340561347ebc' => "request type question",
@@ -901,7 +901,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'select' => [
             'questionType' => 'select',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '212afc3240debecf859880ea9ab4fc2e' => "select question",
@@ -928,7 +928,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          // 'tag' => [
          //    'questionType' => 'tag',
-         //    'expeected' => [
+         //    'expected' => [
          //       'itemlink' =>
          //       [
          //         'e121a8d9e19bf923a648d6bfb33094d8' => "tag question",
@@ -949,7 +949,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          // ],
          'textarea' => [
             'questionType' => 'textarea',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  'b99b0833f1dab41a14eb421fa2ce690d' => "textarea question",
@@ -972,7 +972,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'text' => [
             'questionType' => 'text',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '6fd6eacf3005974a7489a199ed7b45ee' => "text question",
@@ -993,7 +993,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'time' => [
             'questionType' => 'time',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  'e3a0dfbc9d24603beddcbd1388808a7a' => "time question",
@@ -1014,7 +1014,7 @@ class PluginFormcreatorQuestion extends CommonTestCase {
          ],
          'urgency' => [
             'questionType' => 'urgency',
-            'expeected' => [
+            'expected' => [
                'itemlink' =>
                [
                  '49dce550d75300e99052ed4e8006b65a' => "urgency question",

--- a/tests/3-unit/PluginFormcreatorTargetChange.php
+++ b/tests/3-unit/PluginFormcreatorTargetChange.php
@@ -47,15 +47,15 @@ class PluginFormcreatorTargetChange extends CommonTestCase {
    public function providerGetTypeName() {
       return [
          [
-            'input' => 0,
+            'number' => 0,
             'expected' => 'Target changes',
          ],
          [
-            'input' => 1,
+            'number' => 1,
             'expected' => 'Target change',
          ],
          [
-            'input' => 2,
+            'number' => 2,
             'expected' => 'Target changes',
          ],
       ];

--- a/tests/3-unit/PluginFormcreatorTargetProblem.php
+++ b/tests/3-unit/PluginFormcreatorTargetProblem.php
@@ -48,15 +48,15 @@ class PluginFormcreatorTargetProblem extends CommonTestCase {
    public function providerGetTypeName() {
       return [
          [
-            'input' => 0,
+            'number' => 0,
             'expected' => 'Target problems',
          ],
          [
-            'input' => 1,
+            'number' => 1,
             'expected' => 'Target problem',
          ],
          [
-            'input' => 2,
+            'number' => 2,
             'expected' => 'Target problems',
          ],
       ];

--- a/tests/3-unit/PluginFormcreatorTargetTicket.php
+++ b/tests/3-unit/PluginFormcreatorTargetTicket.php
@@ -54,15 +54,15 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
    public function providerGetTypeName() {
       return [
          [
-            'input' => 0,
+            'number' => 0,
             'expected' => 'Target tickets',
          ],
          [
-            'input' => 1,
+            'number' => 1,
             'expected' => 'Target ticket',
          ],
          [
-            'input' => 2,
+            'number' => 2,
             'expected' => 'Target tickets',
          ],
       ];
@@ -498,8 +498,8 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
       ]);
       return [
          [
-            'instance'   => $targetTicket1,
-            'formanswerid' => (new \PluginFormcreatorFormAnswer())->add([
+            'originalInstance'   => $targetTicket1,
+            'formAnswerId' => (new \PluginFormcreatorFormAnswer())->add([
                \PluginFormcreatorForm::getForeignKeyField() => $form1->getID(),
                'name' => $form1->fields['name'],
                'requester_id' => 2, // glpi user id
@@ -510,8 +510,8 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
             'expected'   => \Ticket::INCIDENT_TYPE,
          ],
          [
-            'instance'   => $targetTicket1,
-            'formanswerid' => (new \PluginFormcreatorFormAnswer())->add([
+            'originalInstance'   => $targetTicket1,
+            'formAnswerId' => (new \PluginFormcreatorFormAnswer())->add([
                \PluginFormcreatorForm::getForeignKeyField() => $form1->getID(),
                'name' => $form1->fields['name'],
                'requester_id' => 2, // glpi user id
@@ -522,8 +522,8 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
             'expected'   => \Ticket::INCIDENT_TYPE,
          ],
          [
-            'instance'   => $targetTicket2,
-            'formanswerid' => (new \PluginFormcreatorFormAnswer())->add([
+            'originalInstance'   => $targetTicket2,
+            'formAnswerId' => (new \PluginFormcreatorFormAnswer())->add([
                \PluginFormcreatorForm::getForeignKeyField() => $form2->getID(),
                'name' => $form2->fields['name'],
                'requester_id' => 2, // glpi user id
@@ -534,8 +534,8 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
             'expected'   => \Ticket::DEMAND_TYPE,
          ],
          [
-            'instance'   => $targetTicket2,
-            'formanswerid' => (new \PluginFormcreatorFormAnswer())->add([
+            'originalInstance'   => $targetTicket2,
+            'formAnswerId' => (new \PluginFormcreatorFormAnswer())->add([
                \PluginFormcreatorForm::getForeignKeyField() => $form2->getID(),
                'name' => $form2->fields['name'],
                'requester_id' => 2, // glpi user id
@@ -609,7 +609,7 @@ class PluginFormcreatorTargetTicket extends CommonTestCase {
       return [
          [
             'template' => '##FULLFORM##',
-            'form_answer' => $formAnswer,
+            'formAnswer' => $formAnswer,
             'expected' => [
                0 => 'Form data' . $eolSimple
                   . '=================' . $eolSimple

--- a/tests/3-unit/PluginFormcreatorTarget_Actor.php
+++ b/tests/3-unit/PluginFormcreatorTarget_Actor.php
@@ -63,15 +63,15 @@ class PluginFormcreatorTarget_Actor extends CommonTestCase {
    public function providerGetTypeName() {
       return [
          [
-            'input' => 0,
+            'number' => 0,
             'expected' => 'Target actors',
          ],
          [
-            'input' => 1,
+            'number' => 1,
             'expected' => 'Target actor',
          ],
          [
-            'input' => 2,
+            'number' => 2,
             'expected' => 'Target actors',
          ],
       ];

--- a/tests/script-functions.sh
+++ b/tests/script-functions.sh
@@ -20,16 +20,16 @@ init_databases() {
 install_glpi() {
    echo Installing GLPI
    rm -rf ../glpi
-   # git clone --depth=35 $GLPI_SOURCE -b $GLPI_BRANCH ../glpi
-   # cd ../glpi
-   # composer install --no-dev --no-interaction
-   # php bin/console dependencies install composer-options=--no-dev
-   # php bin/console locales:compile
-   # php bin/console glpi:build:compile_scss
-   # php bin/console glpi:system:check_requirements
-   # rm .atoum.php
-   curl $GLPI_PACKAGE_URL --output /tmp/glpi.tar.gz
-   tar xf /tmp/glpi.tar.gz --directory ../
+   git clone --depth=35 $GLPI_SOURCE -b $GLPI_BRANCH ../glpi
+   cd ../glpi
+   composer install --no-dev --no-interaction
+   php bin/console dependencies install composer-options=--no-dev
+   php bin/console locales:compile
+   php bin/console glpi:build:compile_scss
+   php bin/console glpi:system:check_requirements
+   rm .atoum.php
+   # curl $GLPI_PACKAGE_URL --output /tmp/glpi.tar.gz
+   # tar xf /tmp/glpi.tar.gz --directory ../
    cd ../glpi
    mkdir -p tests/files/_cache
    cp -r ../$PLUGINNAME plugins/$PLUGINNAME


### PR DESCRIPTION
fix tests to run with PHP 8

many data providers having keys for parameters are interpreted as name for named parameters in method calls, feature of PHP 8.

Any difference between a key and an argument name triggers an axception.