### PR TITLE
Fix FAQ list

### DIFF
--- a/inc/knowbase.class.php
+++ b/inc/knowbase.class.php
@@ -112,13 +112,12 @@ class PluginFormcreatorKnowbase {
                            KnowbaseItem_KnowbaseItemCategory::getTable() => KnowbaseItem::getForeignKeyField(),
                      ],
                   ],
-                  KnowbaseItemCategory::getTable() => [
-                     'FKEY' => [
-                        KnowbaseItem_KnowbaseItemCategory::getTable() => KnowbaseItemCategory::getForeignKeyField(),
-                        KnowbaseItemCategory::getTable() => 'id',
-                     ],
-                  ],
                ],
+               'WHERE'  => [
+                  KnowbaseItem_KnowbaseItemCategory::getTableField($cat_fk) => new QueryExpression(
+                      $DB->quoteName(KnowbaseItemCategory::getTableField('id'))
+                  ),
+              ]
             ],
             $kbitem_visibility_crit
          ),

--- a/inc/knowbase.class.php
+++ b/inc/knowbase.class.php
@@ -117,7 +117,7 @@ class PluginFormcreatorKnowbase {
                   KnowbaseItem_KnowbaseItemCategory::getTableField($cat_fk) => new QueryExpression(
                       $DB->quoteName(KnowbaseItemCategory::getTableField('id'))
                   ),
-              ]
+               ]
             ],
             $kbitem_visibility_crit
          ),

--- a/inc/knowbase.class.php
+++ b/inc/knowbase.class.php
@@ -105,7 +105,7 @@ class PluginFormcreatorKnowbase {
             [
                'SELECT' => ['COUNT DISTINCT' => KnowbaseItem::getTableField('id') . ' as cpt'],
                'FROM'   => KnowbaseItem::getTable(),
-               'LEFT JOIN' => [
+               'INNER JOIN' => [
                   KnowbaseItem_KnowbaseItemCategory::getTable() => [
                      'FKEY' => [
                            KnowbaseItem::getTable() => 'id',


### PR DESCRIPTION
### Changes description

After fixing the FAQ tree in https://github.com/glpi-project/glpi/pull/12922, I've noticed that it was still incorrect in formcreator.
If you have at least one visible article then all categories will be shown (even if these categories have no visible articles themselves).

This seems caused by an incorrect SQL query:

![image](https://user-images.githubusercontent.com/42734840/195286635-44b9d1ec-fbb8-47ae-97ea-95633edff5a6.png)

The column that is supposed to count the visible items in a category actually count the number of visible articles in the whole FAQ (as you can see in the `WHERE` clause - no restriction on current category).

If I compare the code to the one used in the core (there is two very similar functions - maybe formcreator should reuse the core code here instead of rewriting it).
Formcreator `inc.knowbase.class.php`:
![image](https://user-images.githubusercontent.com/42734840/195287608-0ccb0fea-c74c-48e5-8c4c-d060ffb0713d.png)

Core  `Src/Knowbase.php`:
![image](https://user-images.githubusercontent.com/42734840/195287880-afc81ff1-eee2-45f1-a2b5-b2f91df16740.png)

You can see that the core code have the correct `WHERE` clause that limit the scope to the current category, while the formcreator code seems to have an useless `JOIN` instead (that must be removed for the `WHERE` to work as it target the same table).

After copying the core code, the SQL request work as expected:

![image](https://user-images.githubusercontent.com/42734840/195288418-f28aac17-0372-43aa-aa50-bbf3c99b2733.png)

### References

!25026
https://github.com/glpi-project/glpi/pull/12922