### PR TITLE
Form_Profile: Fix PHPDOC / undefined session value

### DIFF
--- a/inc/form_profile.class.php
+++ b/inc/form_profile.class.php
@@ -44,7 +44,7 @@ class PluginFormcreatorForm_Profile extends PluginFormcreatorRestrictedFormCrite
     *
     * @param PluginFormcreatorForm $form The given form
     *
-    * @return bool True if there is a match, the user is whitelisted
+    * @return QuerySubQuery Whitelist criteria
     */
    public static function getListCriteriaSubQuery(): QuerySubQuery {
       // Allow only the current user active profile
@@ -52,7 +52,7 @@ class PluginFormcreatorForm_Profile extends PluginFormcreatorRestrictedFormCrite
          'SELECT' => static::$items_id_1,
          'FROM'   => self::getTable(),
          'WHERE'  => [
-            static::$items_id_2 => $_SESSION['glpiactiveprofile']['id']
+            static::$items_id_2 => ($_SESSION['glpiactiveprofile']['id'] ?? -1)
          ]
       ]);
    }


### PR DESCRIPTION
I've seen some error logs where `glpiactiveprofile` was not defined so I'm adding a fallback value.
Also fixed PHPDoc return type which was wrong.