### PR TITLE
Prevent useless DB queries on plugins state checks

### DIFF
--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -1030,8 +1030,7 @@ PluginFormcreatorTranslatableInterface
    protected function showPluginTagsSettings($rand) {
       global $DB;
 
-      $plugin = new Plugin();
-      if ($plugin->isInstalled('tag') && $plugin->isActivated('tag')) {
+      if (Plugin::isPluginActive('tag')) {
          echo '<tr>';
          echo '<td width="15%">' . __('Ticket tags', 'formcreator') . '</td>';
          echo '<td width="25%">';
@@ -1639,8 +1638,7 @@ SCRIPT;
       global $DB;
 
       // Add tag if presents
-      $plugin = new Plugin();
-      if (!$plugin->isActivated('tag')) {
+      if (!Plugin::isPluginActive('tag')) {
          return;
       }
 

--- a/inc/field/fieldsfield.class.php
+++ b/inc/field/fieldsfield.class.php
@@ -72,7 +72,7 @@ class FieldsField extends PluginFormcreatorAbstractField
    }
 
    public function isPrerequisites(): bool {
-      return (new Plugin())->isActivated('fields');
+      return Plugin::isPluginActive('fields');
    }
 
    public static function getFieldsFromBlock($block_id): array {
@@ -149,7 +149,7 @@ class FieldsField extends PluginFormcreatorAbstractField
    }
 
    public function showForm(array $options): void {
-      if (!\Plugin::isPluginActive('fields')) {
+      if (!Plugin::isPluginActive('fields')) {
          $options['error'] = __('Warning: Additional Fields plugin is disabled or missing', 'formcreator');
          $template = '@formcreator/field/undefinedfield.html.twig';
          TemplateRenderer::getInstance()->display($template, [
@@ -177,7 +177,7 @@ class FieldsField extends PluginFormcreatorAbstractField
 
    public function getRenderedHtml($domain, $canEdit = true): string {
       // Plugin field not available
-      if (!(new Plugin())->isActivated('fields')) {
+      if (!Plugin::isPluginActive('fields')) {
          return '';
       }
 

--- a/inc/field/tagfield.class.php
+++ b/inc/field/tagfield.class.php
@@ -33,6 +33,7 @@
 namespace GlpiPlugin\Formcreator\Field;
 
 use Dropdown;
+use Plugin;
 use PluginTagTag;
 use Session;
 use GlpiPlugin\Formcreator\Exception\ComparisonException;
@@ -46,7 +47,7 @@ class TagField extends DropdownField
    }
 
    public function showForm(array $options): void {
-      if (!\Plugin::isPluginActive('tag')) {
+      if (!Plugin::isPluginActive('tag')) {
          $options['error'] = __('Warning: Tag plugin is disabled or missing', 'formcreator');
          $template = '@formcreator/field/undefinedfield.html.twig';
          TemplateRenderer::getInstance()->display($template, [

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -1323,10 +1323,10 @@ PluginFormcreatorTranslatableInterface
             Profile::class            => Profile::getTypeName(2)
          ],
       ];
-      if ((new Plugin())->isActivated('appliances')) {
+      if (Plugin::isPluginActive('appliances')) {
          $optgroup[__("Assets")][PluginAppliancesAppliance::class] = PluginAppliancesAppliance::getTypeName(2) . ' (' . _n('Plugin', 'Plugins', 1) . ')';
       }
-      if ((new Plugin())->isActivated('databases')) {
+      if (Plugin::isPluginActive('databases')) {
          $optgroup[__("Assets")][PluginDatabasesDatabase::class] = PluginDatabasesDatabase::getTypeName(2) . ' (' . _n('Plugin', 'Plugins', 1) . ')';
       }
 

--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -105,7 +105,7 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
                2 => __('Actors', 'formcreator'),
                3 => __('Condition', 'formcreator'),
             ];
-            // if ((new Plugin)->isActivated('fields')) {
+            // if (Plugin::isPluginActive('fields')) {
             //    $tab[4] = __('Fields plugin', 'formcreator');
             // }
             return $tab;
@@ -584,8 +584,7 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
             }
          }
 
-         $plugin = new Plugin();
-         if ($plugin->isInstalled('tag') && $plugin->isActivated('tag')) {
+         if (Plugin::isPluginActive('tag')) {
             if (isset($input['tag_questions'])) {
                $input['tag_questions'] = (!empty($input['_tag_questions']))
                                           ? implode(',', $input['_tag_questions'])

--- a/inc/targetproblem.class.php
+++ b/inc/targetproblem.class.php
@@ -309,8 +309,7 @@ class PluginFormcreatorTargetProblem extends PluginFormcreatorAbstractItilTarget
             }
          }
 
-         $plugin = new Plugin();
-         if ($plugin->isInstalled('tag') && $plugin->isActivated('tag')) {
+         if (Plugin::isPluginActive('tag')) {
             $input['tag_questions'] = (!empty($input['_tag_questions']))
                                        ? implode(',', $input['_tag_questions'])
                                        : '';
@@ -581,7 +580,7 @@ class PluginFormcreatorTargetProblem extends PluginFormcreatorAbstractItilTarget
                2 => __('Actors', 'formcreator'),
                3 => __('Condition', 'formcreator'),
             ];
-            // if ((new Plugin)->isActivated('fields')) {
+            // if (Plugin::isPluginActive('fields')) {
             //    $tab[4] = __('Fields plugin', 'formcreator');
             // }
             return $tab;

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -135,7 +135,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
                2 => __('Actors', 'formcreator'),
                3 => __('Condition', 'formcreator'),
             ];
-            // if ((new Plugin)->isActivated('fields')) {
+            // if (Plugin::isPluginActive('fields')) {
             //    $tab[4] = __('Fields plugin', 'formcreator');
             // }
             return $tab;
@@ -669,8 +669,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
             }
          }
 
-         $plugin = new Plugin();
-         if ($plugin->isActivated('tag')) {
+         if (Plugin::isPluginActive('tag')) {
             if (isset($input['tag_questions'])) {
                $input['tag_questions'] = (!empty($input['_tag_questions']))
                                           ? implode(',', $input['_tag_questions'])


### PR DESCRIPTION
### Changes description

Calling `Plugin::isInstalled()` prior to `Plugin::isPluginActive()`/`Plugin::isActivated()` is useless, as an active plugin is de facto installed. Thus, combining these checks on plugins that are not activated will generate 2 queries, instead of 1 if check is done only on active state.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] ~~Tests for the changes have been added~~ (should not be required)
- [ ] ~~Docs have been added/updated~~ (no impact on docs)

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A