### PR TITLE
Use_notification is not a bool

### DIFF
--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -645,12 +645,12 @@ PluginFormcreatorTranslatableInterface
       if ($actorKey === false) {
          // Add the actor
          $actorType[]                           = $userId;
-         $actorTypeNotif['use_notification'][]  = ($notify == true);
+         $actorTypeNotif['use_notification'][]  = $notify;
          $actorTypeNotif['alternative_email'][] = $alternativeEmail;
       } else {
          // New actor settings takes precedence
          $actorType[$actorKey]                           = $userId;
-         $actorTypeNotif['use_notification'][$actorKey]  = ($notify == true);
+         $actorTypeNotif['use_notification'][$actorKey]  = $notify;
          $actorTypeNotif['alternative_email'][$actorKey] = $alternativeEmail;
       }
 


### PR DESCRIPTION
When notifications are disabled for an actor, GLPI fails to add this actor to the target ITIL object (ticket, change, problem)

fix #2869 