### PR TITLE
fix saving of tag question and specifics in target ticket/change

### DIFF
--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -581,12 +581,12 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
          }
 
          if (Plugin::isPluginActive('tag')) {
-            if (isset($input['tag_questions'])) {
+            if (isset($input['_tag_questions'])) {
                $input['tag_questions'] = (!empty($input['_tag_questions']))
                                           ? implode(',', $input['_tag_questions'])
                                           : '';
             }
-            if (isset($input['tag_specifics'])) {
+            if (isset($input['_tag_specifics'])) {
                $input['tag_specifics'] = (!empty($input['_tag_specifics']))
                                           ? implode(',', $input['_tag_specifics'])
                                           : '';

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -685,12 +685,12 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
 
          $plugin = new Plugin();
          if (Plugin::isPluginActive('tag')) {
-            if (isset($input['tag_questions'])) {
+            if (isset($input['_tag_questions'])) {
                $input['tag_questions'] = (!empty($input['_tag_questions']))
                                           ? implode(',', $input['_tag_questions'])
                                           : '';
             }
-            if (isset($input['tag_specifics'])) {
+            if (isset($input['_tag_specifics'])) {
                $input['tag_specifics'] = (!empty($input['_tag_specifics']))
                                        ? implode(',', $input['_tag_specifics'])
                                        : '';


### PR DESCRIPTION
### Changes description
Target ticket and change does not check proper input values on tag questions it should be `_tag_questions` and `_tag_specifics` 

https://github.com/pluginsGLPI/formcreator/blob/8413e0af88a473ef5cfc1b17c4c1d5585d9c2381/inc/targetticket.class.php#L687-L698

But looks like TargetProblem does not have this check implemented for some reason at all..

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References


Closes #N/A