### PR TITLE
Show title in navigation header

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -41,6 +41,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
    public $dohistory  = true;
    public $usenotepad = true;
    public $usenotepadrights = true;
+   protected static $showTitleInNavigationHeader = true;
 
    /**
     * Generated targets after creation of a form answer
@@ -522,10 +523,12 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       $editMode = !isset($options['edit']) ? false : ($options['edit'] != '0');
 
       // form title
-      echo "<h1 class='form-title'>";
-      echo $this->fields['name'] . "&nbsp;";
-      echo '<i class="pointer print_button fas fa-print" title="' . __("Print this form", 'formcreator') . '" onclick="window.print();"></i>';
-      echo '</h1>';
+      if (version_compare(GLPI_VERSION, '10.0.3') < 0) {
+         echo "<h1 class='form-title'>";
+         echo $this->fields['name'] . "&nbsp;";
+         echo '<i class="pointer print_button fas fa-print" title="' . __("Print this form", 'formcreator') . '" onclick="window.print();"></i>';
+         echo '</h1>';
+      }
 
       // Form Header
       if (!empty($form->fields['content']) || !empty($form->getExtraHeader())) {

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -37,6 +37,8 @@ use Glpi\RichText\RichText;
 class PluginFormcreatorIssue extends CommonDBTM {
    static $rightname = 'ticket';
 
+   protected static $showTitleInNavigationHeader = true;
+
    public static function getTypeName($nb = 0) {
       return _n('Issue', 'Issues', $nb, 'formcreator');
    }


### PR DESCRIPTION
In service catalog, tickets are displayes without their title. To ensure consistent interface, formanswers and issues should also show their titme in the navigation header.

This PR relies on https://github.com/glpi-project/glpi/pull/12372

The screenshot below show a status dics or circle. This is no longer true because of a change in the PR for GLPI, allowing to not implement getStatusIcon()

### a ticket in service catalog
![image](https://user-images.githubusercontent.com/14139801/182621596-c4ed6cad-e4b7-41d2-b068-11e1f48397ce.png)

### a form answer in service catalog

![image](https://user-images.githubusercontent.com/14139801/182621745-fcede183-687b-43e4-85eb-45dee7ff498b.png)

