### PR TITLE
fix(form): submit once

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1381,6 +1381,10 @@ var plugin_formcreator = new function() {
       var form     = document.querySelector('form[data-itemtype]');
       var data     = new FormData(form);
       data.append('submit_formcreator', '');
+
+      // Disable submit button
+      $(form).find("button[type=submit]").prop('disabled', true);
+
       $.post({
          url: formcreatorRootDoc + '/ajax/formanswer.php',
          processData: false,
@@ -1404,6 +1408,9 @@ var plugin_formcreator = new function() {
             $('#messages_after_redirect').append(html);
             initMessagesAfterRedirectToasts();
          }
+      }).always(function (data) {
+         // Enable submit button
+         $(form).find("button[type=submit]").prop('disabled', false);
       });
    };
 


### PR DESCRIPTION
### Changes description

Prevent submitting a form multiple times (client side).

It is mostly done to prevent user errors (`e.g.` clicking the button multiple time while waiting for a response).
If you want to also prevent this on the server side to avoid potential abuse, feel free to suggest another PR ;)

### References

!25029