### PR TITLE
fix(fields): add default value to prevent SQL error

### DIFF
--- a/src/Field/FieldsField.php
+++ b/src/Field/FieldsField.php
@@ -534,7 +534,15 @@ class FieldsField extends AbstractField
       $decodedValues = json_decode($this->question->fields['values'], JSON_OBJECT_AS_ARRAY);
       $field_name = $decodedValues['dropdown_fields_field'] ?? '';
       $dropdown_field_name = "plugin_fields_" . $decodedValues['dropdown_fields_field'] . "dropdowns_id" ?? '';
-      $value = '';
+
+      //computer default value
+      $field = new PluginFieldsField();
+      $field->getFromDbByCrit(['name' => $field_name]);
+      if ($field->fields['type'] == 'dropdown') {
+         $value = 0;
+      } else {
+         $value = '';
+      }
 
       if (isset($input[$field_name])) {
          $value = $input[$field_name];

--- a/src/Field/FieldsField.php
+++ b/src/Field/FieldsField.php
@@ -535,7 +535,7 @@ class FieldsField extends AbstractField
       $field_name = $decodedValues['dropdown_fields_field'] ?? '';
       $dropdown_field_name = "plugin_fields_" . $decodedValues['dropdown_fields_field'] . "dropdowns_id" ?? '';
 
-      //computer default value
+      // compute default value
       $field = new PluginFieldsField();
       $field->getFromDbByCrit(['name' => $field_name]);
       if ($field->fields['type'] == 'dropdown') {


### PR DESCRIPTION
### Changes description

Prevent SQL error when user does not select value from dropdown

```shell
[2022-09-06 10:11:13] glpisqllog.ERROR: DBmysql::query() in /home/dev/GLPI/10.0-bugfixes/src/DBmysql.php line 370
  *** MySQL query error:
  SQL: INSERT INTO `glpi_plugin_fields_ticketblocfcs` (`plugin_fields_containers_id`, `nativetextfield`, `plugin_fields_customdropdownfielddropdowns_id`, `plugin_fields_plannificationfielddropdowns_id`, `items_id`) VALUES ('5', '', '1', '', '28')
  Error: Incorrect integer value: '' for column 'plugin_fields_plannificationfielddropdowns_id' at row 1
  Backtrace :
  src/DBmysql.php:1312                               
  src/CommonDBTM.php:716                             DBmysql->insert()
  src/CommonDBTM.php:1316                            CommonDBTM->addToDB()
  plugins/fields/inc/container.class.php:1070        CommonDBTM->add()
  plugins/fields/inc/container.class.php:1414        PluginFieldsContainer->updateFieldsValues()
  src/Plugin.php:1476                                PluginFieldsContainer::postItemAdd()
  src/CommonDBTM.php:1363                            Plugin::doHook()
  plugins/formcreator/inc/targetticket.class.php:943 CommonDBTM->add()
  plugins/formcreator/inc/formanswer.class.php:869   PluginFormcreatorTargetTicket->save()
  plugins/formcreator/inc/formanswer.class.php:1091  PluginFormcreatorFormAnswer->generateTarget()
  src/CommonDBTM.php:1317                            PluginFormcreatorFormAnswer->post_addItem()
  plugins/formcreator/ajax/formanswer.php:58         CommonDBTM->add()
  {"user":"2@Desktop","mem_usage":"0.272\", 8.89Mio)"} 
```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A