### PR TITLE
Fix submit for forms without targets

### DIFF
--- a/ajax/formanswer.php
+++ b/ajax/formanswer.php
@@ -101,6 +101,7 @@ if ($_SESSION['glpibackcreated']) {
             'redirect' => $formAnswer->getFormURLWithID($formAnswer->getID()),
          ], JSON_FORCE_OBJECT
       );
+      die();
    }
    echo json_encode(
       [


### PR DESCRIPTION
### Changes description

Form without targets can't be submitted.

This caused by an invalid JSON response returned by `ajax/formanswer.php`, which contains two JSON bodies instead of one  :

![image](https://user-images.githubusercontent.com/42734840/192748854-ffadded2-bb69-4635-8dce-53617abed16c.png)

I suppose you forgot a `die` statement while reordering some code.
The expected correct response would contains only one redirect instruction, like this :

![image](https://user-images.githubusercontent.com/42734840/192749133-581e893a-d0ab-46dd-987c-518adefe54a9.png)

### References

!25027
