### PR TITLE
Bad form rendering in description question

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -379,6 +379,16 @@ form#plugin_formcreator_form {
    width: 48px;
 }
 
+.plugin_formcreator_description {
+   table {
+      border-width: 1px;
+
+      tr, td {
+         border-width: 1px;
+      }
+   }
+}
+
 /* CONDITIONS */
 
 .div_show_condition_field, .div_show_condition_operator,

--- a/inc/field/descriptionfield.class.php
+++ b/inc/field/descriptionfield.class.php
@@ -61,7 +61,8 @@ class DescriptionField extends PluginFormcreatorAbstractField
    public function getRenderedHtml($domain, $canEdit = true): string {
       $value = Toolbox::convertTagToImage(__($this->question->fields['description'], $domain), $this->getQuestion());
       $value = Sanitizer::unsanitize($value);
-      return nl2br(html_entity_decode($value));
+      $value = '<div class="plugin_formcreator_description">' . $value . '</div>';
+      return $value;
    }
 
    public function serializeValue(PluginFormcreatorFormAnswer $formanswer): string {


### PR DESCRIPTION
A table does not has the same CSS styles when rendered in a textarea and a tab of GLPI, causing some rendering diference.

fix #2919 