### PR TITLE
Fix locales plural

### DIFF
--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -949,7 +949,7 @@ PluginFormcreatorTranslatableInterface
 
    protected function showCategorySettings($rand) {
       echo '<tr>';
-      echo '<td width="15%">' . __('Category', 'formcreator') . '</td>';
+      echo '<td width="15%">' . PluginFormcreatorCategory::getTypeName(1) . '</td>';
       echo '<td width="25%">';
       Dropdown::showFromArray(
          'category_rule',
@@ -963,8 +963,8 @@ PluginFormcreatorTranslatableInterface
       echo Html::scriptBlock("plugin_formcreator_changeCategory($rand);");
       echo '</td>';
       echo '<td width="15%">';
-      echo '<span id="category_specific_title" style="display: none">' . __('Category', 'formcreator') . '</span>';
-      echo '<span id="category_question_title" style="display: none">' . __('Question', 'formcreator') . '</span>';
+      echo '<span id="category_specific_title" style="display: none">' . PluginFormcreatorCategory::getTypeName(1) . '</span>';
+      echo '<span id="category_question_title" style="display: none">' . PluginFormcreatorQuestion::getTypeName(1) . '</span>';
       echo '</td>';
       echo '<td width="25%">';
       echo '<div id="category_question_value" style="display: none">';
@@ -1001,7 +1001,7 @@ PluginFormcreatorTranslatableInterface
       echo Html::scriptBlock("plugin_formcreator_changeUrgency($rand);");
       echo '</td>';
       echo '<td width="15%">';
-      echo '<span id="urgency_question_title" style="display: none">' . __('Question', 'formcreator') . '</span>';
+      echo '<span id="urgency_question_title" style="display: none">' . PluginFormcreatorQuestion::getTypeName(1) . '</span>';
       echo '<span id="urgency_specific_title" style="display: none">' . __('Urgency ', 'formcreator') . '</span>';
       echo '</td>';
       echo '<td width="25%">';
@@ -1210,7 +1210,7 @@ SCRIPT;
       echo Html::scriptBlock("plugin_formcreator_change_location($rand)");
       echo '</td>';
       echo '<td width="15%">';
-      echo '<span id="location_question_title" style="display: none">' . __('Question', 'formcreator') . '</span>';
+      echo '<span id="location_question_title" style="display: none">' . PluginFormcreatorQuestion::getTypeName(1) . '</span>';
       echo '<span id="location_specific_title" style="display: none">' . __('Location ', 'formcreator') . '</span>';
       echo '</td>';
       echo '<td width="25%">';
@@ -1291,7 +1291,7 @@ SCRIPT;
 
       $display = $validation_rule == self::COMMONITIL_VALIDATION_RULE_ANSWER_USER || $validation_rule == self::COMMONITIL_VALIDATION_RULE_ANSWER_GROUP ? "" : "display: none";
       echo "<span id='commonitil_validation_from_question_title' style='$display'>";
-      echo __('Question', 'formcreator');
+      echo PluginFormcreatorQuestion::getTypeName(1);
       echo "</span>";
 
       echo '</td>';

--- a/inc/entityconfig.class.php
+++ b/inc/entityconfig.class.php
@@ -472,7 +472,7 @@ class PluginFormcreatorEntityconfig extends CommonDBTM {
       $tab[] = [
          'id'              => '8',
          'table'           => self::getTable(),
-         'name'            => __('Header', 'formcreator'),
+         'name'            => _n('Header', 'Headers', 1, 'formcreator'),
          'field'           => 'header',
          'datatype'        => 'text',
          'nosearch'        => true,

--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -68,8 +68,8 @@ class DropdownField extends PluginFormcreatorAbstractField
 
    public function getEnumEntityRestriction() {
       return [
-         self::ENTITY_RESTRICT_USER =>  __('User', 'formcreator'),
-         self::ENTITY_RESTRICT_FORM =>  __('Form', 'formcreator'),
+         self::ENTITY_RESTRICT_USER =>  User::getTypeName(1),
+         self::ENTITY_RESTRICT_FORM =>  PluginFormcreatorForm::getTypeName(1),
          self::ENTITY_RESTRICT_BOTH =>  __('User and form', 'formcreator'),
       ];
    }

--- a/inc/filter/entityfilter.class.php
+++ b/inc/filter/entityfilter.class.php
@@ -41,8 +41,8 @@ class EntityFilter
 
    public static function getEnumEntityRestriction() {
       return [
-         self::ENTITY_RESTRICT_USER =>  __('User', 'formcreator'),
-         self::ENTITY_RESTRICT_FORM =>  __('Form', 'formcreator'),
+         self::ENTITY_RESTRICT_USER =>  User::getTypeName(1),
+         self::ENTITY_RESTRICT_FORM =>  PluginFormcreatorForm::getTypeName(1),
          self::ENTITY_RESTRICT_BOTH =>  __('User and form', 'formcreator'),
       ];
    }

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -171,7 +171,7 @@ PluginFormcreatorTranslatableInterface
          'id'                 => '5',
          'table'              => 'glpi_entities',
          'field'              => 'completename',
-         'name'               => __('Entity'),
+         'name'               => Entity::getTypeName(1),
          'datatype'           => 'dropdown',
          'massiveaction'      => false
       ];
@@ -227,7 +227,7 @@ PluginFormcreatorTranslatableInterface
          'id'                 => '10',
          'table'              => PluginFormcreatorCategory::getTable(),
          'field'              => 'name',
-         'name'               => __('Form category', 'formcreator'),
+         'name'               => PluginFormcreatorCategory::getTypeName(1),
          'datatype'           => 'dropdown',
          'massiveaction'      => true
       ];
@@ -500,7 +500,7 @@ PluginFormcreatorTranslatableInterface
       echo '<table class="tab_cadrehov">';
       echo '<tr>';
       echo '<th>'._n('Target', 'Targets', 2, 'formcreator').'</th>';
-      echo '<th>'.__('Type', 'formcreator').'</th>';
+      echo '<th>'._n('Type', 'Types', 1).'</th>';
       echo '<th class="right">'.__('Actions', 'formcreator').'</th>';
       echo '</tr>';
 

--- a/inc/form_language.class.php
+++ b/inc/form_language.class.php
@@ -345,7 +345,7 @@ implements PluginFormcreatorExportableInterface
       $header = '<tr>';
       $header.= '<th>' . Html::getCheckAllAsCheckbox("translation_list$rand", $rand) . '</th>';
       $header.= '<th>' . __('Original string', 'formcreator') . '</th>';
-      $header.= '<th>' . __('Translation', 'formcreator') . '</th>';
+      $header.= '<th>' . PluginFormcreatorTranslation::getTypeName(1) . '</th>';
       $header.= '</tr>';
       echo $header;
       echo '</thead>';

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -206,7 +206,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          'id'                 => '3',
          'table'              => 'glpi_plugin_formcreator_forms',
          'field'              => 'name',
-         'name'               => __('Form', 'formcreator'),
+         'name'               => PluginFormcreatorForm::getTypeName(1),
          'searchtype'         => 'contains',
          'datatype'           => 'string',
          'massiveaction'      => false
@@ -216,7 +216,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          'id'                 => '4',
          'table'              => 'glpi_users',
          'field'              => 'name',
-         'name'               => __('Requester'),
+         'name'               => _n('Requester', 'Requesters', 1),
          'datatype'           => 'itemlink',
          'massiveaction'      => false,
          'linkfield'          => 'requester_id'
@@ -615,7 +615,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
       //add requester info
       echo '<div class="form-group">';
-      echo '<label for="requester">' . __('Requester', 'formcreator') . '</label>';
+      echo '<label for="requester">' . _n('Requester', 'Requesters', 1) . '</label>';
       echo Dropdown::getDropdownName('glpi_users', $this->fields['requester_id']);
       echo '</div>';
 

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -540,7 +540,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
          'id'                 => '3',
          'table'              => self::getTable(),
          'field'              => 'itemtype',
-         'name'               => __('Type'),
+         'name'               => _n('Type', 'Types', 1),
          'searchtype'         => [
             '0'                  => 'equals',
             '1'                  => 'notequals'
@@ -583,7 +583,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
          'id'                 => '7',
          'table'              => 'glpi_entities',
          'field'              => 'completename',
-         'name'               => __('Entity'),
+         'name'               => _n('Entity', 'Entities', 1),
          'datatype'           => 'dropdown',
          'massiveaction'      => false
       ];
@@ -593,7 +593,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
          'table'              => 'glpi_users',
          'field'              => 'name',
          'linkfield'          => 'requester_id',
-         'name'               => __('Requester'),
+         'name'               => _n('Requester', 'Requesters', 1),
          'datatype'           => 'dropdown',
          'massiveaction'      => false
       ];

--- a/inc/notificationtargetformanswer.class.php
+++ b/inc/notificationtargetformanswer.class.php
@@ -76,8 +76,8 @@ class PluginFormcreatorNotificationTargetFormAnswer extends NotificationTarget
       $tags = [
          'formcreator.form_id'            => __('Form #', 'formcreator'),
          'formcreator.form_name'          => __('Form name', 'formcreator'),
-         'formcreator.form_requester'     => __('Requester', 'formcreator'),
-         'formcreator.form_validator'     => __('Validator', 'formcreator'),
+         'formcreator.form_requester'     => _n('Requester', 'Requesters', 1),
+         'formcreator.form_validator'     => _x('tag', 'Validator', 'formcreator'),
          'formcreator.form_creation_date' => __('Creation date'),
          'formcreator.form_full_answers'  => __('Full form answers', 'formcreator'),
          'formcreator.validation_comment' => __('Refused comment', 'formcreator'),

--- a/inc/target_actor.class.php
+++ b/inc/target_actor.class.php
@@ -80,7 +80,7 @@ class PluginFormcreatorTarget_Actor extends CommonDBChild implements PluginFormc
 
    static function getEnumRole() {
       return [
-         self::ACTOR_ROLE_REQUESTER => __('Requester'),
+         self::ACTOR_ROLE_REQUESTER => _n('Requester', 'Requesters', 1),
          self::ACTOR_ROLE_OBSERVER  => __('Observer'),
          self::ACTOR_ROLE_ASSIGNED  => __('Assigned to'),
          // TODO : support ACTOR_ROLE_SUPPLIER

--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -103,7 +103,7 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
             $tab = [
                1 => __('Properties', 'formcreator'),
                2 => __('Actors', 'formcreator'),
-               3 => __('Condition', 'formcreator'),
+               3 => PluginFormcreatorCondition::getTypeName(1),
             ];
             // if ((new Plugin)->isActivated('fields')) {
             //    $tab[4] = __('Fields plugin', 'formcreator');

--- a/inc/targetproblem.class.php
+++ b/inc/targetproblem.class.php
@@ -577,7 +577,7 @@ class PluginFormcreatorTargetProblem extends PluginFormcreatorAbstractItilTarget
             $tab = [
                1 => __('Properties', 'formcreator'),
                2 => __('Actors', 'formcreator'),
-               3 => __('Condition', 'formcreator'),
+               3 => PluginFormcreatorCondition::getTypeName(1),
             ];
             // if ((new Plugin)->isActivated('fields')) {
             //    $tab[4] = __('Fields plugin', 'formcreator');

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -132,7 +132,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
             $tab = [
                1 => __('Properties', 'formcreator'),
                2 => __('Actors', 'formcreator'),
-               3 => __('Condition', 'formcreator'),
+               3 => PluginFormcreatorCondition::getTypeName(1),
             ];
             // if ((new Plugin)->isActivated('fields')) {
             //    $tab[4] = __('Fields plugin', 'formcreator');
@@ -1103,7 +1103,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
       echo Html::scriptBlock("plugin_formcreator_changeRequestType($rand);");
       echo '</td>';
       echo '<td width="15%">';
-      echo '<span id="requesttype_question_title" style="display: none">' . __('Question', 'formcreator') . '</span>';
+      echo '<span id="requesttype_question_title" style="display: none">' . PluginFormcreatorQuestion::getTypeName(1) . '</span>';
       echo '<span id="requesttype_specific_title" style="display: none">' . __('Type ', 'formcreator') . '</span>';
       echo '</td>';
       echo '<td width="25%">';
@@ -1142,7 +1142,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
       echo Html::scriptBlock("plugin_formcreator_change_associate($rand)");
       echo '</td>';
       echo '<td width="15%">';
-      echo '<span id="plugin_formcreator_associate_question_title" style="display: none">' . __('Question', 'formcreator') . '</span>';
+      echo '<span id="plugin_formcreator_associate_question_title" style="display: none">' . PluginFormcreatorQuestion::getTypeName(1) . '</span>';
       echo '<span id="plugin_formcreator_associate_specific_title" style="display: none">' . __('Item ', 'formcreator') . '</span>';
       echo '</td>';
       echo '<td width="25%">';

--- a/locales/ca_ES.po
+++ b/locales/ca_ES.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
 "Last-Translator: Nuria Costa <nuria.costa@uvic.cat>, 2022\n"
 "Language-Team: Catalan (Spain) (https://www.transifex.com/teclib/teams/28042/ca_ES/)\n"
@@ -67,10 +67,9 @@ msgstr "Límit de profunditat del subtree"
 msgid "No limit"
 msgstr "Sense límit"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Formulari"
@@ -136,8 +135,8 @@ msgstr "Sol·licitud incorrecta eliminant un actor."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Creador de formularis"
 
@@ -147,12 +146,12 @@ msgstr "Creador de formularis"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Llista de formularis"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "S'ha guardat el formulari correctament!"
 
@@ -168,7 +167,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s afegeix la reserva %2$s per a l'element %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Categoria"
@@ -182,30 +180,25 @@ msgstr "Veure-ho tot"
 msgid "Please, describe your need here"
 msgstr "Si us plau, descriu què necessites aquí"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Textarea"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Un camp obligatori està buit:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "Expressió regular no vàlida"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Usuari"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Usuari i formulari"
 
@@ -241,162 +234,158 @@ msgstr ""
 "Per respectar el sistema d'entitats GLPI, cal seleccionar \"Formulari\". "
 "Altres configuracions trencaran les restriccions de l'entitat"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "S'ha superat el límit de mida LDAP"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP Select"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "Directori LDAP no defnint!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "Directori LDAP no trobat!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "El format específic no coincideix: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "El text és massa curt (mínim %d caràcters): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "El text és massa llarg (màxim %d caràcters): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Text"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Expressió regular"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Interval"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Validació addicional"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Radios"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "El camp Valor és obligatori"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Un camp obligatori està buit: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Això no és un enter: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "El número %s ha de ser més gran que %d"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "El número %s ha de ser més petit que %d"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Enter"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Sense definir"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "Adreça IP"
 msgstr[1] "Adreces IP"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgència"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Molt alta"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Alta"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Mitjana"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Baixa"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Alerta: el connector d'etiquetes està desactivat o falta"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Etiquetes"
 msgstr[1] "Etiquetes"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "Objecte GLPI"
 msgstr[1] "Objectes GLPI"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Hostname"
 msgstr[1] "Hostnames"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Temps"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "No és una adreça electrònica vàlida: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Email"
@@ -406,41 +395,41 @@ msgstr[1] "Emails"
 msgid "Select"
 msgstr "Select"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Data i hora"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Actor"
 msgstr[1] "Actors"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Valor invàlid: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "No s'ha trobat l'usuari o l'adreça electrònica no és corrrecte: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "No hi ha cap document adjunt"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Document adjunt"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Falta un fitxer necessari: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Arxiu"
 
@@ -448,95 +437,94 @@ msgstr "Arxiu"
 msgid "Multiselect"
 msgstr "Multiselect"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Alerta: el connector de camps addicionals està desactivat o falta"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Bloc"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Camps"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr " mostra"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "El tipus de camp '%1$s' encara no s'ha implementat!"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Alguns camps numèrics contenen valors no numèrics"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Alguns camps d'URL contenen enllaços no vàlids"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Camps addicionals"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Checkboxes"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "La següent pregunta necessita un mínim de %d respostes"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "La segünet pregunta no accepta més de %d respostes"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Interval mínim"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Interval màxim"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Tipus de petició"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Això no és un número: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Float"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Data"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Descripció"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "El camp Descripció hauria de tenir una descripció:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Camp ocult"
 msgstr[1] "Camps ocults"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Condició"
@@ -566,26 +554,26 @@ msgstr "Ocult llevat que"
 msgid "Displayed unless"
 msgstr "Mostra llevat que"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "No s'ha pogut afegir o actualitzar %1$s%2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "No es pot exportar un objecte buit: %s"
@@ -602,140 +590,130 @@ msgstr "Important"
 msgid "Import in progress"
 msgstr "Importació en curs"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Problema"
 msgstr[1] "Problemes"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr ""
 "Problema d'actualització de dades de tiquets i respostes del formulari"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "L'enquesta de satisfacció ha caducat"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Nom"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
 msgstr[0] "Tipus"
 msgstr[1] "Tipus"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Estat"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Data d'obertura"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Última actualització"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entitat"
 msgstr[1] "Entitats"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Sol·licitant"
 msgstr[1] "Sol·licitants"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Usuari que aprova la sol·licitud"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Comentari"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Qui aprova tiquets"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Tècnic/a"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Grup tècnic"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Grup que aprova la sol·licitud"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "No validat"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Rebutjat"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Tot"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Nou"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Assignat"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Esperant"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "Per validar"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Resolt"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Tancat"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Categoria del formulari"
@@ -753,19 +731,19 @@ msgstr "Com a fill de"
 msgid "The form as been saved"
 msgstr "S'ha guardat la sol·licitud"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "La sol·licitud ha de ser validada"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Sol·licitud denegada"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Sol·licitud acceptada"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Sol·licitud eliminada"
 
@@ -778,13 +756,11 @@ msgid "Form name"
 msgstr "Nom del formulari"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Validador"
-msgstr[1] "Validadors"
+msgstr "Validador"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Data de creació"
 
@@ -809,15 +785,15 @@ msgid "Author"
 msgstr "Autor"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Aprovador"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Autor del formulari"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Validador de la sol·licitud"
 
@@ -825,7 +801,7 @@ msgstr "Validador de la sol·licitud"
 msgid "Specific person"
 msgstr "Persona específica"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Persona d'una pregunta"
 
@@ -833,7 +809,7 @@ msgstr "Persona d'una pregunta"
 msgid "Specific group"
 msgstr "Grup específic"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Grup de la pregunta"
 
@@ -849,15 +825,15 @@ msgstr "Grup tècnic d'un objecte"
 msgid "Specific supplier"
 msgstr "Proveïdor específic"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Proveïdor d'una pregunta"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Actors de la pregunta"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Supervisor de l'autor del formulari"
 
@@ -865,7 +841,7 @@ msgstr "Supervisor de l'autor del formulari"
 msgid "Observer"
 msgstr "Observador"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Assignat a"
 
@@ -895,77 +871,86 @@ msgstr "No s'ha pogut trobar el grup: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "No s'ha pogut trobar el proveïdor: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Rebutjat"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Acceptat"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Resposta del formulari"
 msgstr[1] "Respostes del formulari"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Imprimeix el formulari"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Sol·licitud acceptada pel validador."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Sol·licitud guardada correctament."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Desa"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Es requereix si es va denegar"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Denega"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Edita respostes"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Cancel·la l'edició"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Acceptat"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Cal un comentari de denegació!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "No ets el validador d'aquestes respostes"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Dades de la sol·licitud"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "No es poden generar objectius!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "No hi ha conjunt de proves de turing"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Has fallat el test de Turing"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Cal que seleccionis un/a validador/a!"
 
@@ -977,15 +962,15 @@ msgstr "No pots eliminar aquest problema. Potser es té en compte."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "No s'ha pogut eliminar aquest problema. S'ha produït un error intern."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Obre un tiquet"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Els meus tiquets"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consultar feeds"
 
@@ -1017,15 +1002,15 @@ msgid_plural "Form languages"
 msgstr[0] "Idioma del formulari"
 msgstr[1] "Idiomes del formulari"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Traducció"
 msgstr[1] "Traduccions"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "No es pot deixar el nom en blanc!"
 
@@ -1037,7 +1022,7 @@ msgstr "L'idioma s'ha d'associar a un formulari!"
 msgid "Add a translation"
 msgstr "Afegeix una traducció"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Actualitza la traducció"
 
@@ -1058,7 +1043,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Vols eliminar els elements seleccionats?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Elimina"
 
@@ -1075,32 +1060,38 @@ msgstr "Afegeix un idioma nou"
 msgid "Language"
 msgstr "Idioma"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Cap"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Validador"
+msgstr[1] "Validadors"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Necessita validació?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "No"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Desa"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Validació"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Escull un validador"
 
@@ -1110,14 +1101,14 @@ msgid_plural "Target problems"
 msgstr[0] "Problema d'objectiu"
 msgstr[1] "Problemes de d'objectiu"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Propietats"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1126,29 +1117,29 @@ msgstr ""
 "No s'ha pogut afegir o actualizar %1$s %2$s: falta una pregunta i s'utilitza"
 " en un paràmetre de l'objectiu"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Actors"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Títol del problema"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Contingut"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Impacte"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Causa"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Símptoma"
 
@@ -1215,73 +1206,73 @@ msgstr "Alçada variable"
 msgid "Uniform height"
 msgstr "Alçada uniforme"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Mode Helpdesk"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Llista de formularis per defecte"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Ordre de classificació"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Base de coneixements"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Cerca"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Tauler de comptadors"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Missatge de capçalera"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Problema de cerca"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Disseny de mosaic"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
 msgstr[0] "Capçalera"
 msgstr[1] "Capçaleres"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Mostra el camp de cerca"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Mostra la capçalera"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Intervals de pregunta"
 msgstr[1] "Intervals de preguntes"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Interval mínim"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "Interval màxim"
 
@@ -1301,7 +1292,7 @@ msgstr "Accés restringit"
 msgid "Answers waiting for validation"
 msgstr "Respostes pendents de validació"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Importar formularis"
 
@@ -1364,7 +1355,7 @@ msgstr[1] "Objectius"
 msgid "Actions"
 msgstr "Accions"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Afegeix un objectiu"
 
@@ -1380,125 +1371,125 @@ msgstr "propietats"
 msgid "What are you looking for?"
 msgstr "Què vols buscar?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Els meus %1$d últims formularsi (sol·licitant)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Formulari no publicat"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Totes les meves sol·licituds (sol·licitant)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Els meus %1$d últims formularis (validador)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "No hi ha sol·licituds pendents de validació"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Totes les meves sol·licituds (validador)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "No es pot utilitzar un nom buit per a les respostes del formulari. Guardar "
 "el valor anterior."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "La pregunta %s no és compatible amb els formularis públics."
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Duplicat erroni"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Duplicada"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Publicació"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Sol·licitud duplicada: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Sol·licitud transferida: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Enrere"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Càrrega de fitxers JSON no permesa."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "Hauries de permetre fitxers JSON ara."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Crea"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Siusplau, contacta amb l'administrador del GLPI."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Enrere"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "La càrrega de fitxers JSON no està habilitada."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "Hauries d'habilitar els fitxers JSON ara."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Habilitat"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Envia"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Importació de formularis impossible, l'arxiu està buit"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Importació de formularis impossible, l'arxiu sembla corrupte"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr ""
 "Importació de formularis impossible, l'arxiu va ser generat amb una altra "
 "versió"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1506,62 +1497,62 @@ msgstr ""
 "El fitxer no especifica la versió de l'esquema. Probablement es va generar "
 "amb una versió anterior a la 2.10. Desistint."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "No s'ha pogut importar %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formularis importats correctament de %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr ""
 "El formulari %1$s ja existeix i es troba a una entitat no modificable."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "No tens permisos per actualitzar l'entitat %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "L'entitat %1$s es necessari pel formulari %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Error en la creació de documents tipus JSON."
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Document tipus JSON no trobat."
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Error en actualitzar el document tipus JSON."
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formularis sense categoria"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "No hi ha formulari disponible"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Afegeix"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Tipus d'objectiu no admès."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1607,11 +1598,8 @@ msgstr "El títol és obligatori"
 msgid "Failed to find %1$s %2$s"
 msgstr "No s'ha trobat %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Pregunta"
@@ -1646,48 +1634,48 @@ msgstr "Aquest tipus de pregunta requereix paràmetres"
 msgid "A parameter is missing for this question type"
 msgstr "Falta un paràmetre per a aquest tipus de pregunta"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Nivells de servei"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Actius"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Assistència"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Gestió"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Eines"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notes"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "Canal RSS"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administració"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Connector"
@@ -1811,118 +1799,118 @@ msgid_plural "Composite ticket relations"
 msgstr[0] "Relació de tiquets vinculats"
 msgstr[1] "Relacions de tiquets vinculats"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Objectiu del tiquet"
 msgstr[1] "Objectius del tiquets"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Actiu específic"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Igual que la resposta de la pregunta"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Última resposta vàlida"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "Font de la plantilla o per defecte de l'usuari o GLPI per defecte"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Per defecte o d'una plantilla"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Tipus específic"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Títol del tiquet"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Afegeix un missatge de validació al primer seguiment"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Afegeix un camp"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Gestionar camps"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "No hi ha camp gestionat"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Enllaça amb un altre tiquet"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Un altre destí d'aquest formulari"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Tiquet existent"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Tiquet de resposta a una pregunta"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Elimina definitivament"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Tipus d'enllaç no vàlid"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Tipus d'element enllaçat no vàlid"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "L'element enllaçat no existeix"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "No s'ha pogut enllaçar l'element"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "La teva sol·licitud ha estat acceptada pel validador"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Origen de la sol·licitud"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Tipus"
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Elements associats"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Element"
 
@@ -1942,206 +1930,237 @@ msgstr "Formulari no trobat"
 msgid "Failed to add the translation."
 msgstr "No s'ha pogut afegir la traducció."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Etiquetes de les preguntes"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Etiquetes específiques"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Etiquetes de preguntes i etiquetes específiques"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Etiquetes de preguntes o etiquetes específiques"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "és igual la resposta a la pregunta"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "calculada a partir de la data de creació del tiquet"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "calculada a partir de la data de resposta"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "SLA des de la plantilla o cap"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "SLA específic"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "OLA des de la plantilla o cap"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "OLA específic"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgència de plantilla o mitjà"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Urgència específica"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Categoria de plantilla o cap"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Categoria específica"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Ubicació de la plantilla o cap"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Ubicació específica"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Sense validació"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Usuari o grup específic"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Usuari procedent de la resposta d'una pregunta"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Grup procedent de la resposta d'una pregunta"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Temps de resoldre"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minut"
 msgstr[1] "Minuts"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hora"
 msgstr[1] "Hores"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Dia"
 msgstr[1] "Dies"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Mes"
 msgstr[1] "Mesos"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Pregunta (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgència"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Etiquetes del tiquet"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Tags"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Ubicació"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Ubicació"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "Cal que posis una descripció!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Observador"
 msgstr[1] "Observadors"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Cancel·lar"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Seguiment per correu electrònic"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Usuari"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Grup"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Proveïdor"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Sí"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Grup de l'objecte"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Grup tècnic de l'objecte"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"Actualitzeu les taules a innoDB; executeu php bin/console "
-"glpi:migration:myisam_to_innodb"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "S'ha creat el formulari"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "La teva sol·licitud s'ha guardat"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2151,11 +2170,11 @@ msgstr ""
 " ##formcreator.request_id## i s'ha tramès a l'equip de suport. \\nPots veure"
 " les seves respostes a l'enllaç : \\n ##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Hi ha una sol·licitud pendent de validació"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2165,11 +2184,11 @@ msgstr ""
 "  com a validador. \\ nPots accedir-hi fent clic en aquest enllaç :.\\n "
 "##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "La teva sol·licitud ha estat denegada pel validador"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2180,7 +2199,7 @@ msgstr ""
 " ##formcreator.validation_comment##.\\n\\nEncara la pot modificar i tornar a"
 " enviar fent clic en aquest enllaç: \\n ##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2188,11 +2207,11 @@ msgstr ""
 "Hola, \\nEns complau informar-te que la seva sol·licitud ha estat acceptada "
 "pel validador. \\nLa sol·licitud serà tramitada en breu."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "La teva sol·licitud ha estat eliminada per un administrador"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2200,42 +2219,61 @@ msgstr ""
 "Hola, \\n Malauradament la teva sol·licitud no pot ser considerada i ha "
 "estat eliminada per un administrador."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator - Problemes amb la sincronització del catàleg de serveis"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Duplicada"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Transfereix"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Exporta"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Cancel·lar el meu tiquet"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Antic"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Nombre de %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Resum de problemes"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2243,35 +2281,39 @@ msgstr ""
 "El mini tauler de control de Formcreator no es pot utilitzar per defecte. "
 "Aquesta configuració s'ha ignorat."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr "Formulari no trobat. Escull-ne un altre."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "Formulari no trobat."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "No s'ha trobat l'element a FAQ."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Segur que vols eliminar aquesta pregunta?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Segur que vols eliminar aquesta secció?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Afegeix traduccions"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Error en consultar els formularis"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Segur que vols eliminar aquest objectiu?"
 
@@ -2322,13 +2364,17 @@ msgstr "Accés directe a la pàgina d'inici"
 msgid "Default form in service catalog"
 msgstr "Formulari per defecte del catàleg de serveis"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Ets un robot?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Envia"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Condició per mostrar la secció"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/cs_CZ.po
+++ b/locales/cs_CZ.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
 "Last-Translator: David Stepan <stepand@tiscali.cz>, 2022\n"
 "Language-Team: Czech (Czech Republic) (https://www.transifex.com/teclib/teams/28042/cs_CZ/)\n"
@@ -68,10 +68,9 @@ msgstr "Omezit hloubku dílčího stromu"
 msgid "No limit"
 msgstr "Žádný limit"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Formulář"
@@ -139,8 +138,8 @@ msgstr "Špatný požadavek při mazání aktéra."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Tvorba formulářů"
 
@@ -150,12 +149,12 @@ msgstr "Tvorba formulářů"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Seznam formulářů"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Formulář byl úspěšně uložen!"
 
@@ -171,7 +170,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s přidá rezervaci %2$s pro položku %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Kategorie"
@@ -187,30 +185,25 @@ msgstr "Zobrazit vše"
 msgid "Please, describe your need here"
 msgstr "Zde popište své potřeby"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Textové pole"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Není vyplněná povinná kolonka:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "Regulární výraz není platný"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Uživatel"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Uživatel a formulář"
 
@@ -248,96 +241,92 @@ msgstr ""
 "Aby byl respektován systém entit GLPI, měl by být vybrán \"Formulář\". "
 "Ostatní nastavení poruší omezení entity"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "Překročen limit velikosti LDAP"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP výběr"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "Není určený LDAP adresář!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "LDAP adresář nenalezen!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Konkrétní formát neodpovídá: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "Text je příliš krátký (přinejmenším %d znaků): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "Text je příliš dlouhý (nejvýše %d znaků): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Text"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Regulární výraz"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Rozmezí"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Dodatečné ověření"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Přepínač"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "Je třeba vyplnit hodnotu do kolonky:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Povinné pole je prázdné: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Toto není celé číslo: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "Je třeba, aby následující číslo bylo vyšší než %d: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "Je třeba, aby následující číslo bylo nižší než %d: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Celé číslo"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Nedefinováno"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "IP adresa"
@@ -345,40 +334,40 @@ msgstr[1] "IP adres"
 msgstr[2] "IP adres"
 msgstr[3] "IP adresy"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Naléhavost"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Velmi vysoká"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Vysoká"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Střední"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Nízká"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Upozornění: Zásuvný modul Tagů je deaktivován nebo chybí"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Tag"
@@ -386,7 +375,7 @@ msgstr[1] "Tagů"
 msgstr[2] "Tagů"
 msgstr[3] "Tagy"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "GLPI objekt"
@@ -394,7 +383,7 @@ msgstr[1] "GLPI objektů"
 msgstr[2] "GLPI objektů"
 msgstr[3] "GLPI objekty"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Jméno hostitele"
@@ -402,16 +391,16 @@ msgstr[1] "Jmen hostitele"
 msgstr[2] "Jmen hostitele"
 msgstr[3] "Jména hostitelů"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Čas"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Toto není platná emailová adresa: %s "
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Email"
@@ -423,11 +412,11 @@ msgstr[3] "Emaily"
 msgid "Select"
 msgstr "Vybrat"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Datum a čas"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Aktér"
@@ -435,31 +424,31 @@ msgstr[1] "Aktérů"
 msgstr[2] "Aktérů"
 msgstr[3] "Aktéři"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Neplatná hodnota: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Uživatel nebyl nalezen nebo je nevalidní emailová adresa %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Bez připojených dokumentů"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Připojený dokument"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Chybí požadovaný soubor: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Soubor"
 
@@ -467,88 +456,88 @@ msgstr "Soubor"
 msgid "Multiselect"
 msgstr "Výběr vícero položek"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Upozornění: Zásuvný modul Další pole je deaktivován nebo chybí"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Blokovat"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Pole"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "zobrazit"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "Typ pole '%1$s' není ještě implementován!"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Některá číselná pole obsahují nečíselné hodnoty"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Některá pole adres URL obsahují neplatné odkazy"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Další pole"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Zaškrtávací kolonka"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "Následující otázka vyžaduje posledních %dodpovědí"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "Následující dotaz nepřijímá více než %d odpovědí"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Rozsah min"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Rozsah max"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Typ dotazu"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Toto není číslo: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Desetinné číslo"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Datum"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Popis"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Kolonka popis by měla obsahovat popis:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Skryté pole"
@@ -556,8 +545,7 @@ msgstr[1] "Skrytých polí"
 msgstr[2] "Skrytých polí"
 msgstr[3] "Skrytá pole"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Podmínka"
@@ -589,26 +577,26 @@ msgstr "Skrýt dokud"
 msgid "Displayed unless"
 msgstr "Zobrazit dokud"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Nepodařilo se přidat nebo aktualizovat %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Nelze exportovat prázdný objekt: %s"
@@ -625,7 +613,7 @@ msgstr "Importuji"
 msgid "Import in progress"
 msgstr "Probíhá import"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Problém"
@@ -633,29 +621,29 @@ msgstr[1] "Problémů"
 msgstr[2] "Problémů"
 msgstr[3] "Problémy"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Aktualizovat data problému z požadavků a odpovědí z formulářů"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Platnost průzkumu spokojenosti vypršela"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Název"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -664,20 +652,19 @@ msgstr[1] "Typů"
 msgstr[2] "Typů"
 msgstr[3] "Typy"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Stav"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Datum otevření"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Poslední aktualizace"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entita"
@@ -685,9 +672,9 @@ msgstr[1] "Entit"
 msgstr[2] "Entit"
 msgstr[3] "Entity"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Žadatel"
@@ -695,77 +682,68 @@ msgstr[1] "Žadatelů"
 msgstr[2] "Žadatelů"
 msgstr[3] "Žadatelé"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Schvalovatel formuláře"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Komentář"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Schvalovatel požadavku"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Technik"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Skupina technika"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Skupina schvalovatele formuláře"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Neověřeno"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Odmítnuto"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s%2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Vše"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Nový"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Přířazeno"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Čeká se"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "K ověření"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Vyřešeno"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Uzavřeno"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Kategorie formuláře"
@@ -785,19 +763,19 @@ msgstr "Jako potomek"
 msgid "The form as been saved"
 msgstr "Formulář byl uložen"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Formulář je třeba ověřit"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Formulář byl zamítnut"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Formulář byl přijat"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Formulář byl smazán"
 
@@ -810,15 +788,11 @@ msgid "Form name"
 msgstr "Název formuláře"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Ověřovatel"
-msgstr[1] "Ověřovatelů"
-msgstr[2] "Ověřovatelů"
-msgstr[3] "Ověřovatelé"
+msgstr "Ověřovatel"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Datum vytvoření"
 
@@ -843,15 +817,15 @@ msgid "Author"
 msgstr "Autor"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Schvalovatel"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Autor formuláře"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Ověřování formulářů"
 
@@ -859,7 +833,7 @@ msgstr "Ověřování formulářů"
 msgid "Specific person"
 msgstr "Konkrétní osoba"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Osoba z otázky"
 
@@ -867,7 +841,7 @@ msgstr "Osoba z otázky"
 msgid "Specific group"
 msgstr "Konkrétní skupina"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Skupina z otázky"
 
@@ -883,15 +857,15 @@ msgstr "Skupina řešitelů z objektu"
 msgid "Specific supplier"
 msgstr "Konkrétní dodavatel"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Dodavatel z otázky"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Účastníci z otázky"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Vedoucí autora formuláře"
 
@@ -899,7 +873,7 @@ msgstr "Vedoucí autora formuláře"
 msgid "Observer"
 msgstr "Pozorovatel"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Přiřazeno k"
 
@@ -931,11 +905,15 @@ msgstr "Nepodařilo se najít skupinu: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Nepodařilo se najít dodavatele: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Odmítnuto"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Přijato"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Odpověď formuláře"
@@ -943,67 +921,72 @@ msgstr[1] "Odpovědí formuláře"
 msgstr[2] "Odpovědí formuláře"
 msgstr[3] "Odpovědi formuláře"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Vytisknout tento formulář"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Formulář byl schválen ověřovatelem."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Formulář byl úspěšně uložen."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Uložit"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Požadováno pokud je zamítnuto"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Zamítnout"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Upravit odpovědi"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Zrušit úpravu"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Schválit"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Komentář k zamítnutí je povinný!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Nejste ověřovatelem těchto odpovědí"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Data formuláře"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Není možné vytvářet cíle!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Žádná sada Turingových testů"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Neuspěl jsi v Turingově testu"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Je třeba vybrat ověřovatele!"
 
@@ -1015,15 +998,15 @@ msgstr "Tento problém nelze odstranit. Možná se s tím počítá."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Tento problém se nepodařilo odstranit. Došlo k vnitřní chybě."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Požádat o pomoc"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Mé žádosti o pomoc"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Konzultovat zdroje"
 
@@ -1059,7 +1042,7 @@ msgstr[1] "Jazyků formuláře"
 msgstr[2] "Jazyků formuláře"
 msgstr[3] "Jazyky formuláře"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Překlad"
@@ -1067,9 +1050,9 @@ msgstr[1] "Překladů"
 msgstr[2] "Překladů"
 msgstr[3] "Překlady"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "Jméno nemůže být prázdné!"
 
@@ -1081,7 +1064,7 @@ msgstr "Jazyk musí být přiřazen k formuláři!"
 msgid "Add a translation"
 msgstr "Přidat překlad"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Aktualizovat překlad"
 
@@ -1102,7 +1085,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Chcete smazat vybrané položky?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Smazat"
 
@@ -1119,32 +1102,40 @@ msgstr "Přidat nový jazyk"
 msgid "Language"
 msgstr "Jazyk"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Žádné"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Ověřovatel"
+msgstr[1] "Ověřovatelů"
+msgstr[2] "Ověřovatelů"
+msgstr[3] "Ověřovatelé"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Potřebujete ověření?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Ne"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Uložit"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Ověření správnosti"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Vyberte ověřovatele"
 
@@ -1156,14 +1147,14 @@ msgstr[1] "Cílových problémů"
 msgstr[2] "Cílových problémů"
 msgstr[3] "Cílové problémy"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Vlastnosti"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1172,29 +1163,29 @@ msgstr ""
 "Nepodařilo se přidat nebo aktualizovat %1$s %2$s: otázka chybí a je použita "
 "v parametru cíle"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Účastníci"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Název problému"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Obsah"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Dopad"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Příčina"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Příznak"
 
@@ -1261,48 +1252,48 @@ msgstr "Variabilní výška"
 msgid "Uniform height"
 msgstr "Jednotná výška"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Služba podpory"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Režim služby podpory"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Výchozí režim seznamu formulářů"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Pořadí řazení"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Databáze znalostí"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Hledat"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Počítadla nástěnky"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Záhlaví zprávy"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Problém s hledáním"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Design dlaždic"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1311,15 +1302,15 @@ msgstr[1] "Záhlaví"
 msgstr[2] "Záhlaví"
 msgstr[3] "Záhlaví"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Zobrazit vyhledávací pole"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Zobrazit záhlaví"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Rozsah otázek"
@@ -1327,11 +1318,11 @@ msgstr[1] "Rozsahů otázek"
 msgstr[2] "Rozsahů otázek"
 msgstr[3] "Rozsahy otázek"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Minimální rozsah"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "maximální rozsah"
 
@@ -1351,7 +1342,7 @@ msgstr "Omezený přístup"
 msgid "Answers waiting for validation"
 msgstr "Odpovědi čekající na ověření"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Importovat formuláře"
 
@@ -1416,7 +1407,7 @@ msgstr[3] "Cíle"
 msgid "Actions"
 msgstr "Akce"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Přidat cíl"
 
@@ -1432,123 +1423,123 @@ msgstr "vlastnosti"
 msgid "What are you looking for?"
 msgstr "Co hledáte?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Mých %1$dposledních formulářů (žadatel)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Nebyl odeslán žádný formulář"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Všechny mé formuláře (žadatel)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Mých %1$dposledních formulářů (ověřovatel)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Žádný formulář nečeká na ověření"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Všechny mé formuláře (ověřovatel)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "Pro odpovědi z formuláře nelze použít prázdný název. Zachování předchozí "
 "hodnoty."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "Otázka %s není kompatibilní s veřejnými formuláři"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Chybná kopie"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Kopírovat"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Odeslat"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Formulář byl zkopírován: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Formulář byl přesunut: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Zpět"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Nahrání JSON souborů není dovoleno."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "JSON soubory můžete povolit právě teď."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Vytvořit"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Obraťte se na svého správce GLPI."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Zpět"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Nahrávání JSON souborů není zapnuto."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "JSON soubory můžete zapnout právě teď."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Zapnout"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Odeslat"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Import formuláře není možný, soubor je prázdný"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Import formuláře není možný, soubor je poškozen"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "Import formuláře není možný, soubor byl vytvořen jinou verzí"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1556,61 +1547,61 @@ msgstr ""
 "Soubor neurčuje verzi schématu. Pravděpodobně byl vygenerován s verzí starší"
 " než 2.10. Vzdát."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "%s se nepodařilo importovat"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formuláře byly úspěšně importovány z %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "Formulář %1$s už existuje a je entitou, kterou nelze upravovat."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "Nemáte právo aktualizovat entitu %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "Entita %1$s je potřebná pro formulář %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Nepodařilo se vytvořit typ dokumentu JSON"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Typ JSON dokumentu nenalezen"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Nepodařilo se aktualizovat typ JSON dokumentu"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formuláře bez kategorie"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Není k dispozici žádný formulář"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Přidat"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Nepodporovaný typ cíle."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1660,11 +1651,8 @@ msgstr "Název je povinný"
 msgid "Failed to find %1$s %2$s"
 msgstr "Nepodařilo se najít %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Otázka"
@@ -1701,48 +1689,48 @@ msgstr "Tento typ otázky vyžaduje parametry"
 msgid "A parameter is missing for this question type"
 msgstr "Chybí parametr pro tento typ otázky"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Úrovně služby"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Aktiva"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Podpora"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Management"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Nástroje"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Poznámky"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS kanál"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Správa"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Zásuvný modul"
@@ -1876,7 +1864,7 @@ msgstr[1] "Vztahů složených požadavků"
 msgstr[2] "Vztahů složených požadavků"
 msgstr[3] "Vztahy složených požadavků"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Cílový požadavek"
@@ -1884,112 +1872,112 @@ msgstr[1] "Cílových požadavků"
 msgstr[2] "Cílových požadavků"
 msgstr[3] "Cílové požadavky"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Konkrétní majetek"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Rovná se odpovědi na otázku"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Poslední platná odpověď"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "Zdroj ze šablony nebo výchozího uživatele nebo výchozího GLPI"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Tvůrce formulářů"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Výchozí nebo ze šablony"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Specifický typ"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Název požadavku"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Přidat kontrolní zprávu při první změně požadavku"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Přidat pole"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Spravovaná pole"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Nespravované pole"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Odkázat na jiný požadavek"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Druhý cíl tohoto formuláře"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Existující požadavek"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Požadavek z odpovědi na otázku"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Trvale smazat"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Neplatný typ odkazu"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Neplatný typ odkazované položky"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Odkazovaná položka neexistuje"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Nepodařilo se odkázat na položku"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Váš formulář byl ověřen ověřovatelem"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Zdroj dotazu"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Typ"
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Přidružené prvky"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Položka"
 
@@ -2009,95 +1997,95 @@ msgstr "Formulář nebyl nalezen."
 msgid "Failed to add the translation."
 msgstr "Nepodařilo se přidat překlad."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Štítky z otázek"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Specifické štítky"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Štítky z otázek a konkrétní štítky"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Štítky z otázek nebo konkrétní štítky"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "rovná se odpovědi na otázku"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "počítáno od data vytvoření požadavku"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "počítáno od odpovědi na otázku"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "SLA ze šablony nebo žádné"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "Konkrétní SLA"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "OLA ze šablony nebo žádné"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "Konkrétní OLA"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Naléhavost z šablony nebo Střední"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Konkrétní naléhavost"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Kategorie ze šablony nebo žádná"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Konkrétní kategorie"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Umístění ze šablony nebo žádné"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Konkrétní umístění"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Žádné ověření"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Konkrétní uživatel nebo skupina"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Uživatel z odpovědi na otázku"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Skupina z odpovědi na otázku"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Čas na vyřešení"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuta"
@@ -2105,7 +2093,7 @@ msgstr[1] "Minut"
 msgstr[2] "Minut"
 msgstr[3] "Minuty"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hodina"
@@ -2113,7 +2101,7 @@ msgstr[1] "Hodin"
 msgstr[2] "Hodin"
 msgstr[3] "Hodiny"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Den"
@@ -2121,7 +2109,7 @@ msgstr[1] "Dní"
 msgstr[2] "Dní"
 msgstr[3] "Dny"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Měsíc"
@@ -2129,43 +2117,43 @@ msgstr[1] "Měsíců"
 msgstr[2] "Měsíců"
 msgstr[3] "Měsíce"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Otázka (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Naléhavost"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Tagy požadavků"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Štítky"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Umístění"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Umístění"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "Popis nemůže být prázdný"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Pozorovatel"
@@ -2173,52 +2161,83 @@ msgstr[1] "Pozorovatelů"
 msgstr[2] "Pozorovatelů"
 msgstr[3] "Pozorovatelé"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Storno"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Emailové sledování"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Uživatel"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Skupina"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Dodavatel"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Ano"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Skupina z objektu"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Skupina řešitelů z objektu"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"Aktualizujte tabulky na innoDB; spusťte php bin/console "
-"glpi:migration:myisam_to_innodb"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Formulář byl vytvořen"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Vaše žádost byla uložena"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2228,11 +2247,11 @@ msgstr ""
 "##formcreator.request_id## a předán týmu podpory. Odpovědi můžete vidět na "
 "následujícím odkazu:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Formulář z GLPI je třeba ověřit"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2242,11 +2261,11 @@ msgstr ""
 "jako ověřovatel.\\n K formuláři můžete přistoupit kliknutím na tento "
 "odkaz:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Váš formulář byl zamítnut ověřovatelem"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2257,7 +2276,7 @@ msgstr ""
 "\\n##formcreator.validation_comment##\\n\\nFormulář můžete nadále upravovat "
 "kliknutím na tento odkaz:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2265,52 +2284,71 @@ msgstr ""
 "Dobrý den,\\n Váš formulář byl schválen ověřovatelem.\\n Váš požadavek bude "
 "brzy řešen."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Váš formulář byl smazán správcem"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
 msgstr "Dobrý den,\\n Váš formulář nebude řešen a byl smazán správcem."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Vytváření formulářů – problémy katalogu synchronizační služby"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Kopírovat"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Převod"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Export"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Zrušit můj požadavek"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Staré"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Počet z %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Shrnutí problémů"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2318,35 +2356,39 @@ msgstr ""
 "Mini nástěnka Tvůrce formulářů nelze jako výchozí použít. Toto nastavení "
 "bylo ignorováno."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr "Nebyl nalezen žádný formulář. Vyberte prosím formulář níže."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "Nebyl nalezen žádný formulář."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "Nebyla nalezena žádná položka FAQ."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Opravdu chcete smazat tuto otázku?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Opravdu chcete smazat tuto sekci?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Přidat překlady"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Došlo k chybě při dotazování formuláře"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Opravdu chcete smazat tento cíl:"
 
@@ -2399,13 +2441,17 @@ msgstr "Přímý přístup na domovskou stránku"
 msgid "Default form in service catalog"
 msgstr "Výchozí formulář v katalogu služeb"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Jste robot?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Odeslat"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Podmínka pro zobrazení sekce"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/en.po
+++ b/locales/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,10 +63,9 @@ msgstr "Limit subtree depth"
 msgid "No limit"
 msgstr "No limit"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Form"
@@ -132,8 +131,8 @@ msgstr "Bad request while deleting an actor."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Form Creator"
 
@@ -143,12 +142,12 @@ msgstr "Form Creator"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Form list"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "The form has been successfully saved!"
 
@@ -164,7 +163,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s adds the reservation %2$s for item %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Category"
@@ -178,30 +176,25 @@ msgstr "See all"
 msgid "Please, describe your need here"
 msgstr "Please, describe your need here"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Textarea"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "A required field is empty:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "The regular expression is invalid"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "User"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "User and form"
 
@@ -237,162 +230,158 @@ msgstr ""
 "To respect the GLPI entity system, \"Form\" should be selected. Others "
 "settings will break the entity restrictions"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "LDAP size limit exceeded"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP Select"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "LDAP directory not defined!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "LDAP directory not found!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Specific format does not match: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "The text is too short (minimum %d characters): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "The text is too long (maximum %d characters): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Text"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Regular expression"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Range"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Additional validation"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Radios"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "The field value is required:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "A required field is empty: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "This is not an integer: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "The following number must be greater than %d: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "The following number must be lower than %d: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Integer"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Undefined"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "IP address"
 msgstr[1] "IP addresses"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgency"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Very high"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "High"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Medium"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Low"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Very low"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Warning: Tag plugin is disabled or missing"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Tag"
 msgstr[1] "Tags"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "GLPI object"
 msgstr[1] "GLPI objects"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Hostname"
 msgstr[1] "Hostnames"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Time"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "This is not a valid e-mail: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Email"
@@ -402,41 +391,41 @@ msgstr[1] "Emails"
 msgid "Select"
 msgstr "Select"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Date & time"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Actor"
 msgstr[1] "Actors"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Invalid value: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "User not found or invalid email address: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "No attached document"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Attached document"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "A required file is missing: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "File"
 
@@ -444,95 +433,94 @@ msgstr "File"
 msgid "Multiselect"
 msgstr "Multiselect"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Warning: Additional Fields plugin is disabled or missing"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Block"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Field"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "show"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "Field '%1$s' type not implemented yet!"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Some numeric fields contains non numeric values"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Some URL fields contains invalid links"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Additionnal fields"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Checkboxes"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "The following question needs at least %d answers"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "The following question does not accept more than %d answers"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Range min"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Range max"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Request type"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "This is not a number: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Float"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Date"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Description"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "A description field should have a description:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Hidden field"
 msgstr[1] "Hidden fields"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Condition"
@@ -562,26 +550,26 @@ msgstr "Hidden unless"
 msgid "Displayed unless"
 msgstr "Displayed unless"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Failed to add or update the %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Cannot export an empty object: %s"
@@ -598,139 +586,129 @@ msgstr "Importing"
 msgid "Import in progress"
 msgstr "Import in progress"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Issue"
 msgstr[1] "Issues"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Update issue data from tickets and form answers"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Satisfaction survey expired"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Name"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
 msgstr[0] "Type"
 msgstr[1] "Types"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Status"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Opening date"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Last update"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entity"
 msgstr[1] "Entities"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Requester"
 msgstr[1] "Requesters"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Form approver"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Comment"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Ticket approver"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Technician"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Technician group"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Form approver group"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Not validated"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Refused"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "All"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "New"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Assigned"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Waiting"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "To validate"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Solved"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Closed"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Form category"
@@ -748,19 +726,19 @@ msgstr "As child of"
 msgid "The form as been saved"
 msgstr "The form as been saved"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "A form need to be validate"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "The form is refused"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "The form is accepted"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "The form is deleted"
 
@@ -773,13 +751,11 @@ msgid "Form name"
 msgstr "Form name"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Validator"
-msgstr[1] "Validators"
+msgstr "Validator"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Creation date"
 
@@ -804,15 +780,15 @@ msgid "Author"
 msgstr "Author"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Approver"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Form author"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Form validator"
 
@@ -820,7 +796,7 @@ msgstr "Form validator"
 msgid "Specific person"
 msgstr "Specific person"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Person from the question"
 
@@ -828,7 +804,7 @@ msgstr "Person from the question"
 msgid "Specific group"
 msgstr "Specific group"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Group from the question"
 
@@ -844,15 +820,15 @@ msgstr "Tech group from an object"
 msgid "Specific supplier"
 msgstr "Specific supplier"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Supplier from the question"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Actors from the question"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Form author's supervisor"
 
@@ -860,7 +836,7 @@ msgstr "Form author's supervisor"
 msgid "Observer"
 msgstr "Observer"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Assigned to"
 
@@ -890,77 +866,86 @@ msgstr "Failed to find a group: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Failed to find a supplier: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Refused"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Accepted"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Form answer"
 msgstr[1] "Form answers"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Print this form"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Form accepted by validator."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Form successfully saved."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Save"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Required if refused"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Refuse"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Edit answers"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Cancel edition"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Accept"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Refused comment is required!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "You are not the validator of these answers"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr "Item sucessfully added: %1$s (%2$s: %3$s)"
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Form data"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Cannot generate targets!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "No turing test set"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "You failed the Turing test"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "You must select validator!"
 
@@ -972,15 +957,15 @@ msgstr "You cannot delete this issue. Maybe it is taken into account."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Failed to delete this issue. An internal error occured."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Seek assistance"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "My requests for assistance"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consult feeds"
 
@@ -1012,15 +997,15 @@ msgid_plural "Form languages"
 msgstr[0] "Form language"
 msgstr[1] "Form languages"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Translation"
 msgstr[1] "Translations"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "The name cannot be empty!"
 
@@ -1032,7 +1017,7 @@ msgstr "The language must be associated to a form!"
 msgid "Add a translation"
 msgstr "Add a translation"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Update a translation"
 
@@ -1053,7 +1038,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Do you want to delete the selected items?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Delete"
 
@@ -1070,32 +1055,38 @@ msgstr "Add a new language"
 msgid "Language"
 msgstr "Language"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "None"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Validator"
+msgstr[1] "Validators"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Need validaton?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "No"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Save"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Validation"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Choose a validator"
 
@@ -1105,14 +1096,14 @@ msgid_plural "Target problems"
 msgstr[0] "Target problem"
 msgstr[1] "Target problems"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Properties"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1121,29 +1112,29 @@ msgstr ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
 "a parameter of the target"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Actors"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Problem title"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Content"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Impact"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Cause"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Symptom"
 
@@ -1210,73 +1201,73 @@ msgstr "Variable height"
 msgid "Uniform height"
 msgstr "Uniform height"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Helpdesk mode"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Default Form list mode"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Sort order"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Knowledge base"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Search"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Counters dashboard"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Header message"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Search issue"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Tile design"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
 msgstr[0] "Header"
 msgstr[1] "Headers"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Display search field"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Display header"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Question range"
 msgstr[1] "Question ranges"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Minimum range"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "maximum range"
 
@@ -1296,7 +1287,7 @@ msgstr "Restricted access"
 msgid "Answers waiting for validation"
 msgstr "Answers waiting for validation"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Import forms"
 
@@ -1359,7 +1350,7 @@ msgstr[1] "Targets"
 msgid "Actions"
 msgstr "Actions"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Add a target"
 
@@ -1375,121 +1366,121 @@ msgstr "properties"
 msgid "What are you looking for?"
 msgstr "What are you looking for?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "My %1$d last forms (requester)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "No form posted yet"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "All my forms (requester)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "My %1$d last forms (validator)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "No form waiting for validation"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "All my forms (validator)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr "Cannot use empty name for form answers. Keeping the previous value."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "The question %s is not compatible with public forms"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Errored duplicate"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Post"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Form duplicated: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Form Transfered: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Back"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Upload of JSON files not allowed."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "You may allow JSON files right now."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Create"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Please contact your GLPI administrator."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Back"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Upload of JSON files not enabled."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "You may enable JSON files right now."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Enable"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Send"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Forms import impossible, the file is empty"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Forms import impossible, the file seems corrupt"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "Forms import impossible, the file was generated with another version"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1497,61 +1488,61 @@ msgstr ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Failed to import %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Forms successfully imported from %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "The form %1$s already exists and is in an unmodifiable entity."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "You don't have right to update the entity %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "The entity %1$s is required for the form %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Failed to create JSON document type"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "JSON document type not found"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Failed to update JSON document type"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Forms without category"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "No form available"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Add"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Unsupported target type."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1597,11 +1588,8 @@ msgstr "The title is required"
 msgid "Failed to find %1$s %2$s"
 msgstr "Failed to find %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Question"
@@ -1636,48 +1624,48 @@ msgstr "This type of question requires parameters"
 msgid "A parameter is missing for this question type"
 msgstr "A parameter is missing for this question type"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Service levels"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Assets"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Assistance"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Management"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Tools"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notes"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS feed"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administration"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Plugin"
@@ -1801,118 +1789,118 @@ msgid_plural "Composite ticket relations"
 msgstr[0] "Composite ticket relation"
 msgstr[1] "Composite ticket relations"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Target ticket"
 msgstr[1] "Target tickets"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Specific asset"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Equals to the answer to the question"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Last valid answer"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "Source from template or user default or GLPI default"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Default or from a template"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Specific type"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Ticket title"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Add validation message as first ticket followup"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Add a field"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Managed fields"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "No managed field"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Link to an other ticket"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "An other destination of this form"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "An existing ticket"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "A ticket from an answer to a question"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Delete permanently"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Invalid link type"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Invalid linked item type"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Linked item does not exists"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Failed to link the item"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Your form has been accepted by the validator"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Request source"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Type "
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Associated elements"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Item "
 
@@ -1932,206 +1920,244 @@ msgstr "Form not found."
 msgid "Failed to add the translation."
 msgstr "Failed to add the translation."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Tags from questions"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Specific tags"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Tags from questions and specific tags"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Tags from questions or specific tags"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "equals to the answer to the question"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "calculated from the ticket creation date"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "calculated from the answer to the question"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "SLA from template or none"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "Specific SLA"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "OLA from template or none"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "Specific OLA"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgency from template or Medium"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Specific urgency"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Category from template or none"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Specific category"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Location from template or none"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Specific location"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "No validation"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Specific user or group"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "User from question answer"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Group from question answer"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Time to resolve"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minute"
 msgstr[1] "Minutes"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hour"
 msgstr[1] "Hours"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Day"
 msgstr[1] "Days"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Month"
 msgstr[1] "Months"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Question (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgency "
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Ticket tags"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Tags"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Location"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Location "
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "The description cannot be empty!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Watcher"
 msgstr[1] "Watchers"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Cancel"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Email followup"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "User"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Group"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Supplier"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Yes"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Group from the object"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Tech group from the object"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
-msgstr ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
+msgstr "Upgrade tables to innoDB; run %s"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr "To ignore the inconsistencies and upgrade anyway run %s"
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr "The tables of the plugin passed the schema integrity check."
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "A form has been created"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Your request has been saved"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2141,11 +2167,11 @@ msgstr ""
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
 "see your answers onto the following link:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "A form from GLPI need to be validate"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2155,11 +2181,11 @@ msgstr ""
 "validator.\\nYou can access it by clicking onto this "
 "link:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Your form has been refused by the validator"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2171,7 +2197,7 @@ msgstr ""
 "below:\\n##formcreator.validation_comment##\\n\\nYou can still modify and "
 "resubmit it by clicking onto this link:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2179,11 +2205,11 @@ msgstr ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Your form has been deleted by an administrator"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2191,42 +2217,61 @@ msgstr ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator - Sync service catalog issues"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr "Failed to check the sanity of the tables!"
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr "Table schema differs for table \"%s\"."
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr "Table \"%s\" is missing."
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr "Unknown table \"%s\" has been found in database."
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Transfer"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Export"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Cancel my ticket"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Old"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Number of %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Issues summary"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2234,35 +2279,39 @@ msgstr ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr "No form found. Please choose a form below instead."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "No form found."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "No FAQ item found."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Are you sure you want to delete this question?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Are you sure you want to delete this section?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Add translations"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "An error occured while querying forms"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr "An internal error occurred. Please report it to administrator."
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Are you sure you want to delete this target:"
 
@@ -2313,13 +2362,17 @@ msgstr "Direct access on homepage"
 msgid "Default form in service catalog"
 msgstr "Default form in service catalog"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Are you a robot ?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Send"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Condition to show the section"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/en_GB.po
+++ b/locales/en_GB.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: glpi 100a\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
-"PO-Revision-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
+"PO-Revision-Date: 2022-10-14 17:09+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en_GB\n"
@@ -62,10 +62,9 @@ msgstr "Limit subtree depth"
 msgid "No limit"
 msgstr "No limit"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Form"
@@ -131,8 +130,8 @@ msgstr "Bad request while deleting an actor."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Form Creator"
 
@@ -142,12 +141,12 @@ msgstr "Form Creator"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Form list"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "The form has been successfully saved!"
 
@@ -163,7 +162,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s adds the reservation %2$s for item %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Category"
@@ -177,30 +175,25 @@ msgstr "See all"
 msgid "Please, describe your need here"
 msgstr "Please, describe your need here"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Textarea"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "A required field is empty:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "The regular expression is invalid"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "User"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "User and form"
 
@@ -236,162 +229,158 @@ msgstr ""
 "To respect the GLPI entity system, \"Form\" should be selected. Others "
 "settings will break the entity restrictions"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "LDAP size limit exceeded"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP Select"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "LDAP directory not defined!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "LDAP directory not found!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Specific format does not match: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "The text is too short (minimum %d characters): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "The text is too long (maximum %d characters): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Text"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Regular expression"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Range"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Additional validation"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Radios"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "The field value is required:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "A required field is empty: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "This is not an integer: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "The following number must be greater than %d: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "The following number must be lower than %d: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Integer"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Undefined"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "IP address"
 msgstr[1] "IP addresses"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgency"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Very high"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "High"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Medium"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Low"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Very low"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Warning: Tag plugin is disabled or missing"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Tag"
 msgstr[1] "Tags"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "GLPI object"
 msgstr[1] "GLPI objects"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Hostname"
 msgstr[1] "Hostnames"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Time"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "This is not a valid e-mail: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Email"
@@ -401,41 +390,41 @@ msgstr[1] "Emails"
 msgid "Select"
 msgstr "Select"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Date & time"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Actor"
 msgstr[1] "Actors"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Invalid value: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "User not found or invalid email address: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "No attached document"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Attached document"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "A required file is missing: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "File"
 
@@ -443,95 +432,94 @@ msgstr "File"
 msgid "Multiselect"
 msgstr "Multiselect"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Warning: Additional Fields plugin is disabled or missing"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Block"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Field"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "show"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "Field '%1$s' type not implemented yet!"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Some numeric fields contains non numeric values"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Some URL fields contains invalid links"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Additionnal fields"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Checkboxes"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "The following question needs at least %d answers"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "The following question does not accept more than %d answers"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Range min"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Range max"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Request type"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "This is not a number: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Float"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Date"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Description"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "A description field should have a description:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Hidden field"
 msgstr[1] "Hidden fields"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Condition"
@@ -561,26 +549,26 @@ msgstr "Hidden unless"
 msgid "Displayed unless"
 msgstr "Displayed unless"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Failed to add or update the %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Cannot export an empty object: %s"
@@ -597,139 +585,129 @@ msgstr "Importing"
 msgid "Import in progress"
 msgstr "Import in progress"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Issue"
 msgstr[1] "Issues"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Update issue data from tickets and form answers"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Satisfaction survey expired"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Name"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
 msgstr[0] "Type"
 msgstr[1] "Types"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Status"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Opening date"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Last update"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entity"
 msgstr[1] "Entities"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Requester"
 msgstr[1] "Requesters"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Form approver"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Comment"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Ticket approver"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Technician"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Technician group"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Form approver group"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Not validated"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Refused"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "All"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "New"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Assigned"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Waiting"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "To validate"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Solved"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Closed"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Form category"
@@ -747,19 +725,19 @@ msgstr "As child of"
 msgid "The form as been saved"
 msgstr "The form as been saved"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "A form need to be validate"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "The form is refused"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "The form is accepted"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "The form is deleted"
 
@@ -772,13 +750,11 @@ msgid "Form name"
 msgstr "Form name"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Validator"
-msgstr[1] "Validators"
+msgstr "Validator"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Creation date"
 
@@ -803,15 +779,15 @@ msgid "Author"
 msgstr "Author"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Approver"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Form author"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Form validator"
 
@@ -819,7 +795,7 @@ msgstr "Form validator"
 msgid "Specific person"
 msgstr "Specific person"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Person from the question"
 
@@ -827,7 +803,7 @@ msgstr "Person from the question"
 msgid "Specific group"
 msgstr "Specific group"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Group from the question"
 
@@ -843,15 +819,15 @@ msgstr "Tech group from an object"
 msgid "Specific supplier"
 msgstr "Specific supplier"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Supplier from the question"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Actors from the question"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Form author's supervisor"
 
@@ -859,7 +835,7 @@ msgstr "Form author's supervisor"
 msgid "Observer"
 msgstr "Observer"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Assigned to"
 
@@ -889,77 +865,86 @@ msgstr "Failed to find a group: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Failed to find a supplier: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Refused"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Accepted"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Form answer"
 msgstr[1] "Form answers"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Print this form"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Form accepted by validator."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Form successfully saved."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Save"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Required if refused"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Refuse"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Edit answers"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Cancel edition"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Accept"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Refused comment is required!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "You are not the validator of these answers"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr "Item sucessfully added: %1$s (%2$s: %3$s)"
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Form data"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Cannot generate targets!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "No turing test set"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "You failed the Turing test"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "You must select validator!"
 
@@ -971,15 +956,15 @@ msgstr "You cannot delete this issue. Maybe it is taken into account."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Failed to delete this issue. An internal error occured."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Seek assistance"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "My requests for assistance"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consult feeds"
 
@@ -1011,15 +996,15 @@ msgid_plural "Form languages"
 msgstr[0] "Form language"
 msgstr[1] "Form languages"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Translation"
 msgstr[1] "Translations"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "The name cannot be empty!"
 
@@ -1031,7 +1016,7 @@ msgstr "The language must be associated to a form!"
 msgid "Add a translation"
 msgstr "Add a translation"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Update a translation"
 
@@ -1052,7 +1037,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Do you want to delete the selected items?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Delete"
 
@@ -1069,32 +1054,38 @@ msgstr "Add a new language"
 msgid "Language"
 msgstr "Language"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "None"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Validator"
+msgstr[1] "Validators"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Need validaton?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "No"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Save"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Validation"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Choose a validator"
 
@@ -1104,14 +1095,14 @@ msgid_plural "Target problems"
 msgstr[0] "Target problem"
 msgstr[1] "Target problems"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Properties"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1120,29 +1111,29 @@ msgstr ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
 "a parameter of the target"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Actors"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Problem title"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Content"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Impact"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Cause"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Symptom"
 
@@ -1209,73 +1200,73 @@ msgstr "Variable height"
 msgid "Uniform height"
 msgstr "Uniform height"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Helpdesk mode"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Default Form list mode"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Sort order"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Knowledge base"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Search"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Counters dashboard"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Header message"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Search issue"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Tile design"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
 msgstr[0] "Header"
 msgstr[1] "Headers"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Display search field"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Display header"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Question range"
 msgstr[1] "Question ranges"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Minimum range"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "maximum range"
 
@@ -1295,7 +1286,7 @@ msgstr "Restricted access"
 msgid "Answers waiting for validation"
 msgstr "Answers waiting for validation"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Import forms"
 
@@ -1358,7 +1349,7 @@ msgstr[1] "Targets"
 msgid "Actions"
 msgstr "Actions"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Add a target"
 
@@ -1374,121 +1365,121 @@ msgstr "properties"
 msgid "What are you looking for?"
 msgstr "What are you looking for?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "My %1$d last forms (requester)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "No form posted yet"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "All my forms (requester)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "My %1$d last forms (validator)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "No form waiting for validation"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "All my forms (validator)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr "Cannot use empty name for form answers. Keeping the previous value."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "The question %s is not compatible with public forms"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Errored duplicate"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Post"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Form duplicated: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Form Transfered: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Back"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Upload of JSON files not allowed."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "You may allow JSON files right now."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Create"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Please contact your GLPI administrator."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Back"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Upload of JSON files not enabled."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "You may enable JSON files right now."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Enable"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Send"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Forms import impossible, the file is empty"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Forms import impossible, the file seems corrupt"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "Forms import impossible, the file was generated with another version"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1496,61 +1487,61 @@ msgstr ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Failed to import %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Forms successfully imported from %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "The form %1$s already exists and is in an unmodifiable entity."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "You don't have right to update the entity %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "The entity %1$s is required for the form %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Failed to create JSON document type"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "JSON document type not found"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Failed to update JSON document type"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Forms without category"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "No form available"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Add"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Unsupported target type."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1596,11 +1587,8 @@ msgstr "The title is required"
 msgid "Failed to find %1$s %2$s"
 msgstr "Failed to find %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Question"
@@ -1635,48 +1623,48 @@ msgstr "This type of question requires parameters"
 msgid "A parameter is missing for this question type"
 msgstr "A parameter is missing for this question type"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Service levels"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Assets"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Assistance"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Management"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Tools"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notes"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS feed"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administration"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Plugin"
@@ -1800,118 +1788,118 @@ msgid_plural "Composite ticket relations"
 msgstr[0] "Composite ticket relation"
 msgstr[1] "Composite ticket relations"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Target ticket"
 msgstr[1] "Target tickets"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Specific asset"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Equals to the answer to the question"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Last valid answer"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "Source from template or user default or GLPI default"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Default or from a template"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Specific type"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Ticket title"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Add validation message as first ticket followup"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Add a field"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Managed fields"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "No managed field"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Link to an other ticket"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "An other destination of this form"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "An existing ticket"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "A ticket from an answer to a question"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Delete permanently"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Invalid link type"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Invalid linked item type"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Linked item does not exists"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Failed to link the item"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Your form has been accepted by the validator"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Request source"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Type "
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Associated elements"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Item "
 
@@ -1931,204 +1919,244 @@ msgstr "Form not found."
 msgid "Failed to add the translation."
 msgstr "Failed to add the translation."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Tags from questions"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Specific tags"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Tags from questions and specific tags"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Tags from questions or specific tags"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "equals to the answer to the question"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "calculated from the ticket creation date"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "calculated from the answer to the question"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "SLA from template or none"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "Specific SLA"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "OLA from template or none"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "Specific OLA"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgency from template or Medium"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Specific urgency"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Category from template or none"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Specific category"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Location from template or none"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Specific location"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "No validation"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Specific user or group"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "User from question answer"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Group from question answer"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Time to resolve"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minute"
 msgstr[1] "Minutes"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hour"
 msgstr[1] "Hours"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Day"
 msgstr[1] "Days"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Month"
 msgstr[1] "Months"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Question (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgency "
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Ticket tags"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Tags"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Location"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Location "
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "The description cannot be empty!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Watcher"
 msgstr[1] "Watchers"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Cancel"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Email followup"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "User"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Group"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Supplier"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Yes"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Group from the object"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Tech group from the object"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console glpi:migration:myisam_to_innodb"
-msgstr ""
-"Upgrade tables to innoDB; run php bin/console glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
+msgstr "Upgrade tables to innoDB; run %s"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr "To ignore the inconsistencies and upgrade anyway run %s"
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade "
+"to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to "
+"GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade "
+"to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to "
+"GLPI 10 or later and Formcreator 2.13 or later."
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr "The tables of the plugin passed the schema integrity check."
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "A form has been created"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Your request has been saved"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2138,11 +2166,11 @@ msgstr ""
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
 "see your answers onto the following link:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "A form from GLPI need to be validate"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this link:\\n##formcreator."
@@ -2152,23 +2180,23 @@ msgstr ""
 "validator.\\nYou can access it by clicking onto this link:\\n##formcreator."
 "validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Your form has been refused by the validator"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
-"validator for the reason below:\\n##formcreator.validation_comment##\\n"
-"\\nYou can still modify and resubmit it by clicking onto this link:"
-"\\n##formcreator.validation_link##"
+"validator for the reason below:\\n##formcreator."
+"validation_comment##\\n\\nYou can still modify and resubmit it by clicking "
+"onto this link:\\n##formcreator.validation_link##"
 msgstr ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
-"validator for the reason below:\\n##formcreator.validation_comment##\\n"
-"\\nYou can still modify and resubmit it by clicking onto this link:"
-"\\n##formcreator.validation_link##"
+"validator for the reason below:\\n##formcreator."
+"validation_comment##\\n\\nYou can still modify and resubmit it by clicking "
+"onto this link:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2176,11 +2204,11 @@ msgstr ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Your form has been deleted by an administrator"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2188,42 +2216,61 @@ msgstr ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator - Sync service catalog issues"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr "Failed to check the sanity of the tables!"
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr "Table schema differs for table \"%s\"."
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr "Table \"%s\" is missing."
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr "Unknown table \"%s\" has been found in database."
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Transfer"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Export"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Cancel my ticket"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Old"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Number of %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Issues summary"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2231,35 +2278,39 @@ msgstr ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr "No form found. Please choose a form below instead."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "No form found."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "No FAQ item found."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Are you sure you want to delete this question?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Are you sure you want to delete this section?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Add translations"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "An error occured while querying forms"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr "An internal error occurred. Please report it to administrator."
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Are you sure you want to delete this target:"
 
@@ -2310,13 +2361,17 @@ msgstr "Direct access on homepage"
 msgid "Default form in service catalog"
 msgstr "Default form in service catalog"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Are you a robot ?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Send"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Condition to show the section"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/es_ES.po
+++ b/locales/es_ES.po
@@ -5,20 +5,20 @@
 # 
 # Translators:
 # Jorge Saiz, 2021
-# 5b63a00e0726b96d7ef35c99d5553cd0_b787b5f <8bb2d0f7e8927228f17fba8639d787be_31711>, 2022
-# Ricardo Herrero <ricardo.herrero@gmail.com>, 2022
 # Óscar Beiro - TICgal, 2022
 # Thierry Bugier <tbugier@teclib.com>, 2022
 # Nuria Costa <nuria.costa@uvic.cat>, 2022
+# Ricardo Herrero <ricardo.herrero@gmail.com>, 2022
+# 5b63a00e0726b96d7ef35c99d5553cd0_b787b5f <8bb2d0f7e8927228f17fba8639d787be_31711>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
-"Last-Translator: Nuria Costa <nuria.costa@uvic.cat>, 2022\n"
+"Last-Translator: 5b63a00e0726b96d7ef35c99d5553cd0_b787b5f <8bb2d0f7e8927228f17fba8639d787be_31711>, 2022\n"
 "Language-Team: Spanish (Spain) (https://www.transifex.com/teclib/teams/28042/es_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -71,10 +71,9 @@ msgstr "Limitar la profundidad del subarbol"
 msgid "No limit"
 msgstr "Sin límite"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Formulario"
@@ -141,8 +140,8 @@ msgstr ""
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Creador de Formulario"
 
@@ -152,12 +151,12 @@ msgstr "Creador de Formulario"
 msgid "%1$s = %2$s"
 msgstr ""
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Lista de formulario"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "¡El formulario ha sido guardado exitosamente!"
 
@@ -173,7 +172,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr ""
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Categoría"
@@ -188,30 +186,25 @@ msgstr ""
 msgid "Please, describe your need here"
 msgstr "Por favor, describe tu necesidad aquí"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Textarea"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Un campo requerido está vacío:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "La expresión regular es inválida"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Usuario"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Usuario y formulario"
 
@@ -249,166 +242,162 @@ msgstr ""
 "\"Formulario\". Otras configuraciones romperán las restricciones de la "
 "entidad"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "El límite del tamaña LDAP se ha sobrepasado"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP Select"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "El directorio LDAP no está definido!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "El directorio LDAP no se ha encontrado!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "El formato especificado no coincide: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "El texto es demasiado corto (mínimo %d caracteres): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "El texto es demasiado largo (máximo %d caracteres): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Texto"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Expresión regular"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Rango"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Validación adicional"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Radios"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "El campo valor es requerido:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Un campo obligatorio está vacío: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "No es un entero: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "El siguiente número debe ser mayor que %d: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "El siguiente número debe ser menor que %d: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Integer"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr ""
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgencia"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Muy alta"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Alta"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Medio"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Baja"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr ""
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Etiqueta"
 msgstr[1] "Etiquetas"
 msgstr[2] "Etiquetas"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "Objeto GLPI"
 msgstr[1] "Objetos GLPI"
 msgstr[2] "Objetos GLPI"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "tiempo"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Este no es un e-mail válido: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Correo"
@@ -419,42 +408,42 @@ msgstr[2] "Correos"
 msgid "Select"
 msgstr "Select"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Fecha & Hora"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Actor"
 msgstr[1] "Actores"
 msgstr[2] "Actores"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Valor inválido: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "No se ha encontrado al usuario o el email es inválido: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "No hay documento adjunto"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Documento adjunto"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Un campo obligatorio está vacío: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Archivo"
 
@@ -462,96 +451,95 @@ msgstr "Archivo"
 msgid "Multiselect"
 msgstr "Multiselect"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Campo"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr ""
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Checkboxes"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "La siguiente pregunta requiere al menos %d respuesta(s)"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "La siguente pregunta no acepta más de %d respuestas"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr ""
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr ""
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Tipo de Petición"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Esto no es un número: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Float"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Fecha"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Descripción"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "El campo descripción debe tener una descripción:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Campo oculto"
 msgstr[1] "Campos ocultos"
 msgstr[2] "Campos ocultos"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Condición"
@@ -582,26 +570,26 @@ msgstr "Oculto a menos"
 msgid "Displayed unless"
 msgstr "Mostrar a meno que"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Fallo al añadir o actualizar el %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "No se puede exportar un objeto vacío: %s"
@@ -618,37 +606,37 @@ msgstr "Importando"
 msgid "Import in progress"
 msgstr "Importación en curso"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Problema"
 msgstr[1] "Problemas"
 msgstr[2] "Problemas"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr ""
 "Problema de actualización de datos de tiquets y respuestas de formulario"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Encuesta de satisfacción caducada"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Nombre"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -656,106 +644,96 @@ msgstr[0] "Tipo"
 msgstr[1] "Tipos"
 msgstr[2] "Tipos"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Estado"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Fecha de apertura"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Última modificación"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entidade"
 msgstr[1] "Entidades"
 msgstr[2] "Entidades"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
 msgstr[1] "Solicitantes"
 msgstr[2] "Solicitantes"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Aprobador del formulario"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Comentario"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Aprobador del ticket"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Técnico"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Grupo de técnicos"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Grupo de aprobación del formulario"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "No validado"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Rechazado"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr ""
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Todos"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr ""
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr ""
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Esperando"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "Para validar"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr ""
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Cerrado"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Categoría del formulario"
@@ -774,19 +752,19 @@ msgstr ""
 msgid "The form as been saved"
 msgstr "El formulario ha sido guardado"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Un formulario necesita ser validado"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "El formulario está rechazado"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "El formulario es aceptado"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "El formulario es eliminado"
 
@@ -799,14 +777,11 @@ msgid "Form name"
 msgstr "Formulario nombre"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr "Validador"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr ""
 
@@ -831,15 +806,15 @@ msgid "Author"
 msgstr "Autor"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr ""
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Autor del formulario"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Desde el validador"
 
@@ -847,7 +822,7 @@ msgstr "Desde el validador"
 msgid "Specific person"
 msgstr "Persona específica"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Persona desde la pregunta"
 
@@ -855,7 +830,7 @@ msgstr "Persona desde la pregunta"
 msgid "Specific group"
 msgstr "Grupo específico"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Grupo desde la pregunta"
 
@@ -871,15 +846,15 @@ msgstr "Grupo Técnico desde un objeto"
 msgid "Specific supplier"
 msgstr "Proveedor específico"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Proveedor desde la pregunta"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Actores de la pregunta"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Supervisor del autor del formulario"
 
@@ -887,7 +862,7 @@ msgstr "Supervisor del autor del formulario"
 msgid "Observer"
 msgstr "Observador"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Asignado a"
 
@@ -918,78 +893,87 @@ msgstr ""
 msgid "Failed to find a supplier: %1$s"
 msgstr ""
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Rechazado"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Aceptado"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Respuesta del formulario"
 msgstr[1] "Respuestas al formulario"
 msgstr[2] "Respuestas al formulario"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Imprimir este formulario"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Formulario aceptado y validado"
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Formulario guardado exitosamente."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Guardar"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Se requiere si se negó"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Denegado"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Editar las respuestas"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Cancelar la edición"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Aceptado"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "¡Comentario denegado es requerido!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "No eres el validador de estas respuestas"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Datos del formulario"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "¡No se puede generar objetivos!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "No se ha configurado un test de Turing"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Falló el test de Turing"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Debe seleccionar un validador"
 
@@ -1002,15 +986,15 @@ msgstr ""
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Fallo al borrar esta tarea. Ha ocurrido un error interno"
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Buscar ayuda"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Mis solicitudes de asistencia"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consultar feeds"
 
@@ -1044,16 +1028,16 @@ msgstr[0] "Idioma del fomulario"
 msgstr[1] "Idiomas del formulario"
 msgstr[2] "Idiomas del formulario"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Traducción"
 msgstr[1] "Traducciones"
 msgstr[2] "Traducciones"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "¡El nombre no puede estar vacío!"
 
@@ -1065,7 +1049,7 @@ msgstr "El lenguaje debe estar asociado al formulario!"
 msgid "Add a translation"
 msgstr "Añadir una traducción"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr ""
 
@@ -1086,7 +1070,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "¿Quieres borrar los ítems seleccionados?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -1103,32 +1087,39 @@ msgstr "Agregar un nuevo idioma"
 msgid "Language"
 msgstr "Idioma"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Ninguno"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "¿Necesita validación?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "No"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Guardar"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Validación"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Elija un validador"
 
@@ -1139,14 +1130,14 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Propiedades"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1155,29 +1146,29 @@ msgstr ""
 "Fallo al añadir o actualizar el %1$s %2$s: una pregunta está vacía y se ha "
 "empleado en un parámetro del objetivo"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Actores"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Título del problema"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Contenido"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Impacto"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Motivo"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Síntoma"
 
@@ -1244,48 +1235,48 @@ msgstr ""
 msgid "Uniform height"
 msgstr ""
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Modo Helpdesk"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr ""
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Orden de clasificación"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Base de conocimiento"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Búsqueda"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr ""
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Mensaje de Cabecera"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr ""
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr ""
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1293,26 +1284,26 @@ msgstr[0] "Cabecera"
 msgstr[1] "Cabeceras"
 msgstr[2] "Cabeceras"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Mostrar campo de búsqueda"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Mostrar cabecera"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Rango de preguntas"
 msgstr[1] "Rangos de Preguntas"
 msgstr[2] "Rangos de Preguntas"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Rango mínimo"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "Rango máximo"
 
@@ -1332,7 +1323,7 @@ msgstr "Acceso restringido"
 msgid "Answers waiting for validation"
 msgstr ""
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Importar formularios"
 
@@ -1396,7 +1387,7 @@ msgstr[2] "Objetivos"
 msgid "Actions"
 msgstr ""
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Añadir un objetivo"
 
@@ -1412,124 +1403,124 @@ msgstr "propiedades"
 msgid "What are you looking for?"
 msgstr "¿Qué estás buscando?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Mis %1$d ultimos formularios (peticionario)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Formulario no publicado aún"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Todos mis formularios (solicitante)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Mis %1$d ultimos formularios (validador)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "No formulario esperando por validación"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Todos mis formularios (validador)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "La pregunta %s no es compatible con los formularios publicos"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Duplicado erróneo"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Publicar"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Formulario duplicado: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Formulario Transferido: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Atrás"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Carga de ficheros JSON no permitida."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "Deberías permitir la carga de ficheros JSON ahora."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Crear"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Por favor, contacta con el administrador del GLPI."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Atrás"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Carga de ficheros JSON no habilitada."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "Deberías habilitar los ficheros JSON ahora."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Habilitado"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Enviar"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "La importación del formulario es imposible, el fichero está vacío"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr ""
 "La importación del formulario es imposible, el fichero parece corrupto"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr ""
 "La importación del formulario es imposible, el fichero se generó con otra "
 "versión"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1537,62 +1528,62 @@ msgstr ""
 "El fichero no especifica la versión del esquema. Fue probablemente generado "
 "con una versión anterior a la 2.10. No se realiza"
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Fallo al importar %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formularios importados correctamente de %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr ""
 "El formulario %1$s ya existe y está en una entidad que no se puede modificar"
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr ""
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "Se requiere la entidad %1$s para el formulario %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Error al crear el tipo de documento JSON."
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Tipo de documento JSON no encontrado"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Error al actualizar el tipo de documento JSON"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formularios sin categoría"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "No hay un formulario disponible"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Añadir"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Tipo de Objetivo no soportado"
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1640,11 +1631,8 @@ msgstr "El título es requerido"
 msgid "Failed to find %1$s %2$s"
 msgstr ""
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Pregunta"
@@ -1680,48 +1668,48 @@ msgstr "Este tipo de pregunta requiere parámetros"
 msgid "A parameter is missing for this question type"
 msgstr "Un parámetro no se ha completado para este tipo de pregunta"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Niveles de servicio"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "ANS"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "Acuerdo de Nivel de Operación"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Activos"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Asistencia"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Gestión"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Herramientas"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notas"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "Canal RSS"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administración"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Plugin"
@@ -1850,119 +1838,119 @@ msgstr[0] "Componer relación entre tickets"
 msgstr[1] "Componer relaciones entre tickets"
 msgstr[2] "Componer relaciones entre tickets"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Ticket objetivo"
 msgstr[1] "Tickets objetivos"
 msgstr[2] "Tickets objetivos"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Activo específico"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Igual a la respuesta a la pregunta"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Ultima respuesta válida"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr ""
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr ""
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Valor por defecto o desde una plantilla"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Tipo específico"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Título del ticket"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Agregar validación de mensaje como primer ticker de seguimiento"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Agregar un campo"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr ""
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr ""
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Enlazar con otro ticket"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "A otro destino de este formulario"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "A un ticket existente"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr ""
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Eliminar permanentemente"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Tipo de enlace inválido"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "tipo de enlace a objeto inválido "
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "El objeto enlazado no existe"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Fallo al enlazar el item"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Su formulario ha sido aceptado por el validador"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr ""
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Tipo"
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Elementos asociados"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Item u Objeto"
 
@@ -1982,209 +1970,242 @@ msgstr "Formulario no encontrado"
 msgid "Failed to add the translation."
 msgstr "Fallo al añadir la traducción"
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Etiquetas desde preguntas"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Etiquetas específicas"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Etiquetas desde preguntas y etiquetas específicas"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Etiquetas desde preguntas o etiquetas específicas"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "es igual la respuesta a la pregunta"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "calculada a partir de la fecha de creación del ticket"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "calculada a partir de la respuesta del ticket"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "ANS desde plantilla o ninguno"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "ANS específico"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "Acuerdo de Nivel de Operación desde plantilla o ninguno"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "Acuerdo de Nivel de Operación específico"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgencia de plantilla o medio"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Urgencia específica"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Categoría desde plantilla o ninguna"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Categoría específica"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Ubicación desde plantilla o ninguna"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Ubicación específica"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Sin validación"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Usuario o grupo específicos"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Usuario desde la respuesta a la pregunta"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Tiempo para Resolver"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuto"
 msgstr[1] "Minutos"
 msgstr[2] "Minutos"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hora"
 msgstr[1] "Horas"
 msgstr[2] "Horas"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Día"
 msgstr[1] "Días"
 msgstr[2] "Días"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Mes"
 msgstr[1] "Meses"
 msgstr[2] "Meses"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "ANS (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Petición (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgencia"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Etiquetas de ticket"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Ubicación"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Ubicación"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "¡La descripción no puede estar vacía!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Observador"
 msgstr[1] "Observadores"
 msgstr[2] "Observadores"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Seguimiento por correo"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Usuario"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Grupo"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Proveedor"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Sí"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Grupo desde un objeto"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Grupo Técnico desde un objeto"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "El formulario ha sido creado"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Tu solicitud ha sido guardada"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2195,11 +2216,11 @@ msgstr ""
 "puedes ver sus respuestas en el siguiente "
 "enlace:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Un formulario GLPI necesita ser validado"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2209,11 +2230,11 @@ msgstr ""
 "elegido como el validador.\\nUsted puede acceder a él haciendo clic en este "
 "enlace:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Su formulario ha sido rechazado por el validador"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2226,7 +2247,7 @@ msgstr ""
 "modificarlo y volver a enviarlo haciendo clic en este "
 "enlace:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2234,11 +2255,11 @@ msgstr ""
 "Hola,\\nNos complace informarle de que su formulario ha sido aceptado por el"
 " validador.\\n Su solicitud será considerada pronto."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Tu formulario ha sido eliminado por un administrador"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2246,77 +2267,100 @@ msgstr ""
 "Hola,\\nLamentamos informarle de que su solicitud no puede ser considerada, "
 "y ha sido eliminado por un administrador."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr ""
 "Formcreator - Problemas en la sincronización del catálogo de servicios"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Transferir"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Exportar"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Cancelar mi ticket"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr ""
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr ""
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr ""
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
 msgstr ""
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr ""
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr ""
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr ""
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "¿Está seguro de que quiere eliminar esta pregunta?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "¿Está seguro de que quiere eliminar esta sección?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr ""
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Se ha producido un error al consultar formularios"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr ""
 
@@ -2368,13 +2412,17 @@ msgstr "Acceso directo a la página principal"
 msgid "Default form in service catalog"
 msgstr "Formulario por defecto del catálogo de servicios"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "¿Eres un robot?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Enviar"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Condición para mostrar la sección"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/es_VE.po
+++ b/locales/es_VE.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
 "Last-Translator: Francisco Bolivar, 2022\n"
 "Language-Team: Spanish (Venezuela) (https://www.transifex.com/teclib/teams/28042/es_VE/)\n"
@@ -66,10 +66,9 @@ msgstr "Limite de profundidad del subárbol"
 msgid "No limit"
 msgstr "Sin límite"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Formulario"
@@ -136,8 +135,8 @@ msgstr "Petición errada al eliminar actor."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Creador de Formulario"
 
@@ -147,12 +146,12 @@ msgstr "Creador de Formulario"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Lista de formulario"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "¡El formulario ha sido guardado exitosamente!"
 
@@ -168,7 +167,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s agrega la reserva%2$s para el elemento%3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Categoria"
@@ -183,30 +181,25 @@ msgstr "Ver todo"
 msgid "Please, describe your need here"
 msgstr "Por favor, describe tu necesidad aquí"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "AreaDeTexto"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Un campo requerido está vacío:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "La expresión regular no es válida"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Usuario"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Usuario y formulario"
 
@@ -244,166 +237,162 @@ msgstr ""
 "\"Formulario\". Otras configuraciones romperán las restricciones de la "
 "entidad"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "Se superó el límite de tamaño de LDAP"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "Seleccionar LDAP"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "Directorio LDAP no definido!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "Directorio LDAP no encontrado!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "El formato especificado no coincide: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "El texto es demasiado corto (mínimo %d caracteres): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "El texto es demasiado largo (máximo %d caracteres): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Texto"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Expresión regular"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Rango"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Validación adicional"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Radios"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "El campo valor es requerido:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Un campo obligatorio está vacío: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Este no es un número entero: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "El siguiente número debe ser mayor que %d: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "El siguiente número debe ser menor que %d: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Entero"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Indefinido"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "Dirección IP"
 msgstr[1] "Direcciones IP"
 msgstr[2] "Direcciones IP"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgencia"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Muy Alta"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Alta"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Media"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Baja"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Advertencia: el complemento de etiquetas está deshabilitado o falta"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Etiqueta"
 msgstr[1] "Etiquetas"
 msgstr[2] "Etiquetas"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "Objeto de GLPI"
 msgstr[1] "Objetos de GLPI"
 msgstr[2] "Objetos de GLPI"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Nombre de anfitrión"
 msgstr[1] "Nombres de anfitrión"
 msgstr[2] "Nombres de anfitrión"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Hora"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Este no es un correo electrónico válido: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Correo"
@@ -414,42 +403,42 @@ msgstr[2] "Correos"
 msgid "Select"
 msgstr "Seleccionar"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Fecha y hora"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Actor"
 msgstr[1] "Actores"
 msgstr[2] "Actores"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Valor no válido: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Usuario no encontrado o dirección de correo electrónico no válida:%s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Documento no anexado"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Archivo adjunto"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Falta un archivo obligatorio: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Archivo"
 
@@ -457,97 +446,96 @@ msgstr "Archivo"
 msgid "Multiselect"
 msgstr "Mutiselección"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr ""
 "Advertencia: el complemento de campos adicionales está deshabilitado o falta"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Bloquear"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Campo"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "ver"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "¡El tipo de campo '%1$s' aún no está implementado!"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Algunos campos numéricos contienen valores no numéricos"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Algunos campos de URL contienen enlaces no válidos"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Campos Adicionales"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Casillas de verificación"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "La siguiente pregunta necesita al menos %d respuestas"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "La siguiente pregunta no acepta más de %d respuestas"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Rango mínimo"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Rango máximo"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Tipo de solicitud"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Este no es un número: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Flotante"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Fecha"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Descripción"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "El campo descripción debe tener una descripción:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Campo oculto"
 msgstr[1] "Campos ocultos"
 msgstr[2] "Campos ocultos"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Condición"
@@ -578,26 +566,26 @@ msgstr "Oculto a menos"
 msgid "Displayed unless"
 msgstr "Desplegado a menos"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "No se pudo agregar o actualizar %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "No se puede exportar un objeto vacío: %s"
@@ -614,36 +602,36 @@ msgstr "Importando"
 msgid "Import in progress"
 msgstr "Importación en progreso"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Asunto"
 msgstr[1] "Asuntos"
 msgstr[2] "Asuntos"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Actualizar datos de asuntos de casos y respuestas de formularios"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Encuesta de satisfacción caducada"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Nombre"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -651,106 +639,96 @@ msgstr[0] "Tipo"
 msgstr[1] "Tipos"
 msgstr[2] "Tipos"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Estado"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Fecha de apertura"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Última modificación"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entidad"
 msgstr[1] "Entidades"
 msgstr[2] "Entidades"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
 msgstr[1] "Solicitantes"
 msgstr[2] "Solicitantes"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Aprobador de formularios"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Comentario"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Aprobador del caso"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Técnico"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Grupo de técnicos"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Grupo de aprobadores de formularios"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "No validado"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Rechazado"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Todos"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Nuevos"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Asignado"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Esperando"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "Para validar"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Resuelto"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Cerrado"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Categoria de formulario"
@@ -769,19 +747,19 @@ msgstr "Debajo de"
 msgid "The form as been saved"
 msgstr "El formulario ha sido guardado"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Un formulario necesita ser validado"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "El formulario está rechazado"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "El formulario es aceptado"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "El formulario es eliminado"
 
@@ -794,14 +772,11 @@ msgid "Form name"
 msgstr "Formulario nombre"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Validador"
-msgstr[1] "Validadores"
-msgstr[2] "Validadores"
+msgstr "Validador"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Fecha de creación"
 
@@ -826,15 +801,15 @@ msgid "Author"
 msgstr "Autor"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Autorizante"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Autor del formulario"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Desde el validador"
 
@@ -842,7 +817,7 @@ msgstr "Desde el validador"
 msgid "Specific person"
 msgstr "Persona específica"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Persona desde la pregunta"
 
@@ -850,7 +825,7 @@ msgstr "Persona desde la pregunta"
 msgid "Specific group"
 msgstr "Grupo específico"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Grupo desde la pregunta"
 
@@ -866,15 +841,15 @@ msgstr "Grupo tecnológico de un objeto"
 msgid "Specific supplier"
 msgstr "Proveedor específico"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Proveedor desde la pregunta"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Actores de la pregunta"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Supervisor del autor del formulario"
 
@@ -882,7 +857,7 @@ msgstr "Supervisor del autor del formulario"
 msgid "Observer"
 msgstr "Supervisor"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Asignado a"
 
@@ -913,78 +888,87 @@ msgstr "No se pudo encontrar un grupo: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "No se pudo encontrar un proveedor: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Rechazado"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Aceptado"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Respuesta de formulario"
 msgstr[1] "Respuestas de formulario"
 msgstr[2] "Respuestas de formulario"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Imprimir este formulario"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Formulario aceptado y validado."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Formulario guardado exitosamente."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Guardar"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Se requiere si se negó"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Denegado"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Editar respuestas"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Cancelar edición"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Aceptado"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "¡Comentario denegado es requerido!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "No eres el validador de estas respuestas"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Datos del formulario"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "¡No se puede generar objetivos!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Sin equipo de prueba de turing"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Fallaste en la prueba de Turing"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Debes seleccionar validador!"
 
@@ -996,15 +980,15 @@ msgstr "No puede eliminar este asunto. Tal vez se tenga en cuenta."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "No se pudo eliminar este asusto. Ocurrió un error interno."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Solicitar soporte"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Mis solucitudes de ayuda"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consultar feeds"
 
@@ -1038,16 +1022,16 @@ msgstr[0] "Idioma del formulario"
 msgstr[1] "Idiomas del formulario"
 msgstr[2] "Idiomas del formulario"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Traducción"
 msgstr[1] "Traducciones"
 msgstr[2] "Traducciones"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "¡El nombre no puede estar vacío!"
 
@@ -1059,7 +1043,7 @@ msgstr "¡El idioma debe estar asociado a un formulario!"
 msgid "Add a translation"
 msgstr "Agregar una traducción"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Actualizar una traducción"
 
@@ -1080,7 +1064,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "¿Quieres eliminar los elementos seleccionados?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -1097,32 +1081,39 @@ msgstr "Agregar un nuevo idioma"
 msgid "Language"
 msgstr "Idioma"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Ninguno"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Validador"
+msgstr[1] "Validadores"
+msgstr[2] "Validadores"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "¿Necesita validación?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "No"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Guardar"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Convalidación"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Elija un validador"
 
@@ -1133,14 +1124,14 @@ msgstr[0] "Problema objetivo"
 msgstr[1] "Problemas objetivos"
 msgstr[2] "Problemas objetivos"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Propiedades"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1149,29 +1140,29 @@ msgstr ""
 "No se pudo agregar o actualizar %1$s %2$s: falta una pregunta y se usa en un"
 " parámetro del objetivo"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Actores"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Título del problema"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Contenido"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Impacto"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Motivo"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Síntoma"
 
@@ -1238,48 +1229,48 @@ msgstr "Altura variable"
 msgid "Uniform height"
 msgstr "Altura uniforme"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Modo Helpdesk"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Modo de lista de formulario predeterminado"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Orden de clasificación"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Base de conocimiento"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Buscar"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Tablero de contadores"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Mensaje de encabezado"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Buscar asunto"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Diseño de cubierta"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1287,26 +1278,26 @@ msgstr[0] "Encabezado"
 msgstr[1] "Encabezados"
 msgstr[2] "Encabezados"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Mostrar campo de búsqueda"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Encabezado de visualización"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Rango de preguntas"
 msgstr[1] "Rangos de preguntas"
 msgstr[2] "Rangos de preguntas"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Rango mínimo"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "rango maximo"
 
@@ -1326,7 +1317,7 @@ msgstr "Acceso restringido"
 msgid "Answers waiting for validation"
 msgstr "Respuestas esperando validación"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Importar formularios"
 
@@ -1390,7 +1381,7 @@ msgstr[2] "Destinos"
 msgid "Actions"
 msgstr "Acciones"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Agregar un objetivo"
 
@@ -1406,123 +1397,123 @@ msgstr "propiedades"
 msgid "What are you looking for?"
 msgstr "¿Qué estás buscando?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Mis %1$d últimos formularios (solicitante)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Formulario no publicado aún"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Todos mis formularios (solicitante)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Mis %1$d últimos formularios (validador)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "No formulario esperando por validación"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Todos mis formularios (validador)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "No se puede usar un nombre vacío para las respuestas del formulario. "
 "Manteniendo el valor anterior."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "La pregunta %s no es compatible con formularios públicos"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Duplicado con errores"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Publicar"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Formulario duplicado: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Formulario Transferido: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Volver"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Carga de archivos JSON no permitida."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "Puede permitir archivos JSON en este momento."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Crear"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Por favor contacte a su administrador de GLPI."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Volver"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Carga de archivos JSON no habilitada."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "Puede habilitar los archivos JSON en este momento."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Activar"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Enviar"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Imposible importar formularios, el archivo está vacío"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Imposible importar formularios, el archivo parece corrupto"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "Imposible importar formularios, el archivo se generó con otra versión"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1530,61 +1521,61 @@ msgstr ""
 "El archivo no especifica la versión del esquema. Probablemente se generó con"
 " una versión anterior a la 2.10. Abandonar."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Error al importar %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formularios importados correctamente de %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "El formulario %1$s ya existe y está en una entidad inmodificable."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "No tiene derecho a actualizar la entidad %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "La entidad %1$s es necesaria para el formulario %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Error al crear el tipo de documento JSON"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Tipo de documento JSON no encontrado"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Error al actualizar el tipo de documento JSON"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formularios sin categoría"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "No hay formulario disponible"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Agregar"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Tipo de objetivo no admitido."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1632,11 +1623,8 @@ msgstr "El título es requerido"
 msgid "Failed to find %1$s %2$s"
 msgstr "No se pudo buscar %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Pregunta"
@@ -1672,48 +1660,48 @@ msgstr "Este tipo de pregunta requiere parámetros"
 msgid "A parameter is missing for this question type"
 msgstr "Falta un parámetro para este tipo de pregunta"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Niveles de servicio"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "ANS"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "AOS"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Activos"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Asistencia"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Gestión"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Herramientas"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notas"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "Canal RSS"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administración"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Complemento"
@@ -1842,121 +1830,121 @@ msgstr[0] "Relación de ticket compuesto"
 msgstr[1] "Relaciones de ticket compuesto"
 msgstr[2] "Relaciones de ticket compuesto"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Caso destino"
 msgstr[1] "Casos destino"
 msgstr[2] "Casos destino"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Activo especificado"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Igual a la respuesta a la pregunta"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Última respuesta válida"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr ""
 "Origen de plantilla o valor predeterminado de usuario o valor predeterminado"
 " de GLPI"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Predeterminado o de una plantilla"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Tipo especificado"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Título del ticket"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Agregar validación de mensaje como primer seguimiento del caso"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Agregar un campo"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Campos administrados"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Ningún campo administrado"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Enlace a otro caso"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Otro destino para este formulario"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Un caso existente"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Un caso a partir de una respuesta a una pregunta"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Eliminar permanentemente"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Tipo de enlace no válido"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Tipo de elemento vinculado no válido"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "El elemento vinculado no existe"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Error al vincular el elemento"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Su formulario ha sido aceptado por el validador"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Origen de la solicitud"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Tipo "
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Elementos asociados"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Elemento "
 
@@ -1976,213 +1964,244 @@ msgstr "Formulario no encontrado."
 msgid "Failed to add the translation."
 msgstr "No se pudo agregar la traducción."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Etiquetas desde preguntas"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Etiquetas específicas"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Etiquetas desde preguntas y etiquetas específicas"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Etiquetas desde preguntas o etiquetas específicas"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "es igual la respuesta a la pregunta"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "calculada a partir de la fecha de creación del ticket"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "calculada a partir de la respuesta del ticket"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "ANS de plantilla o ninguno"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "ANS especificado"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "AOS desde plantilla o ninguna"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "AOS Especificado"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgencia de plantilla o medio"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Urgencia específica"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Categoría desde plantilla o ninguna"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr ""
 "17/5000\n"
 "Categoría específica"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Ubicación desde plantilla o ninguna"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Ubicación específica"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Sin validación"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Usuario específico o grupo"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Usuario desde la respuesta de la pregunta"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Grupo a partir de respuesta de pregunta"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Tiempo para resolver"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuto"
 msgstr[1] "Minutos"
 msgstr[2] "Minutos"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hora"
 msgstr[1] "Horas"
 msgstr[2] "Horas"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Día"
 msgstr[1] "Días"
 msgstr[2] "Días"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Mes"
 msgstr[1] "Meses"
 msgstr[2] "Meses"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "ANS(TDR/TPR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Pregunta (TIR / TR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "AOS(TDR/TPR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgencia "
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Etiquetas de ticket"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Lugar"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Ubicación "
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "¡La descripción no puede estar vacía!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Observador"
 msgstr[1] "Observadores"
 msgstr[2] "Observadores"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Seguimiento por correo"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Usuario"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Grupo"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Proveedor"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Sí"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Agrupar desde el objeto"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Grupo técnico del objeto"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"Actualizar tablas a innoDB; ejecute php bin/console "
-"glpi:migration:myisam_to_innodb"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "El formulario ha sido creado"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Tu solicitud ha sido guardada"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2193,11 +2212,11 @@ msgstr ""
 "puedes ver sus respuestas en el siguiente "
 "enlace:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Un formulario GLPI necesita ser validado"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2207,11 +2226,11 @@ msgstr ""
 "elegido como el validador.\\nUsted puede acceder a él haciendo clic en este "
 "enlace:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Su formulario ha sido rechazado por el validador"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2224,7 +2243,7 @@ msgstr ""
 "modificarlo y volver a enviarlo haciendo clic en este "
 "enlace:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2232,11 +2251,11 @@ msgstr ""
 "Hola,\\nNos complace informarle de que su formulario ha sido aceptado por el"
 " validador.\\n Su solicitud será considerada pronto."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Tu formulario ha sido eliminado por un administrador"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2244,42 +2263,61 @@ msgstr ""
 "Hola,\\nLamentamos informarle de que su solicitud no puede ser considerada, "
 "y ha sido eliminado por un administrador."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator - Servicio de Sincronización del catálogo de asuntos"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Transferir"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Exportar"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Cancelar mi caso"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Antiguo"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Número de %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Resumen de asuntos"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2287,37 +2325,41 @@ msgstr ""
 "El mini tablero de Formcreator no se puede usar de forma predeterminada. "
 "Esta configuración ha sido ignorada."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr ""
 "No se encontró ningún formulario. Por favor, elija un formulario a "
 "continuación en su lugar."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "No se encontró ningún formulario."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "No se encontró ningún elemento de preguntas frecuentes."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "¿Está seguro de que quiere eliminar esta pregunta?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "¿Está seguro de que quiere eliminar esta sección?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Agregar traducciones"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Se ha producido un error al consultar formularios"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "¿Está seguro de que desea eliminar este objetivo?:"
 
@@ -2369,13 +2411,17 @@ msgstr "Acceso directo a la página principal"
 msgid "Default form in service catalog"
 msgstr "Formulario por defecto del catálogo de servicios"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "¿Eres un robot?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Enviar"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Condición para mostrar la sección"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/fr_CA.po
+++ b/locales/fr_CA.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
 "Last-Translator: Tiago Graça, 2022\n"
 "Language-Team: French (Canada) (https://www.transifex.com/teclib/teams/28042/fr_CA/)\n"
@@ -68,10 +68,9 @@ msgstr "Limite de profondeur du sous arbre"
 msgid "No limit"
 msgstr "Aucune limite"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Formulaire"
@@ -138,8 +137,8 @@ msgstr "Mauvaise requête pendant la suppression d'un acteur"
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Formcreator"
 
@@ -149,12 +148,12 @@ msgstr "Formcreator"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Liste des formulaires"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Le formulaire a été sauvegardé avec succès !"
 
@@ -170,7 +169,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s ajoute la réservation %2$s pour l'objet %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Catégorie"
@@ -185,30 +183,25 @@ msgstr "Voir tous"
 msgid "Please, describe your need here"
 msgstr "Merci de décrire votre besoin ici"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Zone de texte"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Un champ obligatoire est vide :"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "L'expression régulière n'est pas valide"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Utilisateur"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Utilisateur et formulaire"
 
@@ -245,166 +238,162 @@ msgstr ""
 "Pour respecter le système des entités de GLPI, \"Formulaire\" devrait-être "
 "sélectionné. Un autre choix brisera la restriction d'entité."
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "Taille limite LDAP dépassée"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "Sélection LDAP"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "Annuaire LDAP non défini !"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "Annuaire LDAP introuvable !"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Le format spécifique ne correspond pas : %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "Le texte est trop court (minimum %d caractères) : %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "Le texte est trop long (maximum %d caractères) : %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Texte"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Expression régulière"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Étendue"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Validation supplémentaire"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Boutons radio"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "La valeur du champ est obligatoire :"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Un champ obligatoire est vide: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Ce n'est pas un nombre entier : %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "Le nombre suivant doit être supérieur à %d : %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "Le nombre suivant doit être inférieur à %d : %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Entier"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Non défini"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgence"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Très haute"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Haute"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Moyen"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Basse"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Très basse"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Attention: Le plugin Tag est désactivé ou manquant"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Etiquette"
 msgstr[1] "Etiquettes"
 msgstr[2] "Etiquettes"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "Objet GLPI"
 msgstr[1] "Objets GLPI"
 msgstr[2] "Objets GLPI"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Heure"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Ce n'est pas un courriel valide: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Courriel"
@@ -415,42 +404,42 @@ msgstr[2] "Courriels"
 msgid "Select"
 msgstr "Sélection"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Date & heure"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Acteur"
 msgstr[1] "Acteurs"
 msgstr[2] "Acteurs"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Valeur invalide : %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Utilisateur non trouvé ou l'adresse courriel est invalide: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Aucun document joint"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Document joint"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Un champ requis est manquant : %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Fichier"
 
@@ -458,96 +447,95 @@ msgstr "Fichier"
 msgid "Multiselect"
 msgstr "Sélection multiple"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Attention: le plugin Champs additionnels est désactivé ou manquant"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Bloc"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Champ"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "Montrer"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Des champs numériques contiennent des valeurs non numériques"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Des champs URL contiennent des URL invalides"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Champs supplémentaires"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Boites à cocher"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "La question suivante nécessite au moins %d réponses"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "La question suivante n'accepte pas plus de %d réponses"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Intervalle minimum"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Intervalle maximum"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Type de requête"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Ce n'est pas un nombre: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Flottant"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Date"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Description"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Un champ de type description doit avoir une description :"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Champ caché"
 msgstr[1] "Champs cachés"
 msgstr[2] "Champs cachés"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Condition"
@@ -578,26 +566,26 @@ msgstr "Masqué par défaut, sauf si"
 msgid "Displayed unless"
 msgstr "Affiché par défaut, sauf si"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Échec de l'ajout ou de la modification de %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Impossible d'exporter un objet vide: %s"
@@ -614,38 +602,38 @@ msgstr "Importation"
 msgid "Import in progress"
 msgstr "Importation en cours"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Demande d'assistance"
 msgstr[1] "Demandes d'assistance"
 msgstr[2] "Demandes d'assistance"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr ""
 "Mettre à jour les informations sur les demandes à partir des tickets et des "
 "réponses aux formulaires"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Sondage de satisfaction expirée"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Nom"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -653,106 +641,96 @@ msgstr[0] "Type"
 msgstr[1] "Types"
 msgstr[2] "Types"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "État"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Date d'ouverture"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Dernière mise à jour"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entité"
 msgstr[1] "Entités"
 msgstr[2] "Entités"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Demandeur"
 msgstr[1] "Demandeurs"
 msgstr[2] "Demandeurs"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Approbateur de formulaire"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Commentaire"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Approbateur du ticket"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Technicien"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Groupe de techniciens"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Groupe approbateur de formulaire"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Non validé"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Refusé"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Tous"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Nouveau"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Assigné"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "En attente"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "À valider"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Résolu"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Fermé"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Catégorie de formulaire"
@@ -771,19 +749,19 @@ msgstr "Comme enfant de"
 msgid "The form as been saved"
 msgstr "Le formulaire a été sauvegardé"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Un formulaire est en attente de validation"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Le formulaire a été refusé"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Le formulaire a été accepté"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Le formulaire a été supprimé"
 
@@ -796,14 +774,11 @@ msgid "Form name"
 msgstr "Nom du formulaire"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Validateur"
-msgstr[1] "Validateurs"
-msgstr[2] "Validateurs"
+msgstr "Valideur"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Date de création"
 
@@ -828,15 +803,15 @@ msgid "Author"
 msgstr "Auteur"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Approbateur"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Auteur du formulaire"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Valideur du formulaire"
 
@@ -844,7 +819,7 @@ msgstr "Valideur du formulaire"
 msgid "Specific person"
 msgstr "Personne spécifique"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Personne depuis la question"
 
@@ -852,7 +827,7 @@ msgstr "Personne depuis la question"
 msgid "Specific group"
 msgstr "Groupe spécifique"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Groupe depuis la question"
 
@@ -868,15 +843,15 @@ msgstr "Tech groupe à partir d'un objet"
 msgid "Specific supplier"
 msgstr "Fournisseur spécifique"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Fournisseur depuis la question"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Acteurs depuis la question"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Superviseur de l'auteur du formulaire"
 
@@ -884,7 +859,7 @@ msgstr "Superviseur de l'auteur du formulaire"
 msgid "Observer"
 msgstr "Observateur"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Assigné à"
 
@@ -915,78 +890,87 @@ msgstr "Impossible de trouver le groupe: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Impossible de trouver le fournisseur: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Refusé"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Accepté"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Réponse au formulaire"
 msgstr[1] "Réponses au formulaire"
 msgstr[2] "Réponses au formulaire"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Imprimer ce formulaire"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Formulaire accepté par le valideur."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Formulaire sauvegardé avec succès"
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Enregistrer"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Obligatoire en cas de refus"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Refuser"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Editer les réponses"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Annuler l'édition"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Accepter"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Le commentaire de refus est obligatoire !"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Vous n'êtes pas le valideur pour ces réponses"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Données du formulaire"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Impossible de générer les cibles !"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Pas de test de Turing défini"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Vous avez échoué au test de Turing"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Vous devez définir un valideur !"
 
@@ -1001,15 +985,15 @@ msgid "Failed to delete this issue. An internal error occured."
 msgstr ""
 "Échec de la suppression de la demande. Une erreur interne est survenue."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Demander une assistance"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Mes demandes d'assistance"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consulter les flux RSS"
 
@@ -1043,16 +1027,16 @@ msgstr[0] "Langue de formulaire"
 msgstr[1] "Langues de formulaire"
 msgstr[2] "Langues de formulaire"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Traduction"
 msgstr[1] "Traductions"
 msgstr[2] "Traductions"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "Le nom ne doit pas être vide !"
 
@@ -1064,7 +1048,7 @@ msgstr "La langue doit être associée à un formulaire !"
 msgid "Add a translation"
 msgstr "Ajouter une traduction"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Mettre à jour une traduction"
 
@@ -1085,7 +1069,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Voulez-vous supprimer les éléments sélectionnés ?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -1102,32 +1086,39 @@ msgstr "Ajouter une nouvelle langue"
 msgid "Language"
 msgstr "Langue"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Aucun"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Validateur"
+msgstr[1] "Validateurs"
+msgstr[2] "Validateurs"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Requiert une validation ?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Non"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Enregistrer"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Validation"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Choisissez un valideur"
 
@@ -1138,14 +1129,14 @@ msgstr[0] "Problème cible"
 msgstr[1] "Problèmes cibles"
 msgstr[2] "Problèmes cibles"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Propriétés"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1154,29 +1145,29 @@ msgstr ""
 "Échec de l'ajout ou de la modification de %1$s %2$s : une question est "
 "manquante et est utilisée dans un paramètre de la cible"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Acteurs"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Titre de problème"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Contenu"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Impact"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Cause"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Symptôme"
 
@@ -1243,48 +1234,48 @@ msgstr ""
 msgid "Uniform height"
 msgstr ""
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Libre-service"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Mode d'assistance"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Mode des formulaires par défaut"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Ordre de tri"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Base de connaissance"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Recherche"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Tableau de bord de compteurs"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Message d'entête"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr ""
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr ""
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1292,26 +1283,26 @@ msgstr[0] "En-tête"
 msgstr[1] "En-têtes"
 msgstr[2] "En-têtes"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Afficher le champ de recherche"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Afficher l'entête"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Intervalle de question"
 msgstr[1] "Intervalles de question"
 msgstr[2] "Intervalles de question"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Intervalle minimum"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "Intervalle maximum"
 
@@ -1331,7 +1322,7 @@ msgstr "Droits restreints (profils)"
 msgid "Answers waiting for validation"
 msgstr "Réponses en attente de validation"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Import de formulaires"
 
@@ -1395,7 +1386,7 @@ msgstr[2] "Cibles"
 msgid "Actions"
 msgstr ""
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Ajouter une cible"
 
@@ -1411,125 +1402,125 @@ msgstr "propriétés"
 msgid "What are you looking for?"
 msgstr "Que recherchez-vous ?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Mes %1$d derniers formulaires (demandeur)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Aucun formulaire saisi pour le moment"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Tous mes formulaires (Demandeur)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Mes %1$d derniers formulaires (valideur)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Aucun formulaire en attente de validation"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Tous mes formulaires (Valideur)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "Impossible d'utiliser un nom vide pour les réponses aux formulaires. "
 "Maintien de la valeur précédente."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "La question %s n'est pas compatible avec les formulaires publics"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Duplication échouée"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Soumettre"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Formulaire dupliqué : %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Formulaire transféré : %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Retour"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Le téléversement de fichiers JSON n'est pas autorisé."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "vous pouvez utiliser les fichiers JSON dès maintenant"
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Créer"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Veuillez contacter votre administrateur GLPI."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Retour"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Le téléversement de fichiers JSON n'est pas activée"
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "Vous pouvez activer les fichiers JSON dès maintenant"
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Activer"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Envoyer"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "L'importation de formulaires est impossible, le fichier est vide"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Importation de formulaires impossible, le fichier semble corrompu"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr ""
 "Importation de formulaires impossible, le fichier a été généré avec une "
 "autre version"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1537,62 +1528,62 @@ msgstr ""
 "Le fichier ne spécifie pas la version de schéma. Il a probablement été "
 "généré avec une version antérieure à 2.10. Abandon."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Importation échouée de %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formulaires importés avec succès depuis %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr ""
 "Le formulaire %1$s existe déjà et se trouve dans une entité non modifiable."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "Vous n'avez pas le droit de modifier l'entité %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "L'entité %1$s est requise pour le formulaire %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Échec de création du type de fichiers JSON"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Type de document JSON introuvable"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Échec lors de la mise à jour du type de document JSON"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formulaires sans catégorie"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Aucun formulaire disponible"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Ajouter"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Type de cible non supporté."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1640,11 +1631,8 @@ msgstr "L'intitulé est obligatoire"
 msgid "Failed to find %1$s %2$s"
 msgstr "Impossible de trouver %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Question"
@@ -1680,48 +1668,48 @@ msgstr "Ce type de question requiert des paramètres"
 msgid "A parameter is missing for this question type"
 msgstr "Il manque un paramètre pour ce type de question"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Niveaux de service"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "Entente de niveau de service "
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "Entente sur les niveaux opérationnels"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Parc"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Assistance"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Gestion"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Outils"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notes"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "Flux RSS"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administration"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Plugin"
@@ -1850,119 +1838,119 @@ msgstr[0] "Relation de ticket composite"
 msgstr[1] "Relations de ticket composite"
 msgstr[2] "Relations de ticket composite"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Ticket cible"
 msgstr[1] "Tickets cibles"
 msgstr[2] "Tickets cibles"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Actif spécifique"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Égale à la réponse à la question"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Dernière réponse valide"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "Source depuis un gabarit ou défaut de l'utilisateur ou défaut de GLPI"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Par défaut ou à partir d'un modèle"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Type spécifique"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Titre du ticket"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Ajouter le message de validation en premier dans le suivi de ticket"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Ajouter un champ"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Gérer les champs"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Pas de champ géré"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Lier à un autre ticket"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Une autre destination de ce formulaire"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Un ticket existant"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Un ticket depuis une réponse à une question"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Effacer définitivement"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Type de lien invalide"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Type d'objet lié invalide"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "L'objet lié n'existe pas"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Échec de liaison de l'objet"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Votre formulaire a été accepté par le valideur"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Source de la demande"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Type"
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Éléments associés"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Élément"
 
@@ -1982,211 +1970,242 @@ msgstr "Formulaire non trouvé."
 msgid "Failed to add the translation."
 msgstr "L'ajout de la traduction a échoué."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Étiquettes depuis les questions"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Étiquettes spécifiques"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Étiquettes depuis les questions et spécifiques"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Étiquettes depuis les questions ou spécifiques"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "égale à la réponse de la question"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "calculée à partir de la date de création du ticket"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "calculée à partir de la réponse à la question"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "Entente de niveaux de service depuis le gabarit ou aucun"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "Entente de niveaux de service spécifique"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "Entente sur les niveaux opérationnels depuis le gabarit ou aucun"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "Entente sur les niveaux opérationnels spécifique"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgence à partir du gabarit ou Moyen"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Urgence spécifique"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Catégorie depuis le gabarit ou aucune"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Catégorie spécifique"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Lieu à partir d'un gabarit ou aucun"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Lieu spécifique"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Pas de validation"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Utilisateur ou groupe spécifique"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Utilisateur depuis une réponse à une question"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Groupe depuis la réponse à une question"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Temps de résolution"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minute"
 msgstr[1] "Minutes"
 msgstr[2] "Minutes"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Heure"
 msgstr[1] "Heures"
 msgstr[2] "Heures"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Jour"
 msgstr[1] "Jours"
 msgstr[2] "Jours"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Mois"
 msgstr[1] "Mois"
 msgstr[2] "Mois"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Question (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgence"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Étiquettes du ticket"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Étiquettes"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Lieu"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Lieu"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "La desciption ne doit pas être vide !"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Observateur"
 msgstr[1] "Observateurs"
 msgstr[2] "Observateurs"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Annuler"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Courriel de suivi"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Utilisateur"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Groupe"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Fournisseur"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Oui"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Groupe à partir de l'objet"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Tech groupe à partir de l'objet"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"Mettez à jour les tables vers InnoDB; exécutez php bin/console "
-"glpi:migration:myisam_to_innodb"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Un formulaire a été créé"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Votre demande a été sauvegardée avec succès !"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2197,11 +2216,11 @@ msgstr ""
 "support.\\\\nVous pouvez visualiser vos réponses à l'adresse suivante "
 ":\\\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Un formulaire GLPI est en attente de validation"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2211,11 +2230,11 @@ msgstr ""
 "choisi comme valideur.\\nVous pouvez accéder à celui-ci en cliquant sur le "
 "lien ci-dessous :\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Votre formulaire a été refusé par le valideur"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2227,7 +2246,7 @@ msgstr ""
 "toutefois modifier et renvoyer votre demande en cliquant sur le lien ci-"
 "dessous :\\\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2235,11 +2254,11 @@ msgstr ""
 "Bonjour,\\\\nVotre demande a été accepté par le valideur.\\\\nVotre demande "
 "sera traitée prochainement."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Votre formulaire a été supprimé par un administrateur"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2247,42 +2266,61 @@ msgstr ""
 "Bonjour,\\\\nVotre demande ne peut être traitée et a été supprimée par un "
 "administrateur."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formulaires - synchronisation des demandes du catalogue de service"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Transférer"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Exporter"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Annuler mon ticket"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr ""
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Nombre de %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Résulé des demandes d'assistance"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2290,35 +2328,39 @@ msgstr ""
 "Le mini tableau de bord de Formcreator n'est pas utilisable comme défaut. Ce"
 " paramètres a été ignoré."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr ""
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr ""
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr ""
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette question ?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette section ?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Ajouter des traductions"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Une erreur est survenue pendant la recherche de formulaires"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Êtes vous sûr de vouloir supprimer cette cible :"
 
@@ -2370,13 +2412,17 @@ msgstr "Accès direct depuis la page d'accueil"
 msgid "Default form in service catalog"
 msgstr "Formulaire par défaut dans le catalogue de service"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Êtes-vous un robot ?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Envoyer"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Condition pour afficher la section"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/fr_FR.po
+++ b/locales/fr_FR.po
@@ -6,11 +6,11 @@
 # Translators:
 # alexandre delaunay <delaunay.alexandre@gmail.com>, 2021
 # Tiago Graça, 2021
-# tguichard25 <t.guichard@mut25.fr>, 2021
-# 06c8e5f1ec78ded2ceb41498ec52b068, 2022
 # gerald antoniolli <deeper26@gmail.com>, 2022
 # Legastelois François <flegastelois@teclib.com>, 2022
 # Johan Cwiklinski, 2022
+# tguichard25 <t.guichard@mut25.fr>, 2022
+# 06c8e5f1ec78ded2ceb41498ec52b068, 2022
 # Thierry Bugier <tbugier@teclib.com>, 2022
 # 
 #, fuzzy
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
 "Last-Translator: Thierry Bugier <tbugier@teclib.com>, 2022\n"
 "Language-Team: French (France) (https://www.transifex.com/teclib/teams/28042/fr_FR/)\n"
@@ -73,10 +73,9 @@ msgstr "Limite de profondeur du sous arbre"
 msgid "No limit"
 msgstr "Aucune limite"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Formulaire"
@@ -143,8 +142,8 @@ msgstr "Mauvaise requête pendant la suppression d'un acteur"
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Formcreator"
 
@@ -154,12 +153,12 @@ msgstr "Formcreator"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Liste des formulaires"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Le formulaire a été sauvegardé avec succès !"
 
@@ -175,7 +174,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s ajoute la réservation %2$s pour l'objet %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Catégorie"
@@ -190,30 +188,25 @@ msgstr "Voir tous"
 msgid "Please, describe your need here"
 msgstr "Merci de décrire votre besoin ici"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Zone de texte"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Un champ obligatoire est vide :"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "L'expression régulière n'est pas valide"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Utilisateur"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Utilisateur et formulaire"
 
@@ -250,166 +243,162 @@ msgstr ""
 "Pour respecter le système des entités de GLPI, \"Formulaire\" devrait-être "
 "sélectionné. Un autre choix cassera la restriction d'entité."
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "Taille limite LDAP dépassée"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "Sélection LDAP"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "Annuaire LDAP non défini !"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "Annuaire LDAP introuvable !"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Le format spécifique ne correspond pas : %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "Le texte est trop court (minimum %d caractères) : %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "Le texte est trop long (maximum %d caractères) : %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Texte"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Expression régulière"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Taille"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Validation supplémentaire"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Boutons radio"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "La valeur du champ est obligatoire :"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Un champ obligatoire est vide: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Ce n'est pas un nombre entier : %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "Le nombre suivant doit être supérieur à %d : %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "Le nombre suivant doit être inférieur à %d : %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Entier"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Non défini"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "Adresse IP"
 msgstr[1] "Adresses IP"
 msgstr[2] "Adresses IP"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgence"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Très haute"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Haute"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Moyen"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Basse"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Très basse"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Attention: Le plugin Tag est désactivé ou manquant"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Etiquette"
 msgstr[1] "Etiquettes"
 msgstr[2] "Etiquettes"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "Objet GLPI"
 msgstr[1] "Objets GLPI"
 msgstr[2] "Objets GLPI"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Nom d'hôte"
 msgstr[1] "Noms d'hôtes"
 msgstr[2] "Noms d'hôtes"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Heure"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Ce n'est pas un email valide: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Adresse email"
@@ -420,42 +409,42 @@ msgstr[2] "Adresses email"
 msgid "Select"
 msgstr "Sélection"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Date & heure"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Acteur"
 msgstr[1] "Acteurs"
 msgstr[2] "Acteurs"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Valeur invalide : %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Utilisateur non trouvé ou adresse e-mail non valide:%s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Pas de document rattaché"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Document joint"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Un champ requis est manquant : %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Fichier"
 
@@ -463,96 +452,95 @@ msgstr "Fichier"
 msgid "Multiselect"
 msgstr "Sélection multiple"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Attention: le plugin Champs additionnels est désactivé ou manquant"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Bloc"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Champ"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "Montrer"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "Le type de champ '%1$s' n'est pas encore implémenté !"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Des champs numériques contiennent des valeurs non numériques"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Des champs URL contiennent des URL invalides"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Champs supplémentaires"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Boites à cocher"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "La question suivante nécessite au moins %d réponses"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "La question suivante n'accepte pas plus de %d réponses"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Intervalle minimum"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Intervalle maximum"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Type de demande"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Ce n'est pas un nombre: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Flottant"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Date"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Description"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Un champ de type description doit avoir une description :"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Champ caché"
 msgstr[1] "Champs cachés"
 msgstr[2] "Champs cachés"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Condition"
@@ -583,26 +571,26 @@ msgstr "Masqué par défaut, sauf si"
 msgid "Displayed unless"
 msgstr "Affiché par défaut, sauf si"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Échec à l'ajout ou la modification de %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Impossible d'exporter un objet vide: %s"
@@ -619,38 +607,38 @@ msgstr "Importation"
 msgid "Import in progress"
 msgstr "Import en cours"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Demande d'assistance"
 msgstr[1] "Demandes d'assistance"
 msgstr[2] "Demandes d'assistance"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr ""
 "Mettre à jour les informations sur les demandes à partir des tickets et des "
 "réponses aux formulaires"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Enquête de satisfaction expirée"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Nom"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -658,106 +646,96 @@ msgstr[0] "Type"
 msgstr[1] "Types"
 msgstr[2] "Types"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Statut"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Date d'ouverture"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Dernière mise à jour"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entité"
 msgstr[1] "Entités"
 msgstr[2] "Entités"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Demandeur"
 msgstr[1] "Demandeurs"
 msgstr[2] "Demandeurs"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Validateur de formulaire"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Commentaire"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Valideur du ticket"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Technicien"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Groupe de techniciens"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Groupe validateur de formulaire"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Non validé"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Refusé"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Tous"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Nouveau"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Assigné"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "En attente"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "À valider"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Résolu"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Fermé"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Catégorie de formulaire"
@@ -776,19 +754,19 @@ msgstr "Comme enfant de"
 msgid "The form as been saved"
 msgstr "Le formulaire a été sauvegardé"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Un formulaire est en attente de validation"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Le formulaire a été refusé"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Le formulaire a été accepté"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Le formulaire a été supprimé"
 
@@ -801,14 +779,11 @@ msgid "Form name"
 msgstr "Nom du formulaire"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Validateur"
-msgstr[1] "Validateurs"
-msgstr[2] "Validateurs"
+msgstr "Valideur"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Date de création"
 
@@ -833,15 +808,15 @@ msgid "Author"
 msgstr "Auteur"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Approbateur"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Auteur du formulaire"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Valideur du formulaire"
 
@@ -849,7 +824,7 @@ msgstr "Valideur du formulaire"
 msgid "Specific person"
 msgstr "Personne spécifique"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Personne depuis la question"
 
@@ -857,7 +832,7 @@ msgstr "Personne depuis la question"
 msgid "Specific group"
 msgstr "Groupe spécifique"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Groupe depuis la question"
 
@@ -873,15 +848,15 @@ msgstr "Tech groupe à partir d'un objet"
 msgid "Specific supplier"
 msgstr "Fournisseur spécifique"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Fournisseur depuis la question"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Acteurs depuis la question"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Superviseur de l'auteur du formulaire"
 
@@ -889,7 +864,7 @@ msgstr "Superviseur de l'auteur du formulaire"
 msgid "Observer"
 msgstr "Observateur"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Assigné à"
 
@@ -920,78 +895,87 @@ msgstr "Impossible de trouver le groupe: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Impossible de trouver le fournisseur: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Refusé"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Accepté"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Réponse au formulaire"
 msgstr[1] "Réponses au formulaire"
 msgstr[2] "Réponses au formulaire"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Imprimer ce formulaire"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Formulaire accepté par le valideur."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Formulaire sauvegardé avec succès"
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Enregistrer"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Obligatoire en cas de refus"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Refuser"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Editer les réponses"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Annuler l'édition"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Accepter"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Le commentaire de refus est obligatoire !"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Vous n'êtes pas validateur pour ces réponses"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr "Élément ajouté avec succès : %1$s (%2$s : %3$s)"
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Données du formulaire"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Impossible de générer les destinations !"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Pas de test de Turing défini"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Vous avez échoué au test de Turing"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Vous devez définir un valideur !"
 
@@ -1006,15 +990,15 @@ msgid "Failed to delete this issue. An internal error occured."
 msgstr ""
 "Échec à la suppression de la demande. Une erreur interne est survenue."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Demander une assistance"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Mes demandes d'assistance"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consulter les flux RSS"
 
@@ -1048,16 +1032,16 @@ msgstr[0] "Langue de formulaire"
 msgstr[1] "Langues de formulaire"
 msgstr[2] "Langues de formulaire"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Traduction"
 msgstr[1] "Traductions"
 msgstr[2] "Traductions"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "Le nom ne doit pas être vide !"
 
@@ -1069,7 +1053,7 @@ msgstr "La langue doit être associée à un formulaire !"
 msgid "Add a translation"
 msgstr "Ajouter une traduction"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Mettre à jour une traduction"
 
@@ -1090,7 +1074,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Voulez-vous supprimer les éléments sélectionnés ?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -1107,32 +1091,39 @@ msgstr "Ajouter une nouvelle langue"
 msgid "Language"
 msgstr "Langage"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Aucun"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Validateur"
+msgstr[1] "Validateurs"
+msgstr[2] "Validateurs"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Requiert une validation ?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Non"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Enregistrer"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Validation"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Choisissez un valideur"
 
@@ -1143,14 +1134,14 @@ msgstr[0] "Problème cible"
 msgstr[1] "Problèmes cibles"
 msgstr[2] "Problèmes cibles"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Propriétés"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1159,29 +1150,29 @@ msgstr ""
 "Echec à l'ajout ou la modification de %1$s %2$s : une question est manquante"
 " et est utilisée dans un paramètre de la  cible"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Acteurs"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Titre de problème"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Contenu"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Impact"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Cause"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Symptôme"
 
@@ -1248,48 +1239,48 @@ msgstr "Hauteur variable"
 msgid "Uniform height"
 msgstr "Hauteur uniforme"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Assistance"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Mode d'assistance"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Mode des formulaires par défaut"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Ordre de tri"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Base de connaissance"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Recherche"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Tableau de bord de compteurs"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Message d'entête"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Recherche de demande d'assistance"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Apparence des tuiles"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1297,26 +1288,26 @@ msgstr[0] "En-tête"
 msgstr[1] "En-têtes"
 msgstr[2] "En-têtes"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Afficher le champ de recherche"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Afficher l'entête"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Intervalle de question"
 msgstr[1] "Intervalles de question"
 msgstr[2] "Intervalles de question"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Intervalle minimum"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "Intervalle maximum"
 
@@ -1336,7 +1327,7 @@ msgstr "Droits restreints"
 msgid "Answers waiting for validation"
 msgstr "Réponses en attente de validation"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Import de formulaires"
 
@@ -1400,7 +1391,7 @@ msgstr[2] "Cibles"
 msgid "Actions"
 msgstr "Actions"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Ajouter une cible"
 
@@ -1416,125 +1407,125 @@ msgstr "propriétés"
 msgid "What are you looking for?"
 msgstr "Que recherchez-vous ?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Mes %1$d derniers formulaires (demandeur)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Aucun formulaire saisi pour le moment"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Tous mes formulaires (Demandeur)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Mes %1$d derniers formulaires (validateur)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Aucun formulaire en attente de validation"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Tous mes formulaires (Valideur)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "Impossible d'utiliser un nom vide pour les réponses aux formulaires. "
 "Conservation de la valeur précédente."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "La question %s n'est pas compatible avec les formulaires publics"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Erreur de duplication"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Copie"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Soumettre"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Formulaire dupliqué : %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Formulaire transféré : %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Retour"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "La mise à jour de JSON n'est pas autorisé."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "vous pouvez utiliser les fichiers json dès maintenant"
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Créer"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Veuillez contacter votre administrateur GLPI."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Retour"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "La mise à jour de JSON n'est pas disponible"
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "vous pouvez activer JSON dès maintenant"
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Activer"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Envoyer"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Importation du formulaire impossible, le fichier est vide"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Importation du formulaire impossible, le fichier semble corrompu"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr ""
 "Importation du formulaire impossible, le fichier a été généré avec une autre"
 " version"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1542,61 +1533,61 @@ msgstr ""
 "Le fichier le spécifie pas de version de schéma. Il a probablement été "
 "généré avec une version antérieure à 2.10. Abandon."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Echec d'import de %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formulaires importés avec succès depuis %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "Le formulaire %1$s existe déjà et n'est pas modifiable"
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "Vous n'avez pas le droit de modifier l'entité %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "L'entité %1$s est requise pour le formulaire %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Échec de création du type de fichiers JSON"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Type de document JSON introuvable"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Echec lors de la mise à jour du type de document JSON"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formulaires sans catégorie"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Aucun formulaire disponible"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Ajouter"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Type de cible non supporté."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1644,11 +1635,8 @@ msgstr "L'intitulé est obligatoire"
 msgid "Failed to find %1$s %2$s"
 msgstr "Impossible de trouver %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Question"
@@ -1684,48 +1672,48 @@ msgstr "Ce type de question requiert des paramètres"
 msgid "A parameter is missing for this question type"
 msgstr "Il manque un paramètre pour ce type de question"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Niveaux de service"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Parc"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Assistance"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Gestion"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Outils"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notes"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "Flux RSS"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administration"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Plugin"
@@ -1854,119 +1842,119 @@ msgstr[0] "Relation de ticket composite"
 msgstr[1] "Relations de ticket composite"
 msgstr[2] "Relations de ticket composite"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Ticket cible"
 msgstr[1] "Tickets cibles"
 msgstr[2] "Tickets cibles"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Equipement spécifique "
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Égale à la réponse à la question"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Dernière réponse valide"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "Source depuis un gabarit ou défaut de l'utilisateur ou défaut de GLPI"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Par défaut ou à partir d'un modèle"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Type spécifique"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Titre du ticket"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Ajouter le message de validation en premier suivi du ticket"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Ajouter un champ"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Gérer les champs"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Pas de champ géré"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Lier à un autre ticket"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Une autre destination de ce formulaire"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Un ticket existant"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Un ticket depuis une réponse à une question"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Effacer définitivement"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Type de lien invalide"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Type d'objet lié invalide"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "L'objet lié n'existe pas"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Echec de liaison de l'objet"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Votre formulaire a été accepté par le valideur"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Source de la demande"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Type"
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Eléments associés"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Objet"
 
@@ -1986,211 +1974,251 @@ msgstr "Formulaire non trouvé."
 msgid "Failed to add the translation."
 msgstr "L'ajout de la traduction a échoué."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Étiquettes depuis les questions"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Étiquettes spécifiques"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Étiquettes depuis les questions et spécifiques"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Étiquettes depuis les questions ou spécifiques"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "égale à la réponse à la question"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "calculée à partir de la date de création du ticket"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "calculée à partir de la réponse à la question"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "SLA depuis le gabarit ou aucun"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "SLA spécifique"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "OLA depuis le gabarit ou aucun"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "OLA spécifique"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgence à partir du gabarit ou Moyen"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Urgence spécifique"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Catégorie depuis le gabarit ou aucune"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Catégorie spécifique"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Lieu à partir d'un gabarit ou aucun"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Lieu spécifique"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Pas de validation"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Utilisateur ou groupe spécifique"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Utilisateur depuis une réponse à une question"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Groupe depuis la réponse à une question"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Temps de résolution"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minute"
 msgstr[1] "Minutes"
 msgstr[2] "Minutes"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Heure"
 msgstr[1] "Heures"
 msgstr[2] "Heures"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Jour"
 msgstr[1] "Jours"
 msgstr[2] "Jours"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Mois"
 msgstr[1] "Mois"
 msgstr[2] "Mois"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Question (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgence"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Étiquettes du ticket"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Etiquettes"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Lieu"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Lieu"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "La desciption ne doit pas être vide !"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Observateur"
 msgstr[1] "Observateurs"
 msgstr[2] "Observateurs"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Annuler"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Email de suivi"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Utilisateur"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Groupe"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Fournisseur"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Oui"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Groupe à partir de l'objet"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Tech groupe à partir de l'objet"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
-msgstr ""
-"Mettez à jour les tables vers InnoDB; exécutez php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
+msgstr "Mettez à jour les tables en InnoDB; exécutez %s"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+"Le schéma de la base de données n'est pas conforme avec le Formcreator "
+"installé %s. Pour visualiser le journal, exécutez la commande %s"
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+"Pour ignorer les incohérences et faire une mise à jour forcée exécutez %s"
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+"La mise à jour depuis une version antérieure à 2.5.0 n'est plus prise en "
+"charge. Veuillez mettre à jour vers GLPI 9.5.7, mettre à jour Formcreator "
+"vers la version 2.12.5, puis mettre à jour à nouveau vers GLPI 10 ou plus "
+"récent et Formcreator 2.13 ou plus récent."
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+"Le schéma de la base de données n'est pas conforme avec le Formcreator "
+"installé %s. Pour visualiser le journal, exécutez la commande %s"
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr "Les tables du plugin ont passé le test d'intégrité du schéma."
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Une demande a été faite à partir d'un formulaire"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Votre demande a été sauvegardée avec succès !"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2201,11 +2229,11 @@ msgstr ""
 "support.\\\\nVous pouvez visualiser vos réponses à l'adresse suivante "
 ":\\\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Un formulaire GLPI est en attente de validation"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2215,11 +2243,11 @@ msgstr ""
 "choisi comme valideur.\\nVous pouvez accéder à celui-ci en cliquant sur le "
 "lien ci-dessous :\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Votre formulaire a été refusé par le valideur"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2232,7 +2260,7 @@ msgstr ""
 "modifier et renvoyer votre demande en cliquant sur le lien ci-dessous "
 ":\\\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2240,11 +2268,11 @@ msgstr ""
 "Bonjour,\\\\nNous avons le plaisir de vous informer que votre demande a été "
 "accepté par le valideur.\\\\nVotre demande vas être traitées prochainement."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Votre formulaire a été supprimé par un administrateur"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2252,42 +2280,61 @@ msgstr ""
 "Bonjour,\\\\nNous sommes au regret de vous informer que votre demande ne "
 "peut être traitée et a été supprimée par un administrateur."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formulaires - synchronisation des demandes du catalogue de service"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr "Échec pendant le test d'intégrité des tables !"
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr "Le schéma de la table diffère pour la  table \"%s\"."
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr "La table \"%s\" est manquante."
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr "La table inconnue \"%s\" a été trouvée dans la base de données."
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Copie"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Transférer"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "porter"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Annuler mon ticket"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Ancien"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Nombre de %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Résulé des demandes d'assistance"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2295,37 +2342,42 @@ msgstr ""
 "Le mini tableau de bord de Formcreator n'est pas utilisable comme défaut. Ce"
 " paramètres a été ignoré."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr ""
 "Aucun formulaire trouvé. Veuillez choisir un formulaire ci dessous à la "
 "place."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "Aucun formulaire trouvé."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "Aucun élément de FAQ n'a été trouvé."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette question ?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette section ?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Ajouter des traductions"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Une erreur est survenue pendant la recherche de formulaires"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+"Une erreur interne est survenue. Veuillez en informer l'administrateur."
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Êtes vous sûr de vouloir supprimer cette cible :"
 
@@ -2377,13 +2429,17 @@ msgstr "Accès direct depuis la page d'accueil"
 msgid "Default form in service catalog"
 msgstr "Formulaire par défaut dans le catalogue de service"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Êtes-vous un robot ?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "EnvoyerEnvoyer"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Condition pour afficher la section"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/glpi.pot
+++ b/locales/glpi.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,10 +63,9 @@ msgstr ""
 msgid "No limit"
 msgstr ""
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] ""
@@ -132,8 +131,8 @@ msgstr ""
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr ""
 
@@ -143,12 +142,12 @@ msgstr ""
 msgid "%1$s = %2$s"
 msgstr ""
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr ""
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr ""
 
@@ -164,7 +163,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr ""
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] ""
@@ -178,30 +176,25 @@ msgstr ""
 msgid "Please, describe your need here"
 msgstr ""
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr ""
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr ""
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr ""
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr ""
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr ""
 
@@ -235,162 +228,158 @@ msgid ""
 "settings will break the entity restrictions"
 msgstr ""
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr ""
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr ""
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr ""
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr ""
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr ""
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr ""
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr ""
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr ""
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr ""
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr ""
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr ""
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr ""
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr ""
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr ""
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr ""
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr ""
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr ""
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr ""
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr ""
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
-msgstr ""
-
-#: inc/field/urgencyfield.class.php:118
-msgctxt "urgency"
-msgid "Very high"
 msgstr ""
 
 #: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
-msgid "High"
+msgid "Very high"
 msgstr ""
 
 #: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
-msgid "Medium"
+msgid "High"
 msgstr ""
 
 #: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
-msgid "Low"
+msgid "Medium"
 msgstr ""
 
 #: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
+msgid "Low"
+msgstr ""
+
+#: inc/field/urgencyfield.class.php:123
+msgctxt "urgency"
 msgid "Very low"
 msgstr ""
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr ""
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr ""
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr ""
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] ""
@@ -400,41 +389,41 @@ msgstr[1] ""
 msgid "Select"
 msgstr ""
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr ""
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr ""
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr ""
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr ""
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr ""
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr ""
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr ""
 
@@ -442,95 +431,94 @@ msgstr ""
 msgid "Multiselect"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr ""
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr ""
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr ""
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr ""
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr ""
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr ""
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr ""
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr ""
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr ""
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr ""
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr ""
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr ""
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] ""
@@ -560,26 +548,26 @@ msgstr ""
 msgid "Displayed unless"
 msgstr ""
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr ""
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr ""
@@ -596,139 +584,129 @@ msgstr ""
 msgid "Import in progress"
 msgstr ""
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr ""
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr ""
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr ""
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr ""
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr ""
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr ""
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr ""
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr ""
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr ""
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr ""
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr ""
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr ""
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr ""
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr ""
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr ""
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr ""
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr ""
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr ""
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr ""
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr ""
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr ""
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr ""
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr ""
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] ""
@@ -746,19 +724,19 @@ msgstr ""
 msgid "The form as been saved"
 msgstr ""
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr ""
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr ""
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr ""
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr ""
 
@@ -771,13 +749,11 @@ msgid "Form name"
 msgstr ""
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] ""
-msgstr[1] ""
+msgstr ""
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr ""
 
@@ -802,15 +778,15 @@ msgid "Author"
 msgstr ""
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr ""
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr ""
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr ""
 
@@ -818,7 +794,7 @@ msgstr ""
 msgid "Specific person"
 msgstr ""
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr ""
 
@@ -826,7 +802,7 @@ msgstr ""
 msgid "Specific group"
 msgstr ""
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr ""
 
@@ -842,15 +818,15 @@ msgstr ""
 msgid "Specific supplier"
 msgstr ""
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr ""
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr ""
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr ""
 
@@ -858,7 +834,7 @@ msgstr ""
 msgid "Observer"
 msgstr ""
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr ""
 
@@ -888,77 +864,86 @@ msgstr ""
 msgid "Failed to find a supplier: %1$s"
 msgstr ""
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr ""
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr ""
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr ""
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr ""
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr ""
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr ""
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr ""
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr ""
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr ""
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr ""
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr ""
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr ""
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr ""
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr ""
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr ""
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr ""
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr ""
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr ""
 
@@ -970,15 +955,15 @@ msgstr ""
 msgid "Failed to delete this issue. An internal error occured."
 msgstr ""
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr ""
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr ""
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr ""
 
@@ -1010,15 +995,15 @@ msgid_plural "Form languages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr ""
 
@@ -1030,7 +1015,7 @@ msgstr ""
 msgid "Add a translation"
 msgstr ""
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr ""
 
@@ -1051,7 +1036,7 @@ msgid "Do you want to delete the selected items?"
 msgstr ""
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr ""
 
@@ -1068,32 +1053,38 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr ""
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] ""
+msgstr[1] ""
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr ""
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr ""
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr ""
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr ""
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr ""
 
@@ -1103,43 +1094,43 @@ msgid_plural "Target problems"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr ""
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
 "a parameter of the target"
 msgstr ""
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr ""
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr ""
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr ""
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr ""
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr ""
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr ""
 
@@ -1206,73 +1197,73 @@ msgstr ""
 msgid "Uniform height"
 msgstr ""
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr ""
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr ""
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr ""
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr ""
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr ""
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr ""
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr ""
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr ""
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr ""
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr ""
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr ""
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr ""
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr ""
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr ""
 
@@ -1292,7 +1283,7 @@ msgstr ""
 msgid "Answers waiting for validation"
 msgstr ""
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr ""
 
@@ -1355,7 +1346,7 @@ msgstr[1] ""
 msgid "Actions"
 msgstr ""
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr ""
 
@@ -1371,181 +1362,181 @@ msgstr ""
 msgid "What are you looking for?"
 msgstr ""
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr ""
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr ""
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr ""
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr ""
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr ""
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr ""
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr ""
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr ""
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr ""
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr ""
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr ""
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr ""
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr ""
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr ""
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr ""
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr ""
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr ""
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr ""
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr ""
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr ""
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr ""
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr ""
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr ""
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr ""
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr ""
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
 msgstr ""
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr ""
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr ""
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr ""
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr ""
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr ""
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr ""
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr ""
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr ""
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr ""
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr ""
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr ""
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr ""
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr ""
 
@@ -1591,11 +1582,8 @@ msgstr ""
 msgid "Failed to find %1$s %2$s"
 msgstr ""
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] ""
@@ -1630,48 +1618,48 @@ msgstr ""
 msgid "A parameter is missing for this question type"
 msgstr ""
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr ""
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr ""
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr ""
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr ""
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr ""
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr ""
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr ""
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr ""
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr ""
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr ""
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] ""
@@ -1795,118 +1783,118 @@ msgid_plural "Composite ticket relations"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr ""
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr ""
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr ""
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr ""
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr ""
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr ""
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr ""
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr ""
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr ""
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr ""
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr ""
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr ""
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr ""
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr ""
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr ""
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr ""
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr ""
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr ""
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr ""
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr ""
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr ""
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr ""
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr ""
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr ""
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr ""
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr ""
 
@@ -1926,318 +1914,375 @@ msgstr ""
 msgid "Failed to add the translation."
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr ""
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr ""
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade "
+"to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to "
+"GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr ""
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr ""
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
 "see your answers onto the following link:\\n##formcreator.validation_link##"
 msgstr ""
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr ""
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this link:\\n##formcreator."
 "validation_link##"
 msgstr ""
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr ""
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
-"validator for the reason below:\\n##formcreator.validation_comment##\\n"
-"\\nYou can still modify and resubmit it by clicking onto this link:"
-"\\n##formcreator.validation_link##"
+"validator for the reason below:\\n##formcreator."
+"validation_comment##\\n\\nYou can still modify and resubmit it by clicking "
+"onto this link:\\n##formcreator.validation_link##"
 msgstr ""
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
 msgstr ""
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr ""
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
 msgstr ""
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr ""
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr ""
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr ""
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr ""
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr ""
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr ""
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr ""
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr ""
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
 msgstr ""
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr ""
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr ""
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr ""
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr ""
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr ""
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr ""
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr ""
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr ""
 
@@ -2288,12 +2333,16 @@ msgstr ""
 msgid "Default form in service catalog"
 msgstr ""
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr ""
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
+msgstr ""
+
+#: entrée standard:64
+msgid "Condition to show the section"
 msgstr ""
 
 #: entrée standard:40

--- a/locales/hr_HR.po
+++ b/locales/hr_HR.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>, 2022\n"
 "Language-Team: Croatian (Croatia) (https://www.transifex.com/teclib/teams/28042/hr_HR/)\n"
@@ -67,10 +67,9 @@ msgstr "Ograniči dubinu podstabla"
 msgid "No limit"
 msgstr "Bez ograničenja"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Obrazac"
@@ -137,8 +136,8 @@ msgstr "Neispravan zahtjev tijekom brisanja učesnika."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Stvaratelj obrasca"
 
@@ -148,12 +147,12 @@ msgstr "Stvaratelj obrasca"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Popis obrazaca"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Obrazac je uspješno spremljen!"
 
@@ -169,7 +168,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s dodaje rezervaciju %2$s za predmet %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Kategorija"
@@ -184,30 +182,25 @@ msgstr "Pogledaj sve"
 msgid "Please, describe your need here"
 msgstr "Ovdje opiši tvoju potrebu"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Tekstualno područje"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Jedno obavezno polje je prazno:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "Regularni izraz nije ispravan"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Korisnik"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Korisnik i obrazac"
 
@@ -244,166 +237,162 @@ msgstr ""
 "Kako bi se poštivao sustav GLPI entiteta, trebao bi se odabrati „Obrazac”. "
 "Druge postavke će prekinuti ograničenja entiteta"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "Ograničenje veličine LDAP-a prekoračena"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP odabir"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "LDAP direktorij nije definiran!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "LDAP direktorij nije pronađen!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Određeni format se ne poklapa: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "Tekst je prekratak (najmanje %d znakova): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "Tekst je predug (najviše %d znakova): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Tekst"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Regularan izraz"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Raspon"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Dodatna potvrda"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Izborni gumbovi"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "Vrijednost polja je obavezna:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Jedno obavezno polje je prazno: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Ovo nije cijeli broj: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "Sljedeći broj mora biti veći od %d: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "Sljedeći broj mora biti manji od %d: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Cijeli broj"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Neodređeno"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "IP adresa"
 msgstr[1] "IP adrese"
 msgstr[2] "IP adrese"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Hitnost"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Vrlo visoka"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Visoka"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Srednje"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Niska"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Vrlo niska"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Upozorenje: Oznaka je deaktivirana ili nedostaje"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Oznaka"
 msgstr[1] "Oznake"
 msgstr[2] "Oznake"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "GLPI objekt"
 msgstr[1] "GLPI objekti"
 msgstr[2] "GLPI objekti"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Ime računala"
 msgstr[1] "Imena računala"
 msgstr[2] "Imena računala"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Vrijeme"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Ovo nije valjana e-mail adresa: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "E-mail"
@@ -414,42 +403,42 @@ msgstr[2] "E-mailovi"
 msgid "Select"
 msgstr "Odaberi"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Datum i vrijeme"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Učesnik"
 msgstr[1] "Učesnici"
 msgstr[2] "Učesnici"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Neispravna vrijednost: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Korisnik nije pronađen ili je e-adresa nevaljana: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Nema priloženog dokumenta"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Priloženi dokument"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Nedostaje jedna obavezna datoteka: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Datoteka"
 
@@ -457,96 +446,95 @@ msgstr "Datoteka"
 msgid "Multiselect"
 msgstr "Višestruki odabir"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Upozorenje: Dodatak za dodatna polja je deaktiviran ili nedostaje"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Blok"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Polje"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "prikaži"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Neka numerička polja sadrže ne numeričke vrijednosti"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Neka URL polja sadrže neispravne poveznice"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Dodatna polja"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Potvrdni okviri"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "Sljedeće pitanje treba barem%d odgovora"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "Sljedeće pitanje ne prihvaća više od %d odgovora"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Minimum raspona"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Maksimum raspona"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Vrsta zahtjeva"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Ovo nije broj: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Plutajući"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Datum"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Opis"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Polje opisa bi trebalo imati opis:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Skriveno polje"
 msgstr[1] "Skrivena polja"
 msgstr[2] "Skrivena polja"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Uvjet"
@@ -577,26 +565,26 @@ msgstr "Skriveno, ukoliko"
 msgid "Displayed unless"
 msgstr "Prikazano, ukoliko"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Neuspjelo dodavanje ili aktualiziranje: %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Nije moguće izvesti prazni objekt: %s"
@@ -613,36 +601,36 @@ msgstr "Uvoz u tijeku"
 msgid "Import in progress"
 msgstr "Uvoz u tijeku"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Problem"
 msgstr[1] "Problemi"
 msgstr[2] "Problemi"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Aktualiziraj podatke problema iz naloga i odgovora na obrascu"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Anketa o zadovoljstvu je istekla"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Ime"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -650,106 +638,96 @@ msgstr[0] "Vrsta"
 msgstr[1] "Vrste"
 msgstr[2] "Vrste"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Stanje"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Datum otvaranja"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Zadnje aktualiziranje"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entitet"
 msgstr[1] "Entiteti"
 msgstr[2] "Entiteti"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Podnositelj"
 msgstr[1] "Podnositelji"
 msgstr[2] "Podnositelji"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Odobravatelj obrazaca"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Komentar"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Odobravatelj naloga"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Tehničar"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Grupa tehničara"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Grupa odobravatelja obrazaca"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Nije potvrđeno"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Odbijeno"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Sve"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Novi"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Dodijeljeni"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Na čekanju"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "Za potvrdu"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Riješeni"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Zatvoreni"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Kategorija obrazaca"
@@ -768,19 +746,19 @@ msgstr "Kao podređeni element od"
 msgid "The form as been saved"
 msgstr "Obrazac kao što je spremljen"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Potrebno je potvrditi jedan obrazac"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Obrazac je odbijen"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Obrazac je prihvaćen"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Obrazac je izbrisan"
 
@@ -793,14 +771,11 @@ msgid "Form name"
 msgstr "Ime obrasca"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Potvrditelj"
-msgstr[1] "Potvrditelji"
-msgstr[2] "Potvrditelji"
+msgstr "Potvrditelj"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Datum izrade"
 
@@ -825,15 +800,15 @@ msgid "Author"
 msgstr "Autor"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Odobravatelj"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Autor obrasca"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Potvrditelj obrasca"
 
@@ -841,7 +816,7 @@ msgstr "Potvrditelj obrasca"
 msgid "Specific person"
 msgstr "Određena osoba"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Osoba iz pitanja"
 
@@ -849,7 +824,7 @@ msgstr "Osoba iz pitanja"
 msgid "Specific group"
 msgstr "Određena grupa"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Grupa iz pitanja"
 
@@ -865,15 +840,15 @@ msgstr "Tehnička grupa iz jednog objekta"
 msgid "Specific supplier"
 msgstr "Određeni dobavljač"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Dobavljač iz pitanja"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Učesnici iz pitanja"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Obrazac autorskog nadzornika"
 
@@ -881,7 +856,7 @@ msgstr "Obrazac autorskog nadzornika"
 msgid "Observer"
 msgstr "Nadglednik"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Dodijeljeno za"
 
@@ -912,78 +887,87 @@ msgstr "Neuspjelo pronalaženje grupe: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Neuspjelo pronalaženje dobavljača: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Odbijeno"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Prihvaćeno"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Odgovor u obrascu"
 msgstr[1] "Odgovori u obrascu"
 msgstr[2] "Odgovori u obrascu"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Ispiši ovaj obrazac"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Obrazac prihvaćen od potvrditelja."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Obrazac je uspješno spremljen."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Spremi"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Obavezno, ako je odbijeno"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Odbij"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Uredi odgovor"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Otkaži izdanje"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Prihvati"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Potreban je komentar za odbijanje!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Nisi potvrditelj ovih odgovora"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Podaci obrasca"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Nije moguće generirati ciljeve!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Nije postavljen nijedan Turingov test"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Turingov test nije položen"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Moraš odabrati potvrditelja!"
 
@@ -995,15 +979,15 @@ msgstr "Ovaj se problem ne može izbrisati. Možda je uzet u obzir."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Neuspjelo brisanje problema. Dogodila se interna greška."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Zatraži pomoć"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Moji zahtjevi za pomoć"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Pregledaj feedove"
 
@@ -1037,16 +1021,16 @@ msgstr[0] "Jezik obrasca"
 msgstr[1] "Jezici obrasca"
 msgstr[2] "Jezici obrasca"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Prijevod"
 msgstr[1] "Prijevodi"
 msgstr[2] "Prijevodi"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "Ime ne može biti prazno!"
 
@@ -1058,7 +1042,7 @@ msgstr "Jezik mora biti povezan s jednim obrascem!"
 msgid "Add a translation"
 msgstr "Dodaj prijevod"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Aktualiziraj prijevod"
 
@@ -1079,7 +1063,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Želiš li izbrisati odabrane predmete?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Izbriši"
 
@@ -1096,32 +1080,39 @@ msgstr "Dodaj novi jezik"
 msgid "Language"
 msgstr "Jezik"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Ništa"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Potvrditelj"
+msgstr[1] "Potvrditelji"
+msgstr[2] "Potvrditelji"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Treba potvrdu?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Ne"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Spremi"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Potvrđivanje"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Odaberi potvrditelja"
 
@@ -1132,14 +1123,14 @@ msgstr[0] "Problem cilja"
 msgstr[1] "Problemi cilja"
 msgstr[2] "Problemi cilja"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Svojstva"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1148,29 +1139,29 @@ msgstr ""
 "%1$s %2$s nije dodano ili aktualizirano: nedostaje pitanje i koristi se u "
 "parametru cilja"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Učesnici"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Naslov problema"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Sadržaj"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Utjecaj"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Uzrok"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Simptom"
 
@@ -1237,48 +1228,48 @@ msgstr "Promjenjiva visina"
 msgid "Uniform height"
 msgstr "Jednolika visina"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Podrška"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Modus podrške"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Standardni modus popisa obrazaca"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Redoslijed"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Baza znanja"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Traži"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Nadzorna ploča brojača"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Poruka zaglavlja"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Traži problem"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Dizajn pločice"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1286,26 +1277,26 @@ msgstr[0] "Zaglavlje"
 msgstr[1] "Zaglavlja"
 msgstr[2] "Zaglavlja"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Prikaži polje pretrage"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Prikaži zaglavlje"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Raspon pitanja"
 msgstr[1] "Rasponi pitanja"
 msgstr[2] "Rasponi pitanja"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Najmanji raspon"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "Najveći raspon"
 
@@ -1325,7 +1316,7 @@ msgstr "Ograničeni pristup"
 msgid "Answers waiting for validation"
 msgstr "Odgovori koji čekaju na potvrdu"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Uvezi obrasce"
 
@@ -1389,7 +1380,7 @@ msgstr[2] "Ciljevi"
 msgid "Actions"
 msgstr "Radnje"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Dodaj cilj"
 
@@ -1405,124 +1396,124 @@ msgstr "svojstva"
 msgid "What are you looking for?"
 msgstr "Što tražiš?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Mojih %1$d zadnjih obrazaca (podnositelj)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Još nije objavljen nijedan obrazac"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Svi moji obrasci (podnositelj)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Mojih %1$d zadnjih obrazaca (potvrditelj)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Nijedan obrazac ne čeka na potvrdu"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Svi moji obrasci (potvrditelj)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "Ne može se koristiti prazno ime za odgovore u obrascu. Zadržava se prethodna"
 " vrijednost."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "Pitanje %s nije kompatibilno s javnim obrascima"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Greška u duplikatu"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Dupliciraj"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Objavi"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Obrazac je dupliciran: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Obrazac je prenesen: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Natrag"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Prijenos JSON datoteka nije dozvoljen."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "Sada smiješ dozvoliti JSON datoteke."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Stvori"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Obrati se GLPI administratoru."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Natrag"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Prijenos JSON datoteka nije aktiviran."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "Sada smiješ aktivirati JSON datoteke."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Aktiviraj"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Pošalji"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Uvoz obrazaca nije moguć, datoteka je prazna"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Uvoz obrazaca nije moguć, datoteka je pokvarena"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr ""
 "Uvoz obrazaca nije moguć, datoteka je stvorena s jednom drugom verzijom"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1530,61 +1521,61 @@ msgstr ""
 "Datoteka ne navodi verziju sheme. Vjerojatno je generirana starijom verzijom"
 " od 2.10. Prekida se."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Nije bilo moguće uvesti %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Obrasci su uspješno uvezeni iz %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "Obrazac %1$s već postoji i nije promjenjiv entitet."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "Nemaš pravo aktualiziranja entiteta %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "Obrazac %1$s je potreban za obrazac %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Neuspjelo stvaranje JSON vrste dokumenta"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "JSON vrsta dokumenta nije pronađena"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Neuspjelo aktualiziranje JSON vrste dokumenta"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Obrasci bez kategorije"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Nema obrasca"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Dodaj"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Nepodržana vrsta cilja."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1632,11 +1623,8 @@ msgstr "Naslov se mora zadati"
 msgid "Failed to find %1$s %2$s"
 msgstr "Neuspjelo pronalaženje %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Pitanje"
@@ -1672,48 +1660,48 @@ msgstr "Ova vrsta pitanja treba parametre"
 msgid "A parameter is missing for this question type"
 msgstr "Jedan parametar nedostaje za ovu vrstu pitanja"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Razine usluge"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "Ugovor o razini usluge (SLA)"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "Ugovor o operativnoj raznini (OLA)"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Inventar"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Pomoć"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Upravljanje"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Alati"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Bilješke"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS vijest"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administracija"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Dodatak"
@@ -1842,119 +1830,119 @@ msgstr[0] "Odnos sastavljenog naloga"
 msgstr[1] "Odnosi sastavljenog naloga"
 msgstr[2] "Odnosi sastavljenog naloga"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Nalog cilja"
 msgstr[1] "Nalozi cilja"
 msgstr[2] "Nalozi cilja"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Određeni inventar"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Jednako je odgovoru na pitanje"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Zadnji valjani odgovor"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "Izvor iz predloška, iz korisničkog standardaa ili iz GLPI standarda"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Standardno ili iz predloška"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Određena vrsta"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Naslov naloga"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Dodaj poruku potvrde kao prvo priopćenje naloga"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Dodaj polje"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Upravljana polja"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Nema upravljanog polja"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Poveži s jednim drugim nalogom"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Jedno drugo odredište ovog obrasca"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Jedan postojeći nalog"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Nalog iz odgovora na pitanje"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Izbriši zauvijek"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Neispravna vrsta poveznice"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Neispravna povezana vrsta predmeta"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Povezani predmet ne postoji"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Neuspjelo povezivanje predmeta"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Potvrditelj je prihvatio tvoj obrazac"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Izvor zahtjeva"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Vrsta "
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Pridruženi elementi"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Predmet "
 
@@ -1974,212 +1962,243 @@ msgstr "Obrazac nije pronađen."
 msgid "Failed to add the translation."
 msgstr "Neuspjelo dodavanje prijevoda."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Oznake iz pitanja"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Određene oznake"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Oznake pitanja i određene oznake"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Oznake pitanja ili određene oznake"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "jednako je odgovoru na pitanje"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "izračunato iz datuma stvaranja naloga"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "izračunato iz odgovora na pitanje"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "Ugovor o razini usluge iz predloška ili ništa"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "Određeni ugovor o razini usluge (SLA)"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "Ugovor o operativnoj raznini iz predloška ili ništa"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "Određeni ugovor o operativnoj raznini (OLA)"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Hitnost iz predloška ili Srednje"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Određena hitnost"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Kategorija iz predloška ili ništa"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Određena kategorija"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Lokacija iz predloška ili ništa"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Određena lokacija"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Bez potvrđivanja"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Odeređeni korisnik ili grupa"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Korisnik iz odgovora na pitanje"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Grupa iz odgovora na pitanje"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Vrijeme rješavanja"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuta"
 msgstr[1] "Minute"
 msgstr[2] "Minute"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Sat"
 msgstr[1] "Sati"
 msgstr[2] "Sati"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Dan"
 msgstr[1] "Dani"
 msgstr[2] "Dani"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Mjesec"
 msgstr[1] "Mjeseci"
 msgstr[2] "Mjeseci"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "Ugovor o razini usluge (vrijeme posjedovanja/vrijeme ispravljanja)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Pitanje (vrijeme posjedovanja/vrijeme ispravljanja)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr ""
 "Ugovor o operativnoj raznini (vrijeme posjedovanja/vrijeme ispravljanja)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Hitnost "
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Oznake naloga"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Oznake"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Lokacija"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Lokacija "
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "Opis ne može biti prazan!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Promatrač"
 msgstr[1] "Promatrači"
 msgstr[2] "Promatrači"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Odustani"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Odgovori na e-mail poruku"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Korisnik"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Grupa"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Dobavljač"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Da"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Grupa iz objekta"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Tehnička grupa iz objekta"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"Nadogradi tablice u innoDB bazi podataka; pokreni php bin/console "
-"glpi:migration:myisam_to_innodb"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Stvoren je jedan obrazac"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Tvoj zahtjev je spremljen"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2189,11 +2208,11 @@ msgstr ""
 "##formcreator.request_id## i proslijeđen podršci.\\nTvoje odgovore možeš "
 "vidjeti na:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Potrebno je potvrditi GLPI obrazac"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2203,11 +2222,11 @@ msgstr ""
 "potvrditelja.\\nPristupi obrascu putem "
 "poveznice:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Potvrditelj je odbio tvoj obrazac"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2219,7 +2238,7 @@ msgstr ""
 "možeš izmijeniti i ponovo poslati na odobrenje putem "
 "poveznice:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2227,11 +2246,11 @@ msgstr ""
 "Pozdrav,\\nobavještavamo te, da je potvrditelj prihvatio tvoj "
 "obrazac.\\nZahtjev će uskoro biti razmotren."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Administrator je izbrisao obrazac"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2239,42 +2258,61 @@ msgstr ""
 "Pozdrav,\\nobavještavamo te, da tvoj zahtjev nažalost ne možemo uzeti u "
 "obzir i da ga je administrator izbrisao."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator – Problemi sa sinkronizacijom kataloga usluga"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Dupliciraj"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Prenesi"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Izvezi"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Otkaži moj nalog"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Staro"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Broj za %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Sažetak problema"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2282,35 +2320,39 @@ msgstr ""
 "Mini nadzorna ploča Formcreatora nije standardno upotrebljiva. Ova "
 "postavkaje zanemarena."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr "Nijedan obrazac nije pronađen. Dolje odaberi obrazac."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "Nijedan obrazac nije pronađen."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "Nijedno ČPP nije pronađeno."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Zaista želiš izbrisati ovo pitanje?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Zaista želiš izbrisati ovaj odjeljak?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Dodaj prijevode"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Dogodila se greška prilikom traženja obrazaca"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Zaista želiš izbrisati ovaj cilj:"
 
@@ -2362,13 +2404,17 @@ msgstr "Izravan pristup na početnoj stranici"
 msgid "Default form in service catalog"
 msgstr "Standardni obrazac u katalogu usluga"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Jesi li robot?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Pošalji"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Uvjet za prikaz odjeljka"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/ko_KR.po
+++ b/locales/ko_KR.po
@@ -5,16 +5,16 @@
 # 
 # Translators:
 # Thierry Bugier <tbugier@teclib.com>, 2022
-# 조성현 <jaymz9634@gmail.com>, 2022
+# SeongHyeon Cho <jaymz9634@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
-"Last-Translator: 조성현 <jaymz9634@gmail.com>, 2022\n"
+"Last-Translator: SeongHyeon Cho <jaymz9634@gmail.com>, 2022\n"
 "Language-Team: Korean (Korea) (https://www.transifex.com/teclib/teams/28042/ko_KR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -67,10 +67,9 @@ msgstr "하위트리 깊이 제한"
 msgid "No limit"
 msgstr "제한 없음"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "양식"
@@ -135,8 +134,8 @@ msgstr "실행자 삭제 중 잘못된 요청."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "양식 생성기"
 
@@ -146,12 +145,12 @@ msgstr "양식 생성기"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "양식 목록"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "양식이 저장되었습니다!"
 
@@ -167,7 +166,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s가 항목 %3$s에 대한 예약 %2$s를 추가합니다"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "분류"
@@ -180,30 +178,25 @@ msgstr "전체 보기"
 msgid "Please, describe your need here"
 msgstr "여기에 요구사항을 적어주세요"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "텍스트에어리어"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "필수 항목이 비었습니다:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "정규식이 잘못되었습니다"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "사용자"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "사용자와 양식"
 
@@ -236,158 +229,154 @@ msgid ""
 "settings will break the entity restrictions"
 msgstr "GLPI 개체 시스템을 중시하려면, \"양식\"을 선택해야 합니다. 다른 설정들은 개체 제한을 파괴합니다."
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "LDAP 크기 제한 초과됨"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP 선택"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "LDAP 디렉토리가 정의되지 않았습니다!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "LDAP 디렉토리를 찾을 수 없습니다!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "지정한 형식이 일치하지 않음: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "문구가 너무 짧음 (최소 %d 자): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "문구가 너무 김 (최대 %d 자): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "문구"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "정규식"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "범위"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "추가 확인"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "라디오"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "항목 값은 필수입니다:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "필수 항목이 비었습니다: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "이것은 정수가 아닙니다: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "다음 숫자는 %d보다 커야 합니다 : %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "다음 숫자는 %d보다 작아야 합니다 : %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "정수"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "정의되지않음"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "IP 주소"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "긴급도"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "매우 높음"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "높음"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "매체"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "낮음"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "경고: 태그 플러그인이 비활성화 됐거나 없습니다."
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "태그"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "GLPI 객체"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "호스트명"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "시간"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "이것은 올바른 이-메일이 아닙니다: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "이메일"
@@ -396,40 +385,40 @@ msgstr[0] "이메일"
 msgid "Select"
 msgstr "선택"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "날짜 & 시간"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "시행자"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "잘못된 값: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "사용자를 찾을 수 없거나 잘못된 이메일 주소: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "첨부된 문서 없음"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "첨부된 문서"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "필수 파일이 누락되었습니다: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "파일"
 
@@ -437,94 +426,93 @@ msgstr "파일"
 msgid "Multiselect"
 msgstr "다중선택"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "경고:부가 항목 플러그인이 비활성화 됐거나 없습니다."
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "블록"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "항목"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "표시"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "항목 '%1$s' 유형이 아직 구현되지 않았습니다!"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "일부 숫자 항목에 숫자가 아닌 값들이 포함되었습니다"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "일부 URL 항목에 잘못된 링크가 포함되었습니다"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "부가 항목"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "체크박스"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "다음 질문은 최소 %d개의 답변이 필요합니다"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "다음 질문은 %d개 이상의 답변이 허용되지 않습니다"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "범위 최소값"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "범위 최대값"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "요청 유형"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "이것은 숫자가 아님: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "부동 소숫점"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "날짜"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "상세"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "상세 항목을 써야 합니다:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "숨겨진 항목"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "조건"
@@ -553,26 +541,26 @@ msgstr "그 외에 숨김"
 msgid "Displayed unless"
 msgstr "그 외에 표시됨"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "%1$s %2$s의 추가 또는 갱신에 실패함"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "빈 객체를 불러올 수 없음: %s"
@@ -589,135 +577,125 @@ msgstr "불러오기"
 msgid "Import in progress"
 msgstr "가져오기 중"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "문제 사항"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "티켓과 양식 답변에서 문제사항 데이터를 갱신"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "만족도 설문조사 만료됨"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "이름"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
 msgstr[0] "유형"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "상태"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "개시 일자"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "최근 수정"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "개체"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "요청자"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "양식 승인자"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "의견"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "티켓 승인자"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "기술자"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "기술자 그룹"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "양식 승인자 그룹"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "확인 안됨"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "거부됨"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "전체"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "신규"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "할당됨"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "대기 중"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "확인 예정"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "해결됨"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "마감됨"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "양식 분류"
@@ -734,19 +712,19 @@ msgstr "다음의 하위"
 msgid "The form as been saved"
 msgstr "저장된 양식"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "확인이 필요한 양식"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "양식 거부됨"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "양식 승인됨"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "양식 삭제됨"
 
@@ -759,12 +737,11 @@ msgid "Form name"
 msgstr "양식 이름"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "검수자"
+msgstr "확인자"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "생성 일자"
 
@@ -789,15 +766,15 @@ msgid "Author"
 msgstr "작성자"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "승인자"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "양식 작성자"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "양식 확인자"
 
@@ -805,7 +782,7 @@ msgstr "양식 확인자"
 msgid "Specific person"
 msgstr "특정인"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "질문자"
 
@@ -813,7 +790,7 @@ msgstr "질문자"
 msgid "Specific group"
 msgstr "그룹 지정"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "질문 그룹"
 
@@ -829,15 +806,15 @@ msgstr "하나의 객체에서의 기술 그룹"
 msgid "Specific supplier"
 msgstr "공급사 지정"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "질문 공급사"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "질문 시행자"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "양식 작성자의 감독자"
 
@@ -845,7 +822,7 @@ msgstr "양식 작성자의 감독자"
 msgid "Observer"
 msgstr "관찰자"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "다음에 할당됨"
 
@@ -874,76 +851,85 @@ msgstr "그룹 검색 실패: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "공급자 검색 실패: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "거부됨"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "승인됨"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "양식 답변"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "이 양식 인쇄"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "확인자에 의해 양식이 승인되었습니다."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "양식이 저장되었습니다."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "저장"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "거부된 경우 필수"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "거부"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "답변 수정"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "수정 취소"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "승인"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "거부 의견은 필수입니다!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "당신은 이 질문들의 확인자가 아닙니다"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "양식 데이터"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "대상을 생성할 수 없습니다!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "튜링 테스트 셋 없음"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "튜링 테스트에 실패함"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "확인자를 선택해야 합니다!"
 
@@ -955,15 +941,15 @@ msgstr "이 이슈를 삭제할 수 없습니다. 잠긴 계정인 것 같습니
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "이 이슈를 삭제하는데 실패했습니다. 내부 오류가 발생했습니다."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "도움 요청"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "나의 도움 요청"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "피드 상담"
 
@@ -993,14 +979,14 @@ msgid "Form language"
 msgid_plural "Form languages"
 msgstr[0] "양식 언어"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "번역"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "이름은 비워둘 수 없습니다!"
 
@@ -1012,7 +998,7 @@ msgstr "언어는 양식에 연결되야 합니다!"
 msgid "Add a translation"
 msgstr "번역 추가"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "번역 수정"
 
@@ -1033,7 +1019,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "선택된 항목들을 삭제하시겠습니까?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "삭제"
 
@@ -1050,32 +1036,37 @@ msgstr "새 언어 추가"
 msgid "Language"
 msgstr "언어"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "없음"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "검수자"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "검증이 필요한가요?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "아니오"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "저장"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "확인"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "확인자를 선택하세요"
 
@@ -1084,43 +1075,43 @@ msgid "Target problem"
 msgid_plural "Target problems"
 msgstr[0] "목표 문제"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "속성"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
 "a parameter of the target"
 msgstr "%1$s%2$s의 추가 또는 갱신에 실패함: 질문이 누락되어 대상의 매개변수에 사용됨"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "실행자"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "문제 제목"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "내용"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "영향"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "원인"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "증상"
 
@@ -1187,71 +1178,71 @@ msgstr "가변 높이"
 msgid "Uniform height"
 msgstr "균일 높이"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "업무 지원 센터"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "업무 지원 센터 모드"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "기본 양식 목록 모드"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "정렬 순서"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "지식 기반"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "검색"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "카운터 대시보드"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "머릿말 메시지"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "문제사항 검색"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "타일 디자인"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
 msgstr[0] "머릿말"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "검색 항목 표시"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "머릿말 표시"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "질문 범위"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "최소 범위"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "최대 범위"
 
@@ -1271,7 +1262,7 @@ msgstr "접속 제한됨"
 msgid "Answers waiting for validation"
 msgstr "검증을 기다리는 답변"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "양식 불러오기"
 
@@ -1333,7 +1324,7 @@ msgstr[0] "대상"
 msgid "Actions"
 msgstr "작업"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "대상 추가"
 
@@ -1349,181 +1340,181 @@ msgstr "속성"
 msgid "What are you looking for?"
 msgstr "무엇을 찾으시나요?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "나의 %1$d 최근 양식 (요청자)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "아직 게시된 양식 없음"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "모든 내 양식 (요청자)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "나의 %1$d 최근 양식 (확인자)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "확인 중인 양식 없음"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "모든 내 양식 (확인자)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr "양식 답변에는 이름을 비워둘 수 없습니다. 이전 값을 유지합니다."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "질문 %s은 공개 양식과 호환되지 않습니다"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "중복 오류"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "복제"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "게시"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "양식 복제됨:  %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "양식 전송됨: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "뒤로가기"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "JSON 파일의 업로드는 허용되지 않습니다."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "지금 바로 JSON 파일을 허용해야 합니다."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "생성"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "GLPI 관리자에게 연락하세요."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "뒤로가기"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "JSON 파일의 업로드가 활성화되지 않았습니다."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "지금 바로 JSON 파일을 활성화해야 합니다."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "활성화"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "전송"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "양식 불러오기를 할 수 없습니다, 파일이 비었습니다"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "양식 불러오기를 할 수 없습니다, 파일이 손상된 것 같습니다"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "양식 불러오기를 할 수 없습니다, 파일이 다른 버전으로 생성되었습니다"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
 msgstr "파일에서 스키마 버전을 지정하지 않았습니다. 2.10 이전 버전으로 생성되었을 수 있습니다. 포기하세요."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "%s불러오기 실패함"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "양식을 %s에서 불러옴"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "양식 %1$s는 이미 존재하며 수정할 수 없는 개체 내에 있습니다."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "요소 %1$s 를 수정할 권한이 없습니다."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "개체 %1$s는 양식 %2$s가 필요합니다."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "JSON 문서 유형 생성 실패함"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "JSON 문서 유형을 찾을 수 없음"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "JSON 문서 유형 갱신 실패함"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "분류 없는 양식"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "사용가능한 양식 없음"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "추가"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "지원되지 않는 대상 유형"
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1567,11 +1558,8 @@ msgstr "제목은 필수입니다"
 msgid "Failed to find %1$s %2$s"
 msgstr "%1$s %2$s 검색 실패"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "질문"
@@ -1605,48 +1593,48 @@ msgstr "이 질문의 유형은 매개변수가 필요합니다"
 msgid "A parameter is missing for this question type"
 msgstr "매개변수가 이 질문 유형에 누락되었습니다"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "서비스 수준"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "자산"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "보조"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "운영관리"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "도구"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "알림"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS 피드"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "관리"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "플러그잉ㄴ"
@@ -1765,117 +1753,117 @@ msgid "Composite ticket relation"
 msgid_plural "Composite ticket relations"
 msgstr[0] "복합 티켓 관계"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "대상 티켓"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "자산 지정"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "질답이 동일함"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "최근 검증한 답변"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "템플릿 또는 사용자 기본값 또는 GLPI 기본값의 소스"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "양식생성기"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "기본 또는 양식 견본"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "특정 유형"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "티켓 제목"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "첫번째 티켓 추적으로서의 확인 메시지 추가"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "항목 추가"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "관리 항목"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "관리 항목 없음"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "다른 티켓에 연결"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "이 양식의 다른 목적"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "존재하는 티켓"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "질문에 대한 답변에서의 티켓"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "영구 삭제"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "잘못된 연결 유형"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "잘못된 연결된 품목 유형"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "연결된 품목이 존재하지 않습니다"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "품목에 연결 실패함"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "당신의 양식이 확인자에 의해 승인되었습니다."
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "요청 소스"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "유형"
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "관련 요소"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "품목"
 
@@ -1895,201 +1883,232 @@ msgstr "양식을 찾을 수 없습니다."
 msgid "Failed to add the translation."
 msgstr "번역 추가에 실패함."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "질문 태그"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "태그 지정"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "질문 태그와 태그 지정"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "질문 태그 또는 태그 지정"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "질답이 동일함"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "티켓 생성일로부터 계산됨"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "질문에 대한 답변에서 계산됨"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "견본의 SLA 또는 없음"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "특정 SLA"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "견본의 OLA 또는 없음"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "특정 OLA"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "견본 또는 매체의 긴급도"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "긴급도 지정"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "견본의 분류 또는 없음"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "분류 지정"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "견본의 위치 또는 없음"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "위치 지정"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "검증 없음"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "특정 사용자 또는 그룹"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "질문 답변의 사용자"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "질문 답변의 그룹"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "해결까지의 시간"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "분"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "시간"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "일"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "월"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "질문 (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "긴급도"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "티켓 태그"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "태그"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "위치"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "위치"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "상세내용은 비워둘 수 없습니다!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "감시자"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "취소"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "이메일 추적"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "사용자"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "그룹"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "공급자"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "예"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "객체에서의 그룹"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "객체에서의 기술 그룹"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"테이블을 innoDB로 업그레이드 하세요; php bin/console glpi:migration:myisam_to_innodb을 "
-"실행하세요"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "양식이 생성되었습니다"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "요청이 저장되었습니다"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2098,11 +2117,11 @@ msgstr ""
 "안녕하세요,\\nGLPI에서의 요청이 ##formcreator.request_id##로 잘 저장되었고 업무 지원 센터 팀에 전달 "
 "되었습니다.\\n다음 링크에서 당신의 질문을 확인할 수 있습니다:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "GLPI에서의 양식은 확인이 필요합니다"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2111,11 +2130,11 @@ msgstr ""
 "안녕하세요,\\nGLPI에서의 양식은 확인이 필요하고 당신은 확인자로 선택 되었습니다.\\n이 링크를 클릭하여 접속할 수 "
 "있습니다:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "확인자에 의해 당신의 양식이 거부되었습니다."
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2126,92 +2145,115 @@ msgstr ""
 "유감입니다:\\n##formcreator.validation_comment##\\n\\n아직은 이 링크를 클릭하여  수정하여 다시 제출할"
 " 수 있습니다:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
 msgstr "안녕하세요,\\n확인자에 의해 당신의 양식이 승인됨을 알리게 되어 기쁩니다.\\n당신의 요청은 곧 고려되게 됩니다."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "당신의 양식이 관리자에 의해 삭제되었습니다"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
 msgstr "안녕하세요,\\n당신의 요청이 고려될 수 없고 관리자에 의해 삭제됨을 알리게 되어 유감입니다."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "양식생성기 - 서비스 목록 문제 동기화"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "복제"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "전송자"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "내보내기"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "내 티켓 취소"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "오래됨"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "%s의 횟수 "
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "이슈 요약"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
 msgstr "양식생성기의 미니 대시보드는 기본적으로 사용할 수 없습니다. 이 설정은 무시되었습니다."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr "양식을 찾을 수 없습니다. 대신 다음 양식에서 선택해 주세요."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "양식을 찾을 수 없습니다."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "FAQ 항목을 찾을 수 없습니다."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "이 질문을 삭제 하시겠습니까?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "이 섹션을 삭제 하시겠습니까?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "번역 추가"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "양식 질의 중 오류 발생함"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "이 대상을 삭제 하시겠습니가:"
 
@@ -2261,13 +2303,17 @@ msgstr "홈페이지에 바로 접속"
 msgid "Default form in service catalog"
 msgstr "서비스 목록 내의 기본 양식"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "당신은 로봇인가요?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "전송"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "섹션 표시 조건"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/nl_NL.po
+++ b/locales/nl_NL.po
@@ -4,17 +4,17 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Glenn Franssen <github@glennfrn.nl>, 2022
 # Chris Gralike, 2022
+# Glenn Franssen <github@glennfrn.nl>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
-"Last-Translator: Chris Gralike, 2022\n"
+"Last-Translator: Glenn Franssen <github@glennfrn.nl>, 2022\n"
 "Language-Team: Dutch (Netherlands) (https://www.transifex.com/teclib/teams/28042/nl_NL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -67,10 +67,9 @@ msgstr ""
 msgid "No limit"
 msgstr "Geen limit"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] ""
@@ -136,8 +135,8 @@ msgstr "Onjuiste aanroep tijdens het verwijderen van een behandelaar"
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Formcreator"
 
@@ -147,12 +146,12 @@ msgstr "Formcreator"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Formulieren lijst"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Het formulier is succesvol bewaard"
 
@@ -168,7 +167,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s voegt de reservering voor %2$s toe voor onderdeel %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] ""
@@ -182,30 +180,25 @@ msgstr "Alles tonen"
 msgid "Please, describe your need here"
 msgstr "Vul hier je zoektermen in"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Tekstveld"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Een verplicht veld is leeg:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "The reguliere expressie is invalide"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Gebruiker"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Gebruiker en formulier"
 
@@ -242,162 +235,158 @@ msgstr ""
 "geselecteerd te zijn. Overige instellingen maken de entiteitbeperkingen "
 "onklaar."
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "LDAP limiet overschreden "
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP selectie"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "LDAP map niet gedefinieerd!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "LDAP map niet gevonden"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Een specifiek formaat komt niet overeen: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "De tekst is te kort (er zijn minimaal %d karakters vereist): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "De tekst is te lang (er zijn maximaal %d karakters toegestaan): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Tekst"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Reguliere expressie"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Range"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Additionele validatie"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Selectieknoppen"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "Veldgegevens zijn verplicht:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Een vereist veld is leeg: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Dit is geen cijfer: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "Het volgende getal moet groter zijn dan %d : %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "Het volgende getal moet lager zijn dan %d : %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Cijfer"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Niet gedefinieerd"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgentie"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Zeer hoog"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Hoog"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Gemiddeld"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Laag"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Zeer laag"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Waarschuwing: Labelplugin is uitgeschakeld of ontbreekt"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Tijd"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Dit is een ongeldig emailadres: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] ""
@@ -407,41 +396,41 @@ msgstr[1] ""
 msgid "Select"
 msgstr "Selectie"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Datum & tijd"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Ongeldige waarde: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Gebruiker niet gevonden of ongeldig emailadres: %s "
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Geen gekoppeld document"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Bijgevoegde document"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Een vereist bestand ontbreekt: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Bestand"
 
@@ -449,95 +438,94 @@ msgstr "Bestand"
 msgid "Multiselect"
 msgstr "Multieselect"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Waarschuwing: Additional Fields plugin ontbreekt of is uitgeschakeld "
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Veld"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "Toon"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Enkele nummerieke velden bevatten ongeldige waarden."
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Enkele URL velden bevatten ongeldige waarden"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Aanvullende velden"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Checkboxes"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "De volgende vraag dient minimaal %d antwoorden te bevatten."
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "De volgende vraag accepteert niet meer dan %d antwoorden."
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Minimaal bereik"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Maximaal bereik"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Verzoektype"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Dit is geen cijfer: %s "
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Kommagetal"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Datum"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Beschrijving"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Het beschrijvingsveld dient een beschrijving te bevatten:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] ""
@@ -567,26 +555,26 @@ msgstr "Verborgen tenzij"
 msgid "Displayed unless"
 msgstr "Laten zien behalve als"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Het toevoegen of bijwerken van %1$s %2$s is gefaald"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Kan een leeg object niet exporteren: %s"
@@ -603,139 +591,129 @@ msgstr "Importeren"
 msgid "Import in progress"
 msgstr "Importeertaak actief"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Update problemen data van tickets en formulier antwoorden"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr ""
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Naam"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Status"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Openingsdatum"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Laatste update"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Goedkeurder"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Commentaar"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Ticket goedkeurder"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Engineer"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Engineergroep"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Goedkeurder groep"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Niet gevalideerd"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Geweigerd"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Alles"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Nieuw"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Toegewezen"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Wachtend"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "Om te valideren"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Opgelost"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Gesloten"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] ""
@@ -753,19 +731,19 @@ msgstr ""
 msgid "The form as been saved"
 msgstr "Het formulier is bewaard"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Een formulier heeft validatie nodig"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Het formulier is geweigerd"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Het formulier is geaccepteerd"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Het formulier is verwijderd"
 
@@ -778,13 +756,11 @@ msgid "Form name"
 msgstr "Formulier naam"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] ""
-msgstr[1] ""
+msgstr "Validatiegever"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Aanmaakdatum"
 
@@ -809,15 +785,15 @@ msgid "Author"
 msgstr "Auteur"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Goedkeurder"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Formulier auteur"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Formulier validatiegever"
 
@@ -825,7 +801,7 @@ msgstr "Formulier validatiegever"
 msgid "Specific person"
 msgstr "Specifiek persoon"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Persoon van vraag"
 
@@ -833,7 +809,7 @@ msgstr "Persoon van vraag"
 msgid "Specific group"
 msgstr "Specifieke groep"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Groep van deze vraag"
 
@@ -849,15 +825,15 @@ msgstr "Tech groep afkomstig uit een object"
 msgid "Specific supplier"
 msgstr "Specifieke leverancier"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Leverancier van deze vraag"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Actors van deze vraag"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Formulier auteur toezichthouder"
 
@@ -865,7 +841,7 @@ msgstr "Formulier auteur toezichthouder"
 msgid "Observer"
 msgstr "Observator"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Toegewezen aan"
 
@@ -895,77 +871,86 @@ msgstr "Groep kon niet worden gevonden: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Leverancier kon niet worden gevonden: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Geweigerd"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Accepteren"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Dit formulier printen"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Formulier geaccepteerd door validator."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Formulier succesvol bewaard."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Opslaan"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Verplicht als het geweigerd wordt"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Geweigerd"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Wijzig antwoorden"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Annuleer editie"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Accepteren"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Geweigerd. Commentaar is verplicht!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Jij bent niet de validatie gever van deze antwoorden"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Formulier data"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Kan het doel niet genereren"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Geen turing test set"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "U heeft de Turing test niet doorstaan"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "U moet een validatie kiezen!"
 
@@ -980,15 +965,15 @@ msgid "Failed to delete this issue. An internal error occured."
 msgstr ""
 "Probleem kon niet verwijderd worden. Er is een interne fout opgetreden."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Assistentie"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Assistentieverzoeken"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consult feeds"
 
@@ -1021,15 +1006,15 @@ msgid_plural "Form languages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "De naam kan niet leeg zijn"
 
@@ -1041,7 +1026,7 @@ msgstr "De taal moet zijn toegewezen aan een formulier!"
 msgid "Add a translation"
 msgstr "Vertaling toevoegen"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Een vertaling bijwerken"
 
@@ -1062,7 +1047,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Wilt u de geselecteerde onderdelen verwijderen? "
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Verwijder"
 
@@ -1079,32 +1064,38 @@ msgstr "Nieuwe taal toevoegen"
 msgid "Language"
 msgstr "Taal"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Geen"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] ""
+msgstr[1] ""
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Validatie nodig?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Nee"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Opslaan"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Validatie"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Kies een validator"
 
@@ -1114,43 +1105,43 @@ msgid_plural "Target problems"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Eigenschappen"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
 "a parameter of the target"
 msgstr ""
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Uitvoerende"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Probleemtitel"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Inhoud"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Gevolgen"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Oorzaak"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Symptoom"
 
@@ -1217,73 +1208,73 @@ msgstr ""
 msgid "Uniform height"
 msgstr ""
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Helpdesk modus"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Standaard formulier lijstmodus"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Sorteervolgorde"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Kennisbank"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Zoeken"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Tellers dashboard"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Kopbericht"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr ""
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr ""
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Zoekveld tonen"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Kopteksten tonen"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Minimaal bereik"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "Maximaal bereik"
 
@@ -1303,7 +1294,7 @@ msgstr "Beperkte toegang"
 msgid "Answers waiting for validation"
 msgstr "Antwoorden die wachten op validatie"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Importeer formulieren"
 
@@ -1366,7 +1357,7 @@ msgstr[1] ""
 msgid "Actions"
 msgstr ""
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Doel toevoegen"
 
@@ -1382,125 +1373,125 @@ msgstr "Eigenschappen"
 msgid "What are you looking for?"
 msgstr "Wat zoekt u?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Mijn %1$d laatste formulieren (verzoeker)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Geen formulieren gepost"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Al mijn formulieren (aanvrager)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Mijn %1$d laatste formilieren (validator)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Geen formulieren wachten op validatie"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Al mijn formulieren (validatie)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "U mag geen leeg naamveld gebruiken bij antwoorden, de eerdere waarde blijft "
 "bewaard."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "De vraag 1%s is niet toepasbaar in publieke formulieren"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "foutief duplicaat"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Dupliceren"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Versturen"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Formulier gedupliceerd: 1%s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Formulier verplaatst: 1%s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Terug"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Het uploaden van JSON bestanden is niet toegestaan"
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "U kunt nu JSON bestanden toestaan "
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Creëren "
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Neem contact op met uw GLPI beheerder"
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Terug"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Uploaden van JSON bestanden is uitgeschakeld"
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "U kunt nu JSON bestanden toestaan."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Verzenden"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Formulier importeren niet mogelijk, het bestand is leeg"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Formulieren importeren niet mogelijk, het bestand lijkt corrupt. "
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr ""
 "Formulieren importeren niet mogelijk, het bestand was gegenereerd met een "
 "andere productversie."
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1508,62 +1499,62 @@ msgstr ""
 "Het bestand heeft geen schemaversie gespecificeerd. Het bestand is "
 "waarschijnlijk aangemaakt met een versie ouder dan 2.10. "
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Het importeren van %s is mislukt."
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formulieren succesvol geïmporteerd van 1%s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "Formulier %1$s bestaat al en betreft een niet te wijzigen entiteit"
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr ""
 "U heeft niet de rechten om wijzigingen aan te brengen in entiteit %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "De entiteit %1$s is noodzakelijk voor formulier %2$s"
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Het is niet gelukt om een JSON document type te maken"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "JSON document type is niet gevonden"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Het is niet gelukt om het JSON document type te updaten"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formulieren zonder categorie"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Geenm formulier beschikbaar"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Toevoegen"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Niet ondersteund doeltype."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr ""
 
@@ -1609,11 +1600,8 @@ msgstr "Titel is verplicht"
 msgid "Failed to find %1$s %2$s"
 msgstr "%1$s %2$s kon niet gevonden worden"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] ""
@@ -1648,48 +1636,48 @@ msgstr "Dit vraagtype vereist parameters."
 msgid "A parameter is missing for this question type"
 msgstr "Er ontbreekt een parameter voor dit vraagtype."
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Service levels"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Assets"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Ondersteuning"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Management"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Hulpmiddelen"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notities"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS feed"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administratie"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] ""
@@ -1813,118 +1801,118 @@ msgid_plural "Composite ticket relations"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr ""
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Gelijk aan antwoord op deze vraag"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr ""
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr ""
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr ""
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr ""
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr ""
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Ticket titel"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Voeg validatie bericht toe als eerste opvolging"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr ""
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr ""
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr ""
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Link aan een ander ticket"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Een ander doel van dit formulier"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Een bestaand ticket"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr ""
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr ""
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Invalide link type"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Invalide gelinkt item type. "
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Gelinkt item bestaat niet"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Gefaald om item te linken"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Je formulier is geaccepteerd door de validator"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr ""
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr ""
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr ""
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr ""
 
@@ -1944,204 +1932,237 @@ msgstr ""
 msgid "Failed to add the translation."
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Tags van vragen"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Specifieke tags"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Tags van vragen en specifieke tags"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Tags van vragen of specifieke tags"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "Gelijk aan antwoord op deze vraag"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "Uitgerekend vanaf datum aanmaak ticket"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "Uitgerekend vanaf antwoord op deze vraag"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgentie van template of gemiddeld"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Specifieke urgentie"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Categorie van template of geen"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Specifieke categorie"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Locatie van template of geen"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Specifieke locatie"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgentie"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Ticket tags"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Tags"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Locatie"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "De omschrijving kan niet leeg zijn"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Gebruiker"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr ""
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Een formulier is gemaakt"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Je verzoek is bewaard"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2151,11 +2172,11 @@ msgstr ""
 "##formcreator.request_id## en aan de helpdesk toegekend.\\nJe kunt hier je "
 "ticket volgen:\\n##formcreator.validation_link## "
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Een formulier van GLPI heeft validatie nodig"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2164,11 +2185,11 @@ msgstr ""
 "Hallo, \\nJe bent uitgekozen om een formulier van GLPI te valideren. \\nJe "
 "kunt hier het forumulier bekijken\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Je formulier is geweigerd door de validator"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2178,7 +2199,7 @@ msgstr ""
 "Hallo,\\nHet spijt ons om je te moeten informeren dat je formulier geweigerd is door de validatiegever. Met deze reden:\n"
 "\\n##formcreator.validation_comment##\\n\\nJe kunt nog steeds het formulieren wijzigen en opnieuw invoeren met deze link:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2186,11 +2207,11 @@ msgstr ""
 "Hallo,\\nWe willen je laten weten dat je formulier geaccepteerd is door de "
 "validatiegever.\\nJe aanvraag zal binnenkort uitgevoerd worden."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Je formulier is verwijderd door de administrator"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2199,76 +2220,99 @@ msgstr ""
 "behandeling genomen zal worden, omdat een administrator je aanvraag heeft "
 "verwijderd. "
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator: Sync service catalogus problemen"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Dupliceren"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr ""
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr ""
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr ""
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr ""
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr ""
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr ""
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
 msgstr ""
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr ""
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr ""
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr ""
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Weet je zeker dat je deze vraag wilt verwijderen?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Weet je zeker dat je dit gedeelte wilt verwijderen?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr ""
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Er is een fout opgetreden terwijl we de formulieren opvroegen"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr ""
 
@@ -2319,13 +2363,17 @@ msgstr "Meteen toegang op homepage"
 msgid "Default form in service catalog"
 msgstr "Standaard formulier in service catalogus"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr ""
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Verzenden"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr ""
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/pl_PL.po
+++ b/locales/pl_PL.po
@@ -9,17 +9,17 @@
 # netruner <netruner80@gmail.com>, 2021
 # Agnieszka Pacyga <papilota@gmail.com>, 2022
 # Norbert Błaszczyk, 2022
-# Ryszard Jeziorski <ryszard.jeziorski@gmail.com>, 2022
 # Daniel Wróblewski <dewuer@gmail.com>, 2022
+# Ryszard Jeziorski <ryszard.jeziorski@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
-"Last-Translator: Daniel Wróblewski <dewuer@gmail.com>, 2022\n"
+"Last-Translator: Ryszard Jeziorski <ryszard.jeziorski@gmail.com>, 2022\n"
 "Language-Team: Polish (Poland) (https://www.transifex.com/teclib/teams/28042/pl_PL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -72,10 +72,9 @@ msgstr "Ogranicz drzewo kategorii zgłoszeń"
 msgid "No limit"
 msgstr "Bez ograniczeń"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Formularz"
@@ -143,8 +142,8 @@ msgstr "Złe żądanie podczas usuwania uczestnika."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Kreator formularzy"
 
@@ -154,12 +153,12 @@ msgstr "Kreator formularzy"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Lista formularzy"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Formularz został zapisany"
 
@@ -175,7 +174,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr ""
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Kategoria"
@@ -191,30 +189,25 @@ msgstr "Zobacz wszystkie"
 msgid "Please, describe your need here"
 msgstr "Wpisz frazę do wyszukania w formularzach"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Obszar tekstu"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Wymagane pole jest puste:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "Wyrażenie regularne jest nieprawidłowe"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Użytkownik"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Użytkownik i formularz"
 
@@ -253,96 +246,92 @@ msgstr ""
 "\"Formularz\". Inne ustawienia spowodują złamanie ograniczeń dotyczących "
 "jednostek"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "Przekroczony limit rozmiaru LDAP"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "Dane z LDAP"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "Katalog LDAP nie został zdefiniowany"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "Katalog LDAP nie znaleziony"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Podany format nie pasuje: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "Tekst jest zbyt krótki (minimalnie %d znaków): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "Tekst jest zbyt długi (maksymalnie %d znaków): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Tekst"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Wyrażenie regularne"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Zakres"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Dodatkowa weryfikacja"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Pola opcji"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "Wymagana wartość w polu:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Wymagane pole jest puste: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "To nie jest liczba całkowita: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "Liczba musi być większa niż %d:%s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "Liczba musi być mniejsza niż %d:%s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Wartość całkowita"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Niezdefiniowane"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] ""
@@ -350,40 +339,40 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Pilność"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Bardzo wysoki"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Wysoki"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Umiarkowany"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Niski"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Ostrzeżenie: Wtyczka Tag jest wyłączona lub jej brak"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] ""
@@ -391,7 +380,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] ""
@@ -399,7 +388,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] ""
@@ -407,16 +396,16 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Czas"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "To nie jest prawidłowy adres e-mail: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] ""
@@ -428,11 +417,11 @@ msgstr[3] ""
 msgid "Select"
 msgstr "Lista wyboru"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Data i godzina"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] ""
@@ -440,31 +429,31 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Błędna wartość: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Nie znaleziono użytkownika lub nieprawidłowy adres e-mail: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Nie załączono dokumentu"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Załączony dokument"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Brak wymaganego pliku: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Plik"
 
@@ -472,88 +461,88 @@ msgstr "Plik"
 msgid "Multiselect"
 msgstr "Lista wielokrotnego wyboru"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Ostrzeżenie: Wtyczka Additional Fields jest wyłączona lub jej brak"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Pole"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "pokaż"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr ""
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Niektóre pola numeryczne zawierają wartości nienumeryczne"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Niektóre pola adresu URL zawierają nieprawidłowe łącza"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Dodatkowe pola"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Pola wyboru"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "Następujące pytanie wymaga co najmniej %d odpowiedzi"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "Na to pytanie należy podać nie więcej niż %d odpowiedzi"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Zakres min."
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Zakres maks."
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Typ zgłoszenia"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "To nie jest liczba: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Wartość rzeczywista"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Data"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Opis"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Pole opisu powinno być wypełnione"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Ukryte pole"
@@ -561,8 +550,7 @@ msgstr[1] "Ukryte pola"
 msgstr[2] "Ukryte pola"
 msgstr[3] "Ukryte pola"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] ""
@@ -594,26 +582,26 @@ msgstr "Niewidoczny aż"
 msgid "Displayed unless"
 msgstr "Widoczny jeżeli"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Nie udało się dodać lub zaktualizować %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr ""
@@ -630,7 +618,7 @@ msgstr "Importuję"
 msgid "Import in progress"
 msgstr "Import w trakcie"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] ""
@@ -638,29 +626,29 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Zaktualizuj informacje o żądaniach zgłoszeń i formularzy odpowiedzi"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Badanie satysfakcji wygasło"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Nazwa"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -669,20 +657,19 @@ msgstr[1] "Typy"
 msgstr[2] "Typy"
 msgstr[3] "Typy"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Status"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Data rozpoczęcia"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Ostatnia aktualizacja"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] ""
@@ -690,9 +677,9 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Zgłaszający"
@@ -700,77 +687,68 @@ msgstr[1] "Zgłaszający"
 msgstr[2] "Zgłaszający"
 msgstr[3] "Zgłaszający"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Zatwierdzający formularze"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Komentarz"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Zatwierdzający zgłoszenie"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Technik"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Grupa technika"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Grupa zatwierdzających formularze"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Nie zweryfikowano"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Odrzucono"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s%2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Wszystkie"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Nowy"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Przypisany"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Oczekiwanie"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "Do zatwierdzenia"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Rozwiązany"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Zamknięte"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Kategoria formularza"
@@ -790,19 +768,19 @@ msgstr ""
 msgid "The form as been saved"
 msgstr "Formularz został zapisany"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Formularz musi zostać zatwierdzony"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Formularz został odrzucony"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Formularz został zaakceptowny"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Formularz został skasowany"
 
@@ -815,15 +793,11 @@ msgid "Form name"
 msgstr "Nazwa formularza"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+msgstr "Zatwierdzający"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Data utworzenia"
 
@@ -848,15 +822,15 @@ msgid "Author"
 msgstr "Autor"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Akceptujący"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Autor formularza"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Weryfikator formularza"
 
@@ -864,7 +838,7 @@ msgstr "Weryfikator formularza"
 msgid "Specific person"
 msgstr "Osoba"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Osoba z pytania"
 
@@ -872,7 +846,7 @@ msgstr "Osoba z pytania"
 msgid "Specific group"
 msgstr "Grupa"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Grupa z pytania"
 
@@ -888,15 +862,15 @@ msgstr ""
 msgid "Specific supplier"
 msgstr "Dostawca"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Dostawca z pytania"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Uczestnicy pytania"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr ""
 
@@ -904,7 +878,7 @@ msgstr ""
 msgid "Observer"
 msgstr "Obserwator"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Przypisane do"
 
@@ -936,11 +910,15 @@ msgstr "Nie udało się znaleźć grupy: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Nie udało się znaleźć dostawcy: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Odrzucono"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Zaakceptowano"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Odpowiedź formularza"
@@ -948,67 +926,72 @@ msgstr[1] "Odpowiedzi formularza"
 msgstr[2] "Odpowiedzi formularza"
 msgstr[3] "Odpowiedzi formularza"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Wydrukuj formularz"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Formularz zaakceptowane przez osobę zatwierdzającą"
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Formularz został zapisany."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Zapisz"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Wymagane w przypadku odrzucenia"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Odrzucenie"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Edytuj odpowiedzi"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Anuluj edycję"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Akceptacja"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Wymagane jest skomentowanie odrzucenia "
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Nie jesteś osobą zatwierdzającą te odpowiedzi"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Dane formularza"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Nie można wygenerowć obiektów docelowych!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr ""
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr ""
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Musisz wybrać osobę zatwierdzającą"
 
@@ -1020,15 +1003,15 @@ msgstr "Nie można usunąć tego problemu. Być może jest już rozpatrywany."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Nie można usunąć tego problemu. Wystąpił błąd wewnętrzny."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Wsparcie"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Moje zgłoszenia"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Sprawdź kanały informacji"
 
@@ -1064,7 +1047,7 @@ msgstr[1] "Języki formularza"
 msgstr[2] "Języki formularza"
 msgstr[3] "Języki formularza"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Tłumaczenie"
@@ -1072,9 +1055,9 @@ msgstr[1] "Tłumaczenia"
 msgstr[2] "Tłumaczenia"
 msgstr[3] "Tłumaczenia"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "Nazwa nie może być pusta!"
 
@@ -1086,7 +1069,7 @@ msgstr "Język musi być powiązany z formularzem!"
 msgid "Add a translation"
 msgstr "Dodaj tłumaczenie"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Zaktualizuj tłumaczenie"
 
@@ -1107,7 +1090,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Czy chcesz usunąć zaznaczone elementy?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Usuń"
 
@@ -1124,32 +1107,40 @@ msgstr "Dodaj nowy język"
 msgid "Language"
 msgstr "Język"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Brak"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Wymaga walidacji?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Nie"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Zapisz"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Zatwierdzający"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Wybierz osobę zatwierdzającą"
 
@@ -1161,43 +1152,43 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Właściwości"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
 "a parameter of the target"
 msgstr ""
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Uczestnicy"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr ""
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Zawartość"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Wpływ"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Przyczyna"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Objaw"
 
@@ -1264,48 +1255,48 @@ msgstr ""
 msgid "Uniform height"
 msgstr ""
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Pomoc techniczna"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Tryb pomocy technicznej"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr ""
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Kolejność sortowania"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Baza wiedzy"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Szukaj"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr ""
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Wiadomość nagłówka"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr ""
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr ""
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1314,15 +1305,15 @@ msgstr[1] "Nagłówki"
 msgstr[2] "Nagłówki"
 msgstr[3] "Nagłówki"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Pokaż pole wyszukiwania"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Pokaż nagłówek"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] ""
@@ -1330,11 +1321,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Zakres minimalny"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "zakres minimalny"
 
@@ -1354,7 +1345,7 @@ msgstr "Dostęp ograniczony"
 msgid "Answers waiting for validation"
 msgstr "Odpowiedzi oczekujące na zatwierdzenie"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Import formularzy"
 
@@ -1419,7 +1410,7 @@ msgstr[3] ""
 msgid "Actions"
 msgstr ""
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Dodaj cel"
 
@@ -1435,185 +1426,185 @@ msgstr "właściwości"
 msgid "What are you looking for?"
 msgstr "Czego szukasz?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Moje %1$d ostatnie formularze (zgłaszający)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Brak zapamiętanych formularzy"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Moje wszystkie formularze (wnioskodawca)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Moje %1$d ostatnie formularze (zatwierdzający)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Brak formularzy oczekujących na zatwierdzenie"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Moje wszystkie formilarze (zatwierdzający)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "Nie można użyć pustej nazwy dla odpowiedzi formularza. Zachowuję poprzednią "
 "wartość."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "Pytanie %s niedostępne w wersji publicznej formularza"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr ""
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Powtórzenie"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr ""
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Powtórzonych formularzy: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Przeniesionych formularzy %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Cofnij"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Pliki typu JSON są niedozwolone."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "Pliki typu JSON są obecnie dozwolone."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Utwórz"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Proszę skontaktuj się z Administratorem Systemu GLPI"
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Cofnij"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Wgranie plików typu JSON nie jest włączone."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "Można włączyć pliki typu JSON."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Włącz"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Wyślij"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Import formularzy niemożliwy, plik jest pusty"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Import formularzy niemożliwy, plik wydaje się uszkodzony"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "Import formularzy niemożliwy, plik został wygenerowany w innej wersji"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
 msgstr ""
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Błąd importu %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formularze pomyślnie zaimportowane z %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr ""
 "Formularz %1$s już istnieje oraz dotyczy jednostki, której nie można "
 "modyfikować."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr ""
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "Jednostka %1$s jest wymagana przy formularzu %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Nie utworzono dokumentu typu JSON"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Nie znaleziono dokumentu typu JSON "
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Nie powiodło się zaktualizowanie dokumentu typu JSON"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formularze bez kategorii"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Brak dostępnego formularza"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Dodaj"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Niewspierany typ udostępnienia."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr ""
 
@@ -1663,11 +1654,8 @@ msgstr "Tytuł jest wymagany"
 msgid "Failed to find %1$s %2$s"
 msgstr "Nie znaleziono %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Pytanie"
@@ -1704,48 +1692,48 @@ msgstr "Ten typ pytania wymaga określenia parametrów"
 msgid "A parameter is missing for this question type"
 msgstr "Wymagany parametr dla tego typu pytania"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Poziomy usług"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr ""
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr ""
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Zasoby"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Wsparcie"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Zarządzanie"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Narzędzia"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Uwagi"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS feed"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administracja"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Wtyczka"
@@ -1881,7 +1869,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] ""
@@ -1889,113 +1877,113 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Zasoby"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr ""
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Ostania prawidłowa odpowiedź"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr ""
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Domyślne lub z szablonu"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Określony typ"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Tytuł zgłoszenia"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr ""
 "Dodaj wiadomość o zatwierdzeniu jako pierwszą pozycję śledzenia w zgłoszeniu"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Dodaj pole"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Pola zarządzane"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Brak zarządzanego pola"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Odnośnik do innego zgłoszenia"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Inne przeznaczenie formularza"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Istniejące zgłoszenie"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr ""
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Usuń trwale"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Błędny typ odnośnika"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Błędny typ powiązanego elementu"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Powiązany element nie istnieje"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Nie udało się powiązać elementu"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Twój formularz został zaakceptowany"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr ""
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Typ"
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Elementy powiązane"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Element"
 
@@ -2015,95 +2003,95 @@ msgstr "Nie znaleziono formularza."
 msgid "Failed to add the translation."
 msgstr "Nie udało się dodać tłumaczenia."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Tagi z pytań"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Tagi"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Tagi z pytań oraz określone tagi"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Tagi z pytań lub określone tagi"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "identyczne z odpowiedzią na pytanie"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "wyliczone z daty utworzenia zgłoszenia"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "equals to the answer to the question"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Pilność"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Kategoria"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Lokalizacja"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Brak walidacji"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Określony użytkownik lub grupa"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Czas na rozwiązanie"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuta"
@@ -2111,7 +2099,7 @@ msgstr[1] "Minut"
 msgstr[2] "Minut"
 msgstr[3] "Minut"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Godzina"
@@ -2119,7 +2107,7 @@ msgstr[1] "Godzin"
 msgstr[2] "Godzin"
 msgstr[3] "Godzin"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Dzień"
@@ -2127,7 +2115,7 @@ msgstr[1] "Dni"
 msgstr[2] "Dni"
 msgstr[3] "Dni"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Miesiąc"
@@ -2135,43 +2123,43 @@ msgstr[1] "Miesięcy"
 msgstr[2] "Miesięcy"
 msgstr[3] "Miesięcy"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Pilność"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Tagi zgłoszenia"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Tagi"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Lokalizacja"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Lokalizacja"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "Opis nie może być pusty!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] ""
@@ -2179,50 +2167,83 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Kontynuacja e-maila"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Użytkownik"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Grupa"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Dostawca"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Tak"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr ""
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr ""
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Formularz został utworzony"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Twoje zgłoszenie zostało zapisane"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2232,11 +2253,11 @@ msgstr ""
 "Możesz zobaczyć swoje odpowiedzi pod podanym adresem:\n"
 "##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Formularz z GLPI musi zostać zatwierdzony"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2246,11 +2267,11 @@ msgstr ""
 "Aby uzyskać dostęp kliknij na poniższy odnośnik:\n"
 "##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Twój formularz został odrzucony"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2263,7 +2284,7 @@ msgstr ""
 "Możesz go zmodyfikować i wysłać klikając na poniższy odnośnik:\n"
 "##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2271,11 +2292,11 @@ msgstr ""
 "Informujemy, że twój formularz został zaakceptowany przez osobę zatwierdzającą.\n"
 "Twój wniosek został przekazany do realizacji."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Twój formularz został usunięty przez administratora"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2283,76 +2304,99 @@ msgstr ""
 "Witaj,\\nZ przykrością informujemy, że twój zgłoszenie nie może zostać "
 "zrealizowane i zostało usunięte przez administratora. "
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Kreator formularzy - zsynchronizuj problemy katalogu usług"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Powtórzenie"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr ""
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Eksport"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Anuluj moje zgłoszenie"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr ""
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr ""
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Posumowanie problemów"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
 msgstr ""
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr ""
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr ""
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr ""
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Czy na pewno chcesz usunąć to pytanie?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Czy na pewno chcesz usunąć tą sekcję?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Dodaj tłumaczenia"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Wystąpił błąd w trakcie przetwarzania formularza"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr ""
 
@@ -2405,13 +2449,17 @@ msgstr "Dostęp ze stony domowej"
 msgid "Default form in service catalog"
 msgstr "Domyślny formularz w katalogu usług"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Czy jesteś robotem?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Wyślij"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr ""
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -12,24 +12,24 @@
 # Paulo Henrique <atual.paulo@gmail.com>, 2021
 # Pablo Pierre Ferreira <pablo.terdulino@gmail.com>, 2021
 # Rafael Viana <rafaelvian@gmail.com>, 2022
-# Pedro de Oliveira Lira <pedrolira@live.com>, 2022
 # Manoel Ramon, 2022
 # Eduardo Spinola <eduardo.spinola@gmail.com>, 2022
 # Thierry Bugier <tbugier@teclib.com>, 2022
 # Paulo Gobbato <paulo.paag@gmail.com>, 2022
-# Jean Vergaças <jvergacas@gmail.com>, 2022
 # Diego Nobre <diego@koruma.com.br>, 2022
 # Rafael Santos <rafacss@gmail.com>, 2022
 # Arthur Schaefer <arthur.r.schaefer@gmail.com>, 2022
+# Jean Vergaças <jvergacas@gmail.com>, 2022
+# Pedro de Oliveira Lira <pedrolira@live.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
-"Last-Translator: Arthur Schaefer <arthur.r.schaefer@gmail.com>, 2022\n"
+"Last-Translator: Pedro de Oliveira Lira <pedrolira@live.com>, 2022\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/teclib/teams/28042/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -82,10 +82,9 @@ msgstr "Limitar Sub níveis"
 msgid "No limit"
 msgstr "Nenhum limite"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Formulário"
@@ -152,8 +151,8 @@ msgstr "Erro ao excluir um ator."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Form Creator"
 
@@ -163,12 +162,12 @@ msgstr "Form Creator"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Lista de formulários"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Formulário salvo com sucesso!"
 
@@ -184,7 +183,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s adiciona a reserva %2$s para o item %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Categoria"
@@ -199,30 +197,25 @@ msgstr "Ver todos"
 msgid "Please, describe your need here"
 msgstr "Por favor, descreva o que precisa aqui"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Área de Texto"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Um campo obrigatório está vazio:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "A expressão regular é inválida"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Usuário"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Usuário e formulário"
 
@@ -259,166 +252,162 @@ msgstr ""
 "Para respeitar o sistema de entidades GLPI, deve-se selecionar "
 "\"Formulário\". Outras configurações quebrarão as restrições da entidade"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "Tamanho do LDAP excedido"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "Seleção LDAP"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "Diretório LDAP não definido!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "Diretório LDAP não encontrado!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Formato específico não corresponde: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "O texto é muito curto (mínimo %d caracteres): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "O texto é muito longo (máximo %d caracteres): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Texto"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Expressão regular"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Range"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Validação adicional"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Seleção única"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "O valor do campo é obrigatório:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Um campo obrigatório está vazio: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Isto não é um número inteiro: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "O número deve ser maior que %d: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "O número deve ser menor que %d: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Inteiro"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Indefinido"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "Endereço IP"
 msgstr[1] "Endereços IP"
 msgstr[2] "Endereços IP"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Urgência"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Muito alto"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Alto"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Médio"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Baixo"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Aviso\\: O plug-in da tag está desabilitado ou ausente"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Etiqueta"
 msgstr[1] "Etiquetas"
 msgstr[2] "Etiquetas"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "Objeto do GLPI"
 msgstr[1] "Objetos do GLPI"
 msgstr[2] "Objetos do GLPI"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Nome de Host"
 msgstr[1] "Nomes de Host"
 msgstr[2] "Nomes de Host"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Horário"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Este não é um e-mail válido: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Email"
@@ -429,42 +418,42 @@ msgstr[2] "Emails"
 msgid "Select"
 msgstr "Selecionar"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Data & hora"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Ator"
 msgstr[1] "Atores"
 msgstr[2] "Atores"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Valor inválido: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Usuário não encontrado ou endereço de e-mail inválido: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Nenhum documento anexado"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Documento anexado"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Faltando arquivo obrigatório: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Arquivo"
 
@@ -472,96 +461,95 @@ msgstr "Arquivo"
 msgid "Multiselect"
 msgstr "Seleção Múltipla"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Aviso\\: O plug-in de campos adicionais está desabilitado ou ausente"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Bloquear"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Campo"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "mostrar"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "Tipo de campo '%1$s' ainda não implementado!"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Alguns campos numéricos contêm valores não numéricos"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Alguns campos da URL contêm links inválidos"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Campos adicionais"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Caixas de Seleção"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "A questão precisa de pelo menos %d respostas"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "A questão não aceita mais que %d respostas"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Intervalo mín"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Intervalo máx"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Tipo de Solicitação"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Isto não é um número: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Float"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Data"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Descrição"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Um campo de \"descrição\" necessita de uma descrição:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Campo oculto"
 msgstr[1] "Campos ocultos"
 msgstr[2] "Campos ocultos"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Condição"
@@ -592,26 +580,26 @@ msgstr "Escondido a menos que"
 msgid "Displayed unless"
 msgstr "Exibido a menos que"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Falha ao adicionar ou atualiza o %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Não é possível exportar um objeto vazio: %s"
@@ -628,36 +616,36 @@ msgstr "Importando"
 msgid "Import in progress"
 msgstr "Importação em progresso"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Edição"
 msgstr[1] "Edições"
 msgstr[2] "Edições"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Atualizar dados de emissão de chamados e respostas de formulário"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Pesquisa de satisfação expirada"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Nome"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -665,106 +653,96 @@ msgstr[0] "Tipo"
 msgstr[1] "Tipos"
 msgstr[2] "Tipos"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Status"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Data de abertura"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Ultima atualização"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Entidade"
 msgstr[1] "Entidades"
 msgstr[2] "Entidades"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Solicitante"
 msgstr[1] "Solicitantes"
 msgstr[2] "Solicitantes"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Aprovador do requisição"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Comentário"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Aprovador do Chamado"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Técnico"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Grupo do técnico"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Grupo aprovador da requisição"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Não validado"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Rejeitado"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Todos"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Novo"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Atribuído"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Aguardando Aprovação"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "Validar"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Resolvido"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Fechado"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Categoria do formulário"
@@ -783,19 +761,19 @@ msgstr "Como filho de"
 msgid "The form as been saved"
 msgstr "Formulário salvo"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Um formulário precisa de validação"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Formulário rejeitado"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Formulário aceito"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Formulário deletado"
 
@@ -808,14 +786,11 @@ msgid "Form name"
 msgstr "Nome do formulário"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Validador"
-msgstr[1] "Validadores"
-msgstr[2] "Validadores"
+msgstr "Validador"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Data de criação"
 
@@ -840,15 +815,15 @@ msgid "Author"
 msgstr "Autor"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Aprovador"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Por autor"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Validador do formulário"
 
@@ -856,7 +831,7 @@ msgstr "Validador do formulário"
 msgid "Specific person"
 msgstr "Pessoa específica"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Pessoa da questão"
 
@@ -864,7 +839,7 @@ msgstr "Pessoa da questão"
 msgid "Specific group"
 msgstr "Grupo específico"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Grupo da questão"
 
@@ -880,15 +855,15 @@ msgstr "Grupo técnico de um objeto"
 msgid "Specific supplier"
 msgstr "Fornecedor específico"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Fornecedor da questão"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Atores da questão"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Supervisor do autor de formulário"
 
@@ -896,7 +871,7 @@ msgstr "Supervisor do autor de formulário"
 msgid "Observer"
 msgstr "Observador"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Atribuído para"
 
@@ -927,78 +902,87 @@ msgstr "Falha ao encontrar um grupo\\: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Falha ao encontrar um fornecedor\\: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Rejeitado"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Aceito"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Resposta do formulário"
 msgstr[1] "Respostas do formulário"
 msgstr[2] "Respostas do formulário"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Imprimir este formulário"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Formulário aceito pelo validador."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Formulário salvo com sucesso."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Salvar"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Necessário se rejeitado"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Rejeitar"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Editar respostas"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Cancelar edição"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Aceitar"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "É necessário o comentário de rejeição !"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Você não é o validador destas respostas"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Dados do formulário"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Impossível gerar alvos!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Nenhum conjunto de teste encontrado"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Falha no teste de Turing"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Você precisa selecionar um validador!"
 
@@ -1010,15 +994,15 @@ msgstr "Você não pode excluir este problema. Talvez seja levado em conta."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Falha ao excluir este problema. Um erro interno ocorreu."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Serviços"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Meus chamados"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Consultar feeds"
 
@@ -1052,16 +1036,16 @@ msgstr[0] "Idioma do formulário"
 msgstr[1] "Idiomas do formulário"
 msgstr[2] "Idiomas do formulário"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Tradução"
 msgstr[1] "Traduções"
 msgstr[2] "Traduções"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "O nome não pode ser vazio!"
 
@@ -1073,7 +1057,7 @@ msgstr "A língua deve ser associada a um formulário!"
 msgid "Add a translation"
 msgstr "Adicionar tradução"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Atualizar uma tradução"
 
@@ -1094,7 +1078,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Você gostaria de deletar os itens selecionados?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Deletar"
 
@@ -1111,32 +1095,39 @@ msgstr "Adicionar uma nova linguagem"
 msgid "Language"
 msgstr "Linguagem"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Nenhum"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Validador"
+msgstr[1] "Validadores"
+msgstr[2] "Validadores"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Precisa de validação?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Não"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Salvar"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Validação"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Escolha um validador"
 
@@ -1147,14 +1138,14 @@ msgstr[0] "Problema alvo"
 msgstr[1] "Problemas alvo"
 msgstr[2] "Problemas alvo"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Propriedades"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1163,29 +1154,29 @@ msgstr ""
 "Falha ao adicionar ou atualizar o %1$s %2$s: uma questão está faltando e é "
 "usada em um parâmetro do alvo"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Atores"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Título do problema"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Conteúdo"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Impacto"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Causa"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Sintoma"
 
@@ -1252,48 +1243,48 @@ msgstr "Altura variável"
 msgid "Uniform height"
 msgstr "Altura uniforme"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Modo de helpdesk"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Modo de lista do formulário padrão"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Ordem de classificação"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Base de conhecimento"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Pesquisar"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Painel de contadores"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Mensagem de cabeçalho"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Problema de pesquisa"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Estilo dos cartões"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1301,26 +1292,26 @@ msgstr[0] "Cabeçalho"
 msgstr[1] "Cabeçalhos"
 msgstr[2] "Cabeçalhos"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Exibir campo de pesquisa"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Mostrar cabeçalho"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Faixa da questão"
 msgstr[1] "Faixas da questão"
 msgstr[2] "Faixas da questão"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Faixa mínima"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "faixa máxima"
 
@@ -1340,7 +1331,7 @@ msgstr "Acesso restrito"
 msgid "Answers waiting for validation"
 msgstr "Respostas aguardando validação"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Importar formulários"
 
@@ -1404,7 +1395,7 @@ msgstr[2] "Alvos"
 msgid "Actions"
 msgstr "Ações"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Adicionar em alvo"
 
@@ -1420,123 +1411,123 @@ msgstr "Propriedades"
 msgid "What are you looking for?"
 msgstr "O que você está procurando?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Meus %1$d últimos formulários (requerente)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Nenhum formulário postado ainda"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Todos os formulários (requerente)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Meus %1$d últimos formulários (validador)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Nenhum formulário aguarda validação"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Todos os formulários (validador)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "Não é possível usar um nome vazio para as respostas do formulário. Mantendo "
 "o valor anterior."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "A pergunta 1%s não é compatível com formulários públicos"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Erro ao duplicar"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Publicar"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Formulário duplicado: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Formulário transferido: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Voltar"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "O upload de arquivos JSON não é permitido."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "Você pode permitir arquivos JSON agora."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Criar"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Entre em contato com o administrador do GLPI."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Voltar"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "O upload de arquivos JSON não está habilitado."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "Você pode habilitar os arquivos JSON agora."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Habilitar"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Enviar"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Impossível importar o formulário, o arquivo está vazio"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Impossível importar o formulário, arquivo corrompido"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "Impossível importar o formulário, arquivo gerado em outra versão"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1544,61 +1535,61 @@ msgstr ""
 "O arquivo não especifica a versão do esquema. Provavelmente foi gerado com "
 "uma versão mais velha que 2.10. Desistir."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Falha ao importar %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Formulários importados com sucesso de %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "O formulário %1$s já existe e está em uma entidade não modificável."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "Você não tem o direito de atualizar a entidade%1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "A entidade %1$s é necessária para o formulário %2$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Falha ao criar o tipo de documento JSON"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Tipo de documento JSON não encontrado"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Falha ao atualizar o tipo de documento JSON"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Formulários sem categoria"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Nenhum formulário disponível"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Adicionar"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Tipo de alvo não suportado."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1646,11 +1637,8 @@ msgstr "O título é obrigatório"
 msgid "Failed to find %1$s %2$s"
 msgstr "Falha ao encontrar %1$s %2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Questão"
@@ -1686,48 +1674,48 @@ msgstr "Este tipo de questão requer parâmetros"
 msgid "A parameter is missing for this question type"
 msgstr "Um parâmetro está faltando para este tipo de questão"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Níveis de serviço"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Bens"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Assistência"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Gerenciamento"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Ferramentas"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notas"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "Feed RSS"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Administração"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Plugin"
@@ -1856,120 +1844,120 @@ msgstr[0] "Relação composta do chamado"
 msgstr[1] "Relações composta do chamado"
 msgstr[2] "Relações composta do chamado"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Chamado alvo"
 msgstr[1] "Chamados alvo"
 msgstr[2] "Chamados alvo"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Ativo específico"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Igual a resposta da questão"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Última resposta válida"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr "Origem do modelo ou padrão do usuário ou padrão do GLPI"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Criador de formulários"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Padrão ou a partir de um modelo"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Tipo específico"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Título do chamado"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr ""
 "Adicionar mensagem de validação como primeiro acompanhamento do chamado"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Adicionar um campo "
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Campos gerenciados"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Nenhum campo gerenciado"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Link para outro chamado"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Outro destino deste formulário"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Um chamado existente"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Um chamado de uma resposta para uma pergunta"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Apagar permanentemente"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Tipo de vínculo inválido"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Tipo de item vinculado inválido"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Item vinculado não existe"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Falha ao vincular o item"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Seu formulário foi aceito pelo validador"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Origem da solicitação"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Tipo "
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Elementos associados"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Item "
 
@@ -1989,211 +1977,242 @@ msgstr "Formulário não encontrado."
 msgid "Failed to add the translation."
 msgstr "Falia ao adiciona a tradução."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Tags das perguntas do formulário"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Tags específicas"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Tags das perguntas e tags específicas"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Tags de perguntas ou tags específicas"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "igual a resposta da questão"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "calculado da data de criação do chamado"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "calculado da resposta a questão"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "SLA do modelo ou nenhum"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "SLA Específico"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "OLA do modelo ou nenhum"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "OLA Específico"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Urgência do modelo ou Média"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Urgência específica"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Categoria do modelo ou nenhum"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Categoria específica"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Localização do modelo ou nenhuma"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Localização específica"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Sem validação"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Usuário ou grupo especifico"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Usuário da resposta da pergunta"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Grupo de resposta da pergunta"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Tempo para solução"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuto"
 msgstr[1] "Minutos"
 msgstr[2] "Minutos"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hora"
 msgstr[1] "Horas"
 msgstr[2] "Horas"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Dia"
 msgstr[1] "Dias"
 msgstr[2] "Dias"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Mês"
 msgstr[1] "Meses"
 msgstr[2] "Meses"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Questão (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Urgência "
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Tags do chamado"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Tags"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Localização"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Localização "
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "A descrição não pode ser vazia!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Observador"
 msgstr[1] "Observadores"
 msgstr[2] "Observadores"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Acompanhamento de e-mail"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Usuário"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Grupo"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Fornecedor"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Sim"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Grupo do objeto"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Grupo técnico do objeto"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"Atualizar tabelas para innoDB; execute php bin/console "
-"glpi:migration:myisam_to_innodb"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Formulário criado"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Sua requisição foi salva"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2203,11 +2222,11 @@ msgstr ""
 "##formcreator.request_id## e transmitido para a equipe de helpdesk.\\nVocê "
 "pode ver suas respostas no seguinte link:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Um formulário vindo do GLPI necessita ser validado"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2217,11 +2236,11 @@ msgstr ""
 "validador.\\nVocê pode acessá-lo clicando neste "
 "link:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Seu formulário foi recusado pelo validador"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2233,7 +2252,7 @@ msgstr ""
 "modificá-lo e re-submetê-lo clicando neste "
 "link:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2241,11 +2260,11 @@ msgstr ""
 "Olá,\\nTemos a satisfação de informá-lo que o seu formulário foi aceito pelo"
 " validador.\\nSua solicitação será considerada em breve."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Seu formulário foi deletado por um administrador"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2253,42 +2272,61 @@ msgstr ""
 "Olá,\\nNós lamentamos informar que a sua solicitação não pode ser "
 "considerada e foi deletada por um administrador."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator - Sincronizar problemas do catálogo de serviços"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Transferir"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Exportar"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Cancelar meu chamado"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "antigo"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Número de %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Resumo dos problemas"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2296,36 +2334,40 @@ msgstr ""
 "O mini painel do Formcreator não pode ser usado como padrão. Esta "
 "configuração foi ignorada."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr ""
 "Nenhum formulário encontrado. Por favor, escolha um formulário abaixo."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "Nenhum formulário encontrado."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "Nenhum item do FAQ encontrado."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Tem certeza que quer deletar esta questão?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Tem certeza que quer deletar esta seção?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Adicionar traduções"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Um erro ocorreu enquanto requisitando forumlários"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Tem certeza de que deseja excluir este destino:"
 
@@ -2377,13 +2419,17 @@ msgstr "Acesso direto na página inicial"
 msgid "Default form in service catalog"
 msgstr "Formulário padrão no catálogo de serviços"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Você é um robô ?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Enviar"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Condições de exibição da seção"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/ru_RU.po
+++ b/locales/ru_RU.po
@@ -6,19 +6,19 @@
 # Translators:
 # Kirill Smyshkov <rzd10let@gmail.com>, 2021
 # Alexey Petukhov <lexx015@gmail.com>, 2022
-# Thierry Bugier <tbugier@teclib.com>, 2022
-# Nikolai Petrov <techobsl@yandex.ru>, 2022
 # Ilya Pavlov <spirkaa@gmail.com>, 2022
 # Alexander Sokolov <a.sokolov@outlook.com>, 2022
+# Thierry Bugier <tbugier@teclib.com>, 2022
+# Nikolai Petrov <techobsl@yandex.ru>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
-"Last-Translator: Alexander Sokolov <a.sokolov@outlook.com>, 2022\n"
+"Last-Translator: Nikolai Petrov <techobsl@yandex.ru>, 2022\n"
 "Language-Team: Russian (Russia) (https://www.transifex.com/teclib/teams/28042/ru_RU/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -71,10 +71,9 @@ msgstr "Глубина видимости вложенных элементов 
 msgid "No limit"
 msgstr "Без ограничений"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Форма"
@@ -142,8 +141,8 @@ msgstr "Ошибочный запрос при удалении участник
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Создатель форм"
 
@@ -153,12 +152,12 @@ msgstr "Создатель форм"
 msgid "%1$s = %2$s"
 msgstr "%1$s=%2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Список форм"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Форма успешно сохранена!"
 
@@ -174,7 +173,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$sдобавляет резервирование %2$s для элемента %3$s"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Категория"
@@ -190,30 +188,25 @@ msgstr "Показать все"
 msgid "Please, describe your need here"
 msgstr "Введите запрос для поиска"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Текстовое поле"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Обязательное поле пустое:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "Недействительное регулярное выражение"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Пользователь"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Пользователь и форма"
 
@@ -251,96 +244,92 @@ msgstr ""
 "Чтобы соответствовать системе организаций GLPI, следует выбрать «Форма». "
 "Другие настройки могут нарушить ограничения организации"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "Превышено ограничение размера LDAP"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "Выбор LDAP"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "LDAP каталог не определен!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "LDAP каталог не найден!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Указанный формат не соответствует: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "Текст слишком короткий (минимум %d символов): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "Текст слишком длинный (максимум %d символов): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Текст"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Регулярное выражение"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Диапазон"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Дополнительная проверка"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Переключатели"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "Требуется указать значение поля:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Обязательное поле пустое: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Это не целое число: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "Число должно быть больше, чем %d: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "Число должно быть меньше, чем %d: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Целое число"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Не определено"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "IP адрес"
@@ -348,40 +337,40 @@ msgstr[1] "IP адреса"
 msgstr[2] "IP адреса"
 msgstr[3] "IP адреса"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Срочность"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Очень высокий"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Высокий"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Средний"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Низкий"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Осторожно: Тег плагина отключен либо утерян"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Метка"
@@ -389,7 +378,7 @@ msgstr[1] "Метки"
 msgstr[2] "Метки"
 msgstr[3] "Метки"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "Объект GLPI"
@@ -397,7 +386,7 @@ msgstr[1] "Объекты GLPI"
 msgstr[2] "Объекты GLPI"
 msgstr[3] "Объекты GLPI"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Имя хоста"
@@ -405,16 +394,16 @@ msgstr[1] "Имя хостов"
 msgstr[2] "Имя хостов"
 msgstr[3] "Имя хостов"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Время"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "Это недействительный адрес электронной почты: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "Электронная почта"
@@ -426,11 +415,11 @@ msgstr[3] "Электронные почты"
 msgid "Select"
 msgstr "Выбор"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Дата и время"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "Участник"
@@ -438,32 +427,32 @@ msgstr[1] "Участники"
 msgstr[2] "Участники"
 msgstr[3] "Участники"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Недействительное значение: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr ""
 "Пользователь не найден или недействительный адрес электронной почты: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Нет прикрепленных документов"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Прикрепленный документ"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Отсутствует требуемый файл: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Файл"
 
@@ -471,88 +460,88 @@ msgstr "Файл"
 msgid "Multiselect"
 msgstr "Множественный выбор"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Осторожно: плагин Дополнительные поля отключен либо утерян"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Заблокировано"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Поле"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "показать"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "Тип поля \"%1$s\" еще не реализован !"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Некоторые числовые поля содержат не числовые значения"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Некоторые URL-поля содержат неверные ссылки"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Дополнительные поля"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "Галочки"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "Этот вопрос требует не менее %d ответов"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "Этот вопрос требует не более %d ответов"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Диапазон мин."
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Диапазон макс."
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "Тип запроса"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Это не число: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Число с плавающей запятой"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Дата"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Описание"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Поле с описанием должно содержать описание:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Скрытые поля"
@@ -560,8 +549,7 @@ msgstr[1] "Скрытые поля"
 msgstr[2] "Скрытые поля"
 msgstr[3] "Скрытые поля"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Условие"
@@ -593,26 +581,26 @@ msgstr "Скрыт до тех пор, пока"
 msgid "Displayed unless"
 msgstr "Отображается до тех пор, пока"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "Не удалось добавить или обновить %1$s %2$s"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Невозможно экспортировать пустой объект: %s"
@@ -629,7 +617,7 @@ msgstr "Импорт"
 msgid "Import in progress"
 msgstr "Идет процесс импорта"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Проблема"
@@ -637,29 +625,29 @@ msgstr[1] "Проблемы"
 msgstr[2] "Проблемы"
 msgstr[3] "Проблемы"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Обновление данных о проблемах из заявок и ответов на формы"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Срок опроса удовлетворенности истек"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Имя"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "ID"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
@@ -668,20 +656,19 @@ msgstr[1] "Типы"
 msgstr[2] "Типы"
 msgstr[3] "Типы"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Статус"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Дата открытия"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Последнее обновление"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Сущность"
@@ -689,9 +676,9 @@ msgstr[1] "Сущности"
 msgstr[2] "Сущности"
 msgstr[3] "Сущности"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "Заказчик"
@@ -699,77 +686,68 @@ msgstr[1] "Заказчики"
 msgstr[2] "Заказчики"
 msgstr[3] "Заказчики"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Согласующий форму"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Комментарий"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Согласующий заявку"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Техник"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Группа техников"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Группа, согласующая форму"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Не согласовано"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Отклонено"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s%2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Все"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Новый"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Назначенный"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Ожидание"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "На согласовании"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Решено"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Закрыто"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Категория формы"
@@ -789,19 +767,19 @@ msgstr "Родитель"
 msgid "The form as been saved"
 msgstr "Форма сохранена"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Форма требует согласования"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Форма отклонена"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Форма принята"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Форма удалена"
 
@@ -814,15 +792,11 @@ msgid "Form name"
 msgstr "Название формы"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Согласующий"
-msgstr[1] "Согласующие"
-msgstr[2] "Согласующие"
-msgstr[3] "Согласующие"
+msgstr "Согласующий"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Дата создания"
 
@@ -847,15 +821,15 @@ msgid "Author"
 msgstr "Автор"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Согласующий"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Автор формы"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Согласующий форму"
 
@@ -863,7 +837,7 @@ msgstr "Согласующий форму"
 msgid "Specific person"
 msgstr "Конкретный пользователь"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Пользователь из вопроса"
 
@@ -871,7 +845,7 @@ msgstr "Пользователь из вопроса"
 msgid "Specific group"
 msgstr "Конкретная группа"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Группа из вопроса"
 
@@ -887,15 +861,15 @@ msgstr "Тех группа из объекта"
 msgid "Specific supplier"
 msgstr "Конкретный поставщик"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Поставщик из вопроса"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Участники из вопроса"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Менеджер автора формы"
 
@@ -903,7 +877,7 @@ msgstr "Менеджер автора формы"
 msgid "Observer"
 msgstr "Наблюдатель"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Назначенный на"
 
@@ -935,11 +909,15 @@ msgstr "Ошибка поиска группы: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Ошибка поиска поставщика: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Отклонено"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Согласовано"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Ответ формы"
@@ -947,67 +925,72 @@ msgstr[1] "Ответы формы"
 msgstr[2] "Ответы формы"
 msgstr[3] "Ответы формы"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Печать этой формы"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Форма принята согласующим."
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Форма успешно сохранена."
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Сохранить"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Требуется если отклонено"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Отклонить"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Редактировать ответы"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Отменить редактирование"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Принять"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Требуется комментарий для отклонения!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Вы не согласующий этих ответов"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Данные формы"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Не удалось создать цели!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Нет набора тестов Тьюринга"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Вы провалили тест Тьюринга"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Вы должны выбрать согласующего!"
 
@@ -1019,15 +1002,15 @@ msgstr "Вы не можете удалить эту проблему. Може�
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Не удалось удалить эту проблему. Произошла внутренняя ошибка."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Обратиться за помощью"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Мои обращения"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "RSS каналы"
 
@@ -1063,7 +1046,7 @@ msgstr[1] "Языки формы"
 msgstr[2] "Языки формы"
 msgstr[3] "Языки формы"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Перевод"
@@ -1071,9 +1054,9 @@ msgstr[1] "Переводы"
 msgstr[2] "Переводы"
 msgstr[3] "Переводы"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "Требуется указать название!"
 
@@ -1085,7 +1068,7 @@ msgstr "Язык должен быть связан с формой!"
 msgid "Add a translation"
 msgstr "Добавить перевод"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Обновить перевод"
 
@@ -1106,7 +1089,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Вы хотите удалить выбранные элементы?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Удалить"
 
@@ -1123,32 +1106,40 @@ msgstr "Добавить новый язык"
 msgid "Language"
 msgstr "Язык"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Ничего"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Согласующий"
+msgstr[1] "Согласующие"
+msgstr[2] "Согласующие"
+msgstr[3] "Согласующие"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Нужна проверка?"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Нет"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Сохранить"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Согласование"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Выбрать согласующего"
 
@@ -1160,14 +1151,14 @@ msgstr[1] "Целевые проблемы"
 msgstr[2] "Целевые проблемы"
 msgstr[3] "Целевые проблемы"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Свойства"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1176,29 +1167,29 @@ msgstr ""
 "Не удалось добавить или обновить %1$s %2$s: вопрос отсутствует и "
 "используется в качестве параметра цели"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "Участники"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Проблема заголовка"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "Содержание"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Влияние"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Причина"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Признак"
 
@@ -1265,48 +1256,48 @@ msgstr "Изменяемая высота"
 msgid "Uniform height"
 msgstr "Единая высота"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Служба поддержки"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Режим службы поддержки"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Режим Список форм по умолчанию"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Порядок сортировки"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "База знаний"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Поиск"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Панель счетчиков"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Сообщение в заголовке"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Проблема с поиском"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Стиль заголовка"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
@@ -1315,15 +1306,15 @@ msgstr[1] "Заголовки"
 msgstr[2] "Заголовки"
 msgstr[3] "Заголовки"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Показать поле поиска"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Показать заголовок"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Диапазон вопроса"
@@ -1331,11 +1322,11 @@ msgstr[1] "Диапазоны вопроса"
 msgstr[2] "Диапазоны вопроса"
 msgstr[3] "Диапазоны вопроса"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "Минимальный диапазон"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "максимальный диапазон"
 
@@ -1355,7 +1346,7 @@ msgstr "Ограниченный доступ"
 msgid "Answers waiting for validation"
 msgstr "Вопросы ожидают проверку"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Импорт форм"
 
@@ -1420,7 +1411,7 @@ msgstr[3] "Цели"
 msgid "Actions"
 msgstr "Действия"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Добавить цель"
 
@@ -1436,123 +1427,123 @@ msgstr "свойства"
 msgid "What are you looking for?"
 msgstr "Введите запрос для поиска"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Мои %1$d последние формы (заказчик)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Нет заполненных форм"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Все мои формы (заказчик)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Мои %1$d последние формы (согласующий)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Нет форм для согласования"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Все мои формы (согласующий)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr ""
 "Нельзя использовать пустое имя для ответов в форме. Сохранение предыдущего "
 "значения."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "Вопрос \"%s\" несовместим с публичными формами"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Ошибка дублирования"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Дублировать"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "Опубликовать"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Форма дублирована: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Форма передана: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Назад"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "Загрузка файлов JSON не разрешена."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "Вы можете разрешить файлы JSON прямо сейчас."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Создать"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Пожалуйста, свяжитесь с администратором GLPI."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Назад"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "Загрузка файлов JSON не включена."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "Вы можете включить файлы JSON прямо сейчас."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Включить"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Отправить"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Импорт форм невозможен, файл пуст"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Импорт форм невозможен, возможно файл поврежден"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "Импорт форм невозможен, файл создан в другой версии"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1560,63 +1551,63 @@ msgstr ""
 "В файле не указана версия схемы. Вероятно, он был создан более ранней "
 "версией, чем 2.10. Отказ."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "Не удалось импортировать %s"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Формы успешно импортированы из %s"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr ""
 "Форма %1$s уже существует в организации, в которой у вас нет прав "
 "редактирования."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "У вас нет прав редактирования организации %1$s."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "Для формы %2$s требуется организация %1$s."
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "Не удалось создать тип документа JSON"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "Тип документа JSON не найден"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "Не удалось обновить тип документа JSON"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Формы без категории"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Нет доступных форм"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Добавить"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Неподдерживаемый тип цели."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1666,11 +1657,8 @@ msgstr "Требуется указать заголовок"
 msgid "Failed to find %1$s %2$s"
 msgstr "Ошибка поиска %1$s%2$s"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Вопрос"
@@ -1707,48 +1695,48 @@ msgstr "Этот тип вопроса требует указания пара�
 msgid "A parameter is missing for this question type"
 msgstr "Для этого типа вопроса не указаны параметры"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Уровень поддержки"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "SLA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "OLA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Активы"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Помощь"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Управление"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Инструменты"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Заметки"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS-лента"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "Администрация"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Плагин"
@@ -1882,7 +1870,7 @@ msgstr[1] "Связи составной заявки"
 msgstr[2] "Связи составной заявки"
 msgstr[3] "Связи составной заявки"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Заявка"
@@ -1890,113 +1878,113 @@ msgstr[1] "Заявки"
 msgstr[2] "Заявки"
 msgstr[3] "Заявки"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Конкретный актив"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Точный ответ на вопрос"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Последний действительный ответ"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr ""
 "Источник из шаблона или пользователь по умолчанию или GLPI по умолчанию"
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Редактор форм"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "По умолчанию или из шаблона"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Конкретный тип"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Заголовок заявки"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "Добавить сообщение о согласовании как первый комментарий заявки"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Добавить поле"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Управляемые поля"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Нет управляемых полей"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Связать с другой заявкой"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Другая цель этой формы"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Существующая заявка"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Заявка из ответа на вопрос"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Удалить навсегда"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Недействительный тип связи"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Недействительный тип связанного элемента"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Связанный элемент не существует"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Не удалось связать элемент"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Ваша форма была принята согласующим"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "Источник запроса"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Тип "
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "Связанные элементы"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Элемент "
 
@@ -2016,95 +2004,95 @@ msgstr "Форма не найдена."
 msgid "Failed to add the translation."
 msgstr "Не удалось добавить перевод."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Метки из вопросов"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Конкретные метки"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Метки из вопросов И конкретные метки"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Метки из вопросов ИЛИ конкретные метки"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "Точный ответ на вопрос"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "Рассчитать из даты создания заявки"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "Рассчитать из ответа на вопрос"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "SLA из шаблона или ничего"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "Конкретный SLA"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "OLA из шаблона или ничего"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "Конкретный OLA"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Срочность из шаблона или Средняя"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Конкретная срочность"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Категория из шаблона или ничего"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Конкретная категория"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Местоположение из шаблона или ничего"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Конкретное местоположение"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Без проверки"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Специальный пользователь или группа"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Пользователь из ответа на вопрос"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Группа из ответа на вопрос"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Время до решения"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Минута"
@@ -2112,7 +2100,7 @@ msgstr[1] "Минуты"
 msgstr[2] "Минуты"
 msgstr[3] "Минуты"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Час"
@@ -2120,7 +2108,7 @@ msgstr[1] "Часы"
 msgstr[2] "Часы"
 msgstr[3] "Часы"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "День"
@@ -2128,7 +2116,7 @@ msgstr[1] "Дни"
 msgstr[2] "Дни"
 msgstr[3] "Дни"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "Месяц"
@@ -2136,43 +2124,43 @@ msgstr[1] "Месяцы"
 msgstr[2] "Месяцы"
 msgstr[3] "Месяцы"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "SLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Вопрос (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "OLA (TTO/TTR)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Срочность"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Метки заявки"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Метки"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Местоположение"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Местоположение "
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "Требуется указать описание!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "Наблюдатель"
@@ -2180,52 +2168,83 @@ msgstr[1] "Наблюдатели"
 msgstr[2] "Наблюдатели"
 msgstr[3] "Наблюдатели"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "Отменить"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "Отслеживать по Email"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Пользователь"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Группа"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Поставщик"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Да"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Группа из объекта"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Тех группа из объекта"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"Обновление таблиц в innoDB; запустите php bin/console "
-"glpi:migration:myisam_to_innodb"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Форма создана"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "Ваш запрос сохранен"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2235,11 +2254,11 @@ msgstr ""
 "##formcreator.request_id## и передан в службу поддержки.\\nВы можете "
 "посмотреть его по ссылке:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Требуется согласовать форму"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2249,11 +2268,11 @@ msgstr ""
 "согласующего.\\nПерейдите по ссылке для "
 "согласования:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr "Ваш запрос отклонен согласующим"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2265,17 +2284,17 @@ msgstr ""
 "исправления и отправить его заново по "
 "ссылке:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
 msgstr "Здравствуйте,\\nВаш запрос согласован и будет вскоре рассмотрен."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Ваш запрос удален администратором"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
@@ -2283,42 +2302,61 @@ msgstr ""
 "Здравствуйте,\\nВаш запрос не может быть рассмотрен и был удален "
 "администратором."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator - Проблемы каталога службы синхронизации"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Дублировать"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Передача"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Экспорт"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Отменить мою заявку"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Старый"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "Номер из %s"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Список проблем"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2326,35 +2364,39 @@ msgstr ""
 "Мини-панель Formcreator не используется по умолчанию. Эта настройка была "
 "проигнорирована."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr "Форма не найдена. Пожалуйста выберите форму из списка ниже"
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "Форма не найдена."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "Не найдено записи FAQ"
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Вы уверены, что хотите удалить этот вопрос?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Вы уверены, что хотите удалить этот раздел?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Добавить перевод"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Произошла ошибка во время выполнения запроса форм"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Вы уверены, что хотите удалить этот объект:"
 
@@ -2407,13 +2449,17 @@ msgstr "Прямой доступ с домашней страницы"
 msgid "Default form in service catalog"
 msgstr "Форма по умолчанию в каталоге услуг"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Вы робот?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Отправить"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Условие показа раздела"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/locales/tr_TR.po
+++ b/locales/tr_TR.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:10+0200\n"
+"POT-Creation-Date: 2022-10-14 17:09+0200\n"
 "PO-Revision-Date: 2021-08-30 07:22+0000\n"
 "Last-Translator: Kaya Zeren <kayazeren@gmail.com>, 2022\n"
 "Language-Team: Turkish (Turkey) (https://www.transifex.com/teclib/teams/28042/tr_TR/)\n"
@@ -68,10 +68,9 @@ msgstr "Alt ağacın derinlik sınırı"
 msgid "No limit"
 msgstr "Sınır yok"
 
-#: ajax/homepage_link.php:36 inc/field/dropdownfield.class.php:71
-#: inc/formlist.class.php:46 inc/formanswer.class.php:208
+#: ajax/homepage_link.php:36 inc/formlist.class.php:46
 #: inc/entityconfig.class.php:82 inc/form.class.php:111 inc/form.class.php:569
-#: inc/form.class.php:1921 inc/filter/entityfilter.class.php:45
+#: inc/form.class.php:1951
 msgid "Form"
 msgid_plural "Forms"
 msgstr[0] "Form"
@@ -137,8 +136,8 @@ msgstr "Bir ilgili silinirken hatalı bir istek yapıldı."
 
 #: front/targetticket.form.php:95 front/targetchange.form.php:81
 #: front/formanswer.php:47 front/targetproblem.form.php:81
-#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:686
-#: inc/common.class.php:693
+#: front/formanswer.form.php:78 front/form.php:44 inc/common.class.php:689
+#: inc/common.class.php:696
 msgid "Form Creator"
 msgstr "Form Oluşturucu"
 
@@ -148,12 +147,12 @@ msgstr "Form Oluşturucu"
 msgid "%1$s = %2$s"
 msgstr "%1$s = %2$s"
 
-#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:683
+#: front/formlist.php:45 front/formlist.php:48 inc/common.class.php:686
 msgid "Form list"
 msgstr "Form listesi"
 
-#: front/formdisplay.php:90 inc/formanswer.class.php:886
-#: inc/formanswer.class.php:1107 inc/formanswer.class.php:1157
+#: front/formdisplay.php:90 inc/formanswer.class.php:889
+#: inc/formanswer.class.php:1120 inc/formanswer.class.php:1170
 msgid "The form has been successfully saved!"
 msgstr "Form kaydedildi!"
 
@@ -169,7 +168,6 @@ msgid "%1$s adds the reservation %2$s for item %3$s"
 msgstr "%1$s, %3$s ögesinin %2$s ayırtmasını ekledi"
 
 #: inc/knowbase.class.php:60 inc/form.class.php:646
-#: inc/abstractitiltarget.class.php:953 inc/abstractitiltarget.class.php:967
 msgid "Category"
 msgid_plural "Categories"
 msgstr[0] "Kategori"
@@ -183,30 +181,25 @@ msgstr "Tümünü görüntüle"
 msgid "Please, describe your need here"
 msgstr "Lütfen neye gerek duyduğunuzu yazın"
 
-#: inc/field/textareafield.class.php:102
+#: inc/field/textareafield.class.php:183
 msgid "Textarea"
 msgstr "Metin alanı"
 
-#: inc/field/textareafield.class.php:160 inc/field/dropdownfield.class.php:440
-#: inc/field/ldapselectfield.class.php:152 inc/field/textfield.class.php:124
-#: inc/field/urgencyfield.class.php:164 inc/field/tagfield.class.php:162
-#: inc/field/timefield.class.php:112 inc/field/fieldsfield.class.php:486
-#: inc/field/requesttypefield.class.php:159
+#: inc/field/textareafield.class.php:242 inc/field/dropdownfield.class.php:440
+#: inc/field/ldapselectfield.class.php:114 inc/field/textfield.class.php:125
+#: inc/field/urgencyfield.class.php:165 inc/field/tagfield.class.php:163
+#: inc/field/timefield.class.php:113 inc/field/fieldsfield.class.php:488
+#: inc/field/requesttypefield.class.php:160
 msgid "A required field is empty:"
 msgstr "Zorunlu bir alan boş bırakılmış:"
 
-#: inc/field/textareafield.class.php:178 inc/field/textfield.class.php:177
-#: inc/field/integerfield.class.php:111 inc/field/floatfield.class.php:192
+#: inc/field/textareafield.class.php:260 inc/field/textfield.class.php:178
+#: inc/field/integerfield.class.php:112 inc/field/floatfield.class.php:193
 #: inc/conditionnabletrait.class.php:70
 msgid "The regular expression is invalid"
 msgstr "Kurallı ifade geçersiz"
 
-#: inc/field/dropdownfield.class.php:70 inc/filter/entityfilter.class.php:44
-#: inc/abstractitiltarget.class.php:2028 inc/abstractitiltarget.class.php:2046
-msgid "User"
-msgstr "Kullanıcı"
-
-#: inc/field/dropdownfield.class.php:72 inc/filter/entityfilter.class.php:46
+#: inc/field/dropdownfield.class.php:73 inc/filter/entityfilter.class.php:46
 msgid "User and form"
 msgstr "Kullanıcı ve form"
 
@@ -242,162 +235,158 @@ msgstr ""
 "GLPI birim sistemine uymak için \"Form\" seçilmelidir. Diğer ayarlar birim "
 "kısıtlamalarını bozar"
 
-#: inc/field/ldapselectfield.class.php:109
-msgid "LDAP size limit exceeded"
-msgstr "LDAP boyutu sınırı aşıldı"
-
-#: inc/field/ldapselectfield.class.php:133
+#: inc/field/ldapselectfield.class.php:95
 msgid "LDAP Select"
 msgstr "LDAP Seçin"
 
-#: inc/field/ldapselectfield.class.php:177
+#: inc/field/ldapselectfield.class.php:139
 msgid "LDAP directory not defined!"
 msgstr "LDAP dizini belirtilmemiş!"
 
-#: inc/field/ldapselectfield.class.php:184
+#: inc/field/ldapselectfield.class.php:146
 msgid "LDAP directory not found!"
 msgstr "LDAP dizini bulunamadı!"
 
-#: inc/field/textfield.class.php:145 inc/field/integerfield.class.php:70
-#: inc/field/floatfield.class.php:154
+#: inc/field/textfield.class.php:146 inc/field/integerfield.class.php:71
+#: inc/field/floatfield.class.php:155
 #, php-format
 msgid "Specific format does not match: %s"
 msgstr "Özel biçim eşleşmiyor: %s"
 
-#: inc/field/textfield.class.php:154
+#: inc/field/textfield.class.php:155
 #, php-format
 msgid "The text is too short (minimum %d characters): %s"
 msgstr "Metin çok kısa (en az %d karakter olmalı): %s"
 
-#: inc/field/textfield.class.php:159
+#: inc/field/textfield.class.php:160
 #, php-format
 msgid "The text is too long (maximum %d characters): %s"
 msgstr "Metin çok uzun (en fazla %d karakter olmalı): %s"
 
-#: inc/field/textfield.class.php:167
+#: inc/field/textfield.class.php:168
 msgid "Text"
 msgstr "Metin"
 
-#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:233
+#: inc/field/textfield.class.php:212 inc/field/floatfield.class.php:234
 #: inc/questionregex.class.php:62 entrée standard:42
 msgid "Regular expression"
 msgstr "Kurallı ifade"
 
-#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:238
+#: inc/field/textfield.class.php:217 inc/field/floatfield.class.php:239
 msgid "Range"
 msgstr "Aralık"
 
-#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:244
+#: inc/field/textfield.class.php:223 inc/field/floatfield.class.php:245
 msgid "Additional validation"
 msgstr "Ek değerlendirme"
 
-#: inc/field/radiosfield.class.php:108
+#: inc/field/radiosfield.class.php:109
 msgid "Radios"
 msgstr "Radyo düğmeleri"
 
-#: inc/field/radiosfield.class.php:114 inc/field/glpiselectfield.class.php:86
-#: inc/field/fieldsfield.class.php:510 inc/field/checkboxesfield.class.php:229
+#: inc/field/radiosfield.class.php:115 inc/field/glpiselectfield.class.php:93
+#: inc/field/fieldsfield.class.php:512 inc/field/checkboxesfield.class.php:230
 msgid "The field value is required:"
 msgstr "Alan değeri zorunludur:"
 
-#: inc/field/radiosfield.class.php:192 inc/field/selectfield.class.php:104
-#: inc/field/datetimefield.class.php:117 inc/field/actorfield.class.php:239
-#: inc/field/checkboxesfield.class.php:174 inc/field/floatfield.class.php:123
-#: inc/field/datefield.class.php:114
+#: inc/field/radiosfield.class.php:193 inc/field/selectfield.class.php:104
+#: inc/field/datetimefield.class.php:118 inc/field/actorfield.class.php:257
+#: inc/field/checkboxesfield.class.php:175 inc/field/floatfield.class.php:124
+#: inc/field/datefield.class.php:115
 #, php-format
 msgid "A required field is empty: %s"
 msgstr "Zorunlu bir alan boş bırakılmış: %s"
 
-#: inc/field/integerfield.class.php:58
+#: inc/field/integerfield.class.php:59
 #, php-format
 msgid "This is not an integer: %s"
 msgstr "Bu bir tamsayı değil: %s"
 
-#: inc/field/integerfield.class.php:84 inc/field/floatfield.class.php:165
+#: inc/field/integerfield.class.php:85 inc/field/floatfield.class.php:166
 #, php-format
 msgid "The following number must be greater than %d: %s"
 msgstr "Şu sayı %d değerinden büyük olmalıdır: %s"
 
-#: inc/field/integerfield.class.php:90 inc/field/floatfield.class.php:171
+#: inc/field/integerfield.class.php:91 inc/field/floatfield.class.php:172
 #, php-format
 msgid "The following number must be lower than %d: %s"
 msgstr "Şu sayı %d değerinden küçük olmalıdır: %s"
 
-#: inc/field/integerfield.class.php:100
+#: inc/field/integerfield.class.php:101
 msgid "Integer"
 msgstr "Tamsayı"
 
-#: inc/field/undefinedfield.class.php:43
+#: inc/field/undefinedfield.class.php:44
 msgid "Undefined"
 msgstr "Tanımlanmamış"
 
-#: inc/field/ipfield.class.php:121
+#: inc/field/ipfield.class.php:122
 msgid "IP address"
 msgid_plural "IP addresses"
 msgstr[0] "IP adresi"
 msgstr[1] "IP adresleri"
 
-#: inc/field/urgencyfield.class.php:84 inc/abstractitiltarget.class.php:995
+#: inc/field/urgencyfield.class.php:85 inc/abstractitiltarget.class.php:994
 msgid "Urgency"
 msgstr "Önem düzeyi"
 
-#: inc/field/urgencyfield.class.php:118
+#: inc/field/urgencyfield.class.php:119
 msgctxt "urgency"
 msgid "Very high"
 msgstr "Çok yüksek"
 
-#: inc/field/urgencyfield.class.php:119
+#: inc/field/urgencyfield.class.php:120
 msgctxt "urgency"
 msgid "High"
 msgstr "Yüksek"
 
-#: inc/field/urgencyfield.class.php:120
+#: inc/field/urgencyfield.class.php:121
 msgctxt "urgency"
 msgid "Medium"
 msgstr "Orta"
 
-#: inc/field/urgencyfield.class.php:121
+#: inc/field/urgencyfield.class.php:122
 msgctxt "urgency"
 msgid "Low"
 msgstr "Düşük"
 
-#: inc/field/urgencyfield.class.php:122
+#: inc/field/urgencyfield.class.php:123
 msgctxt "urgency"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: inc/field/tagfield.class.php:50
+#: inc/field/tagfield.class.php:51
 msgid "Warning: Tag plugin is disabled or missing"
 msgstr "Uyarı: Etiket uygulama eki devre dışı bırakılmış ya da eksik"
 
-#: inc/field/tagfield.class.php:196
+#: inc/field/tagfield.class.php:197
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Etiket"
 msgstr[1] "Etiketler"
 
-#: inc/field/glpiselectfield.class.php:71 entrée standard:38
+#: inc/field/glpiselectfield.class.php:78 entrée standard:38
 msgid "GLPI object"
 msgid_plural "GLPI objects"
 msgstr[0] "GLPI nesnesi"
 msgstr[1] "GLPI nesneleri"
 
-#: inc/field/hostnamefield.class.php:114
+#: inc/field/hostnamefield.class.php:115
 msgid "Hostname"
 msgid_plural "Hostnames"
 msgstr[0] "Sunucu adı"
 msgstr[1] "Sunucu adları"
 
-#: inc/field/timefield.class.php:128
+#: inc/field/timefield.class.php:129
 msgid "Time"
 msgstr "Zaman"
 
-#: inc/field/emailfield.class.php:87
+#: inc/field/emailfield.class.php:88
 #, php-format
 msgid "This is not a valid e-mail: %s"
 msgstr "E-posta adresi geçersiz: %s"
 
-#: inc/field/emailfield.class.php:98
+#: inc/field/emailfield.class.php:99
 msgid "Email"
 msgid_plural "Emails"
 msgstr[0] "E-posta"
@@ -407,41 +396,41 @@ msgstr[1] "E-postalar"
 msgid "Select"
 msgstr "Seçin"
 
-#: inc/field/datetimefield.class.php:138
+#: inc/field/datetimefield.class.php:139
 msgid "Date & time"
 msgstr "Tarih ve saat"
 
-#: inc/field/actorfield.class.php:65
+#: inc/field/actorfield.class.php:83
 msgid "Actor"
 msgid_plural "Actors"
 msgstr[0] "İlgili"
 msgstr[1] "İlgililer"
 
-#: inc/field/actorfield.class.php:249
+#: inc/field/actorfield.class.php:267
 #, php-format
 msgid "Invalid value: %s"
 msgstr "Değer geçersiz: %s"
 
-#: inc/field/actorfield.class.php:272
+#: inc/field/actorfield.class.php:290
 #, php-format
 msgid "User not found or invalid email address: %s"
 msgstr "Kullanıcı bulunamadı ya da e-posta adresi geçersiz: %s"
 
-#: inc/field/filefield.class.php:104
+#: inc/field/filefield.class.php:105
 msgid "No attached document"
 msgstr "Ekli bir belge yok"
 
-#: inc/field/filefield.class.php:113 inc/field/filefield.class.php:275
-#: inc/field/filefield.class.php:282
+#: inc/field/filefield.class.php:114 inc/field/filefield.class.php:252
+#: inc/field/filefield.class.php:259
 msgid "Attached document"
 msgstr "Ekli belge"
 
-#: inc/field/filefield.class.php:156
+#: inc/field/filefield.class.php:157
 #, php-format
 msgid "A required file is missing: %s"
 msgstr "Gerekli bir dosya eksik: %s"
 
-#: inc/field/filefield.class.php:173
+#: inc/field/filefield.class.php:174
 msgid "File"
 msgstr "Dosya"
 
@@ -449,95 +438,94 @@ msgstr "Dosya"
 msgid "Multiselect"
 msgstr "Çoklu seçim"
 
-#: inc/field/fieldsfield.class.php:153
+#: inc/field/fieldsfield.class.php:154
 msgid "Warning: Additional Fields plugin is disabled or missing"
 msgstr "Uyarı: Ek alanlar uygulama eki devre dışı bırakılmış ya da eksik"
 
-#: inc/field/fieldsfield.class.php:166
+#: inc/field/fieldsfield.class.php:167
 msgid "Block"
 msgstr "Engelle"
 
-#: inc/field/fieldsfield.class.php:170 inc/targetticket.class.php:340
+#: inc/field/fieldsfield.class.php:171 inc/targetticket.class.php:339
 msgid "Field"
 msgstr "Alan"
 
-#: inc/field/fieldsfield.class.php:252
+#: inc/field/fieldsfield.class.php:253
 msgid "show"
 msgstr "görüntüle"
 
-#: inc/field/fieldsfield.class.php:387
+#: inc/field/fieldsfield.class.php:389
 #, php-format
 msgid "Field '%1$s' type not implemented yet!"
 msgstr "'%1$s' alan türü henüz kullanıma sunulmamış!"
 
-#: inc/field/fieldsfield.class.php:464
+#: inc/field/fieldsfield.class.php:466
 msgid "Some numeric fields contains non numeric values"
 msgstr "Bazı sayısal alanlarda sayısal olmayan değerler var"
 
-#: inc/field/fieldsfield.class.php:469
+#: inc/field/fieldsfield.class.php:471
 msgid "Some URL fields contains invalid links"
 msgstr "Bazı adres alanlarında geçersiz bağlantılar var"
 
-#: inc/field/fieldsfield.class.php:555
+#: inc/field/fieldsfield.class.php:565
 msgid "Additionnal fields"
 msgstr "Ek alanlar"
 
-#: inc/field/checkboxesfield.class.php:116
+#: inc/field/checkboxesfield.class.php:117
 msgid "Checkboxes"
 msgstr "İşaret kutuları"
 
-#: inc/field/checkboxesfield.class.php:211
+#: inc/field/checkboxesfield.class.php:212
 #, php-format
 msgid "The following question needs at least %d answers"
 msgstr "Şu sorunun en az %d yanıtı olmalıdır"
 
-#: inc/field/checkboxesfield.class.php:217
+#: inc/field/checkboxesfield.class.php:218
 #, php-format
 msgid "The following question does not accept more than %d answers"
 msgstr "Şu soruya %d yanıttan fazlası verilemez"
 
-#: inc/field/checkboxesfield.class.php:289
+#: inc/field/checkboxesfield.class.php:290
 msgid "Range min"
 msgstr "Aralık başlangıcı"
 
-#: inc/field/checkboxesfield.class.php:290
+#: inc/field/checkboxesfield.class.php:291
 msgid "Range max"
 msgstr "Aralık bitişi"
 
-#: inc/field/requesttypefield.class.php:85 inc/targetticket.class.php:1121
+#: inc/field/requesttypefield.class.php:86 inc/targetticket.class.php:1095
 msgid "Request type"
 msgstr "İstek türü"
 
-#: inc/field/floatfield.class.php:140
+#: inc/field/floatfield.class.php:141
 #, php-format
 msgid "This is not a number: %s"
 msgstr "Bu bir sayı değil: %s"
 
-#: inc/field/floatfield.class.php:181
+#: inc/field/floatfield.class.php:182
 msgid "Float"
 msgstr "Ondalık"
 
-#: inc/field/datefield.class.php:135
+#: inc/field/datefield.class.php:136
 msgid "Date"
 msgstr "Tarih"
 
-#: inc/field/descriptionfield.class.php:103 inc/form.class.php:165
+#: inc/field/descriptionfield.class.php:105 inc/form.class.php:165
 #: inc/question.class.php:166 entrée standard:82 standard:52 standard:113
 msgid "Description"
 msgstr "Açıklama"
 
-#: inc/field/descriptionfield.class.php:110
+#: inc/field/descriptionfield.class.php:112
 msgid "A description field should have a description:"
 msgstr "Bir açıklama alanında açıklama bulunmalıdır:"
 
-#: inc/field/hiddenfield.class.php:94
+#: inc/field/hiddenfield.class.php:95
 msgid "Hidden field"
 msgid_plural "Hidden fields"
 msgstr[0] "Gizli alan"
 msgstr[1] "Gizli alanlar"
 
-#: inc/condition.class.php:65 inc/targetproblem.class.php:579
-#: inc/targetchange.class.php:106 inc/targetticket.class.php:136
+#: inc/condition.class.php:65
 msgid "Condition"
 msgid_plural "Conditions"
 msgstr[0] "Koşul"
@@ -567,26 +555,26 @@ msgstr "Şu olmadan gizlensin"
 msgid "Displayed unless"
 msgstr "Şu olmadan görüntülensin"
 
-#: inc/condition.class.php:179 inc/target_actor.class.php:214
-#: inc/form_language.class.php:540 inc/form_validator.class.php:387
-#: inc/targetproblem.class.php:539 inc/questionrange.class.php:196
-#: inc/form.class.php:1814 inc/targetchange.class.php:303
+#: inc/condition.class.php:179 inc/target_actor.class.php:215
+#: inc/form_language.class.php:540 inc/form_validator.class.php:379
+#: inc/targetproblem.class.php:540 inc/questionrange.class.php:196
+#: inc/form.class.php:1844 inc/targetchange.class.php:303
 #: inc/section.class.php:379 inc/restrictedformcriteria.class.php:200
-#: inc/question.class.php:832 inc/questionparameter/range.class.php:211
+#: inc/question.class.php:828 inc/questionparameter/range.class.php:202
 #: inc/questionregex.class.php:185 inc/questiondependency.class.php:196
-#: inc/item_targetticket.class.php:150 inc/targetticket.class.php:1427
+#: inc/item_targetticket.class.php:154 inc/targetticket.class.php:1404
 #, php-format
 msgid "Failed to add or update the %1$s %2$s"
 msgstr "%1$s%2$s eklenemedi ya da güncellenemedi"
 
-#: inc/condition.class.php:201 inc/target_actor.class.php:235
-#: inc/form_language.class.php:556 inc/form_validator.class.php:411
-#: inc/targetproblem.class.php:374 inc/questionrange.class.php:131
-#: inc/form.class.php:1505 inc/targetchange.class.php:148
+#: inc/condition.class.php:201 inc/target_actor.class.php:236
+#: inc/form_language.class.php:556 inc/form_validator.class.php:403
+#: inc/targetproblem.class.php:375 inc/questionrange.class.php:131
+#: inc/form.class.php:1535 inc/targetchange.class.php:148
 #: inc/section.class.php:404 inc/restrictedformcriteria.class.php:226
-#: inc/question.class.php:881 inc/questionparameter/range.class.php:145
+#: inc/question.class.php:877 inc/questionparameter/range.class.php:137
 #: inc/questionregex.class.php:120 inc/questiondependency.class.php:211
-#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1466
+#: inc/item_targetticket.class.php:64 inc/targetticket.class.php:1443
 #, php-format
 msgid "Cannot export an empty object: %s"
 msgstr "Boş bir nesne dışa aktarılamaz: %s"
@@ -603,139 +591,129 @@ msgstr "İçe aktarılıyor"
 msgid "Import in progress"
 msgstr "İçe aktarılıyor"
 
-#: inc/issue.class.php:41
+#: inc/issue.class.php:43
 msgid "Issue"
 msgid_plural "Issues"
 msgstr[0] "Sorun"
 msgstr[1] "Sorunlar"
 
-#: inc/issue.class.php:54
+#: inc/issue.class.php:56
 msgid "Update issue data from tickets and form answers"
 msgstr "Sorun verileri çağrı kaydı ve form yanıtlarından güncellensin"
 
-#: inc/issue.class.php:389
+#: inc/issue.class.php:392
 msgid "Satisfaction survey expired"
 msgstr "Memnuniyet anketinin süresi geçmiş"
 
-#: inc/issue.class.php:518 inc/form_language.class.php:213
-#: inc/form.class.php:156 inc/form.class.php:2117 entrée standard:52
+#: inc/issue.class.php:521 inc/form_language.class.php:213
+#: inc/form.class.php:156 inc/form.class.php:2148 entrée standard:52
 #: standard:49 standard:57 standard:38 standard:39
 msgid "Name"
 msgstr "Ad"
 
-#: inc/issue.class.php:531 inc/formanswer.class.php:198
-#: inc/formanswer.class.php:272 inc/targetproblem.class.php:622
+#: inc/issue.class.php:534 inc/formanswer.class.php:199
+#: inc/formanswer.class.php:273 inc/targetproblem.class.php:623
 #: inc/form.class.php:147 inc/targetchange.class.php:334
 #: inc/section.class.php:95 inc/question.class.php:156
-#: inc/targetticket.class.php:179
+#: inc/targetticket.class.php:178
 msgid "ID"
 msgstr "Kod"
 
-#: inc/issue.class.php:540 inc/form.class.php:503 inc/form.class.php:2126
+#: inc/issue.class.php:543 inc/form.class.php:503 inc/form.class.php:2157
 #: entrée standard:65
 msgid "Type"
 msgid_plural "Types"
 msgstr[0] "Tür"
 msgstr[1] "Türler"
 
-#: inc/issue.class.php:553 inc/formanswer.class.php:259
+#: inc/issue.class.php:556 inc/formanswer.class.php:260
 msgid "Status"
 msgstr "Durum"
 
-#: inc/issue.class.php:565
+#: inc/issue.class.php:568
 msgid "Opening date"
 msgstr "Açılma tarihi"
 
-#: inc/issue.class.php:574
+#: inc/issue.class.php:577
 msgid "Last update"
 msgstr "Son güncelleme"
 
-#: inc/issue.class.php:583 inc/form.class.php:174
-#: inc/abstracttarget.class.php:518
+#: inc/issue.class.php:586 inc/abstracttarget.class.php:518
 msgid "Entity"
 msgid_plural "Entities"
 msgstr[0] "Birim"
 msgstr[1] "Birimler"
 
-#: inc/issue.class.php:593 inc/notificationtargetformanswer.class.php:79
-#: inc/target_actor.class.php:83 inc/formanswer.class.php:218
-#: inc/formanswer.class.php:615 inc/abstractitiltarget.class.php:1714
+#: inc/issue.class.php:596 inc/notificationtargetformanswer.class.php:79
+#: inc/target_actor.class.php:83 inc/formanswer.class.php:219
+#: inc/formanswer.class.php:618 inc/abstractitiltarget.class.php:1724
 msgid "Requester"
 msgid_plural "Requesters"
 msgstr[0] "İstekte bulunan"
 msgstr[1] "İstekte bulunanlar"
 
-#: inc/issue.class.php:611 inc/formanswer.class.php:228
+#: inc/issue.class.php:614 inc/formanswer.class.php:229
 msgid "Form approver"
 msgstr "Form onaylayıcı"
 
-#: inc/issue.class.php:627 inc/formanswer.class.php:541
-#: inc/formanswer.class.php:548 inc/formanswer.class.php:630
+#: inc/issue.class.php:630 inc/formanswer.class.php:544
+#: inc/formanswer.class.php:551 inc/formanswer.class.php:633
 #: inc/form_language.class.php:227
 msgid "Comment"
 msgstr "Açıklama"
 
-#: inc/issue.class.php:639
+#: inc/issue.class.php:642
 msgid "Ticket approver"
 msgstr "Çağrı kaydını onaylayan"
 
-#: inc/issue.class.php:673
+#: inc/issue.class.php:676
 msgid "Technician"
 msgstr "Teknisyen"
 
-#: inc/issue.class.php:704
+#: inc/issue.class.php:708
 msgid "Technician group"
 msgstr "Teknisyen grubu"
 
-#: inc/issue.class.php:737 inc/formanswer.class.php:248
+#: inc/issue.class.php:741 inc/formanswer.class.php:249
 msgid "Form approver group"
 msgstr "Form onaylayıcı grubu"
 
-#: inc/issue.class.php:776
-msgid "Not validated"
-msgstr "Değerlendirilmemiş"
-
-#: inc/issue.class.php:777 inc/formanswer.class.php:76
-#: inc/form_validator.class.php:71
-msgid "Refused"
-msgstr "Reddedilmiş"
-
-#: inc/issue.class.php:845
+#: inc/issue.class.php:853
 #, php-format
 msgid "%1$s %2$s"
 msgstr "%1$s %2$s"
 
-#: inc/issue.class.php:1108 inc/filter/itilcategoryfilter.class.php:56
-#: hook.php:663
+#: inc/issue.class.php:1115 inc/filter/itilcategoryfilter.class.php:56
+#: hook.php:629
 msgid "All"
 msgstr "Tümü"
 
-#: inc/issue.class.php:1114 hook.php:664
+#: inc/issue.class.php:1121 hook.php:630
 msgid "New"
 msgstr "Ekle"
 
-#: inc/issue.class.php:1120 hook.php:665
+#: inc/issue.class.php:1127 hook.php:631
 msgid "Assigned"
 msgstr "Atanmış"
 
-#: inc/issue.class.php:1126 inc/formanswer.class.php:75
-#: inc/form_validator.class.php:69 hook.php:666
+#: inc/issue.class.php:1133 inc/formanswer.class.php:76
+#: inc/form_validator.class.php:69 hook.php:632
 msgid "Waiting"
 msgstr "Bekliyor"
 
-#: inc/issue.class.php:1132 hook.php:667
+#: inc/issue.class.php:1139 hook.php:633
 msgid "To validate"
 msgstr "Değerlendirilecek"
 
-#: inc/issue.class.php:1138 hook.php:668
+#: inc/issue.class.php:1145 hook.php:634
 msgid "Solved"
 msgstr "Çözümlenmiş"
 
-#: inc/issue.class.php:1144 hook.php:669
+#: inc/issue.class.php:1151 hook.php:635
 msgid "Closed"
 msgstr "Kapalı"
 
-#: inc/category.class.php:50 inc/form.class.php:230 hook.php:72
+#: inc/category.class.php:50 hook.php:72
 msgid "Form category"
 msgid_plural "Form categories"
 msgstr[0] "Form kategorisi"
@@ -753,19 +731,19 @@ msgstr "Şunun alt ögesi olarak"
 msgid "The form as been saved"
 msgstr "Form kaydedildi"
 
-#: inc/notificationtargetformanswer.class.php:44 install/install.php:334
+#: inc/notificationtargetformanswer.class.php:44 install/install.php:408
 msgid "A form need to be validate"
 msgstr "Değerlendirilmesi gereken bir form var"
 
-#: inc/notificationtargetformanswer.class.php:45 install/install.php:340
+#: inc/notificationtargetformanswer.class.php:45 install/install.php:414
 msgid "The form is refused"
 msgstr "Form reddedildi"
 
-#: inc/notificationtargetformanswer.class.php:46 install/install.php:346
+#: inc/notificationtargetformanswer.class.php:46 install/install.php:420
 msgid "The form is accepted"
 msgstr "Form onaylandı"
 
-#: inc/notificationtargetformanswer.class.php:47 install/install.php:352
+#: inc/notificationtargetformanswer.class.php:47 install/install.php:426
 msgid "The form is deleted"
 msgstr "Form silindi"
 
@@ -778,13 +756,11 @@ msgid "Form name"
 msgstr "Form adı"
 
 #: inc/notificationtargetformanswer.class.php:80
-#: inc/form_validator.class.php:76
+msgctxt "tag"
 msgid "Validator"
-msgid_plural "Validators"
-msgstr[0] "Değerlendiren"
-msgstr[1] "Değerlendirenler"
+msgstr "Değerlendiren"
 
-#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:239
+#: inc/notificationtargetformanswer.class.php:81 inc/formanswer.class.php:240
 msgid "Creation date"
 msgstr "Oluşturulma tarihi"
 
@@ -809,15 +785,15 @@ msgid "Author"
 msgstr "Sorumlu"
 
 #: inc/notificationtargetformanswer.class.php:98
-#: inc/abstractitiltarget.class.php:1290
+#: inc/abstractitiltarget.class.php:1289
 msgid "Approver"
 msgstr "Onaylayan"
 
-#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2038
+#: inc/target_actor.class.php:66 inc/abstractitiltarget.class.php:2048
 msgid "Form author"
 msgstr "Form sorumlusu"
 
-#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2041
+#: inc/target_actor.class.php:67 inc/abstractitiltarget.class.php:2051
 msgid "Form validator"
 msgstr "Formu değerlendiren"
 
@@ -825,7 +801,7 @@ msgstr "Formu değerlendiren"
 msgid "Specific person"
 msgstr "Belirli kişi"
 
-#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2051
+#: inc/target_actor.class.php:69 inc/abstractitiltarget.class.php:2061
 msgid "Person from the question"
 msgstr "Sorudan kişi"
 
@@ -833,7 +809,7 @@ msgstr "Sorudan kişi"
 msgid "Specific group"
 msgstr "Belirli grup"
 
-#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2062
+#: inc/target_actor.class.php:71 inc/abstractitiltarget.class.php:2072
 msgid "Group from the question"
 msgstr "Sorudan grup"
 
@@ -849,15 +825,15 @@ msgstr "Bir nesneden teknik grup"
 msgid "Specific supplier"
 msgstr "Belirli sağlayıcı"
 
-#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2091
+#: inc/target_actor.class.php:75 inc/abstractitiltarget.class.php:2101
 msgid "Supplier from the question"
 msgstr "Sorudan sağlayıcı"
 
-#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2080
+#: inc/target_actor.class.php:76 inc/abstractitiltarget.class.php:2090
 msgid "Actors from the question"
 msgstr "Sorudan ilgililer"
 
-#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2095
+#: inc/target_actor.class.php:77 inc/abstractitiltarget.class.php:2105
 msgid "Form author's supervisor"
 msgstr "Formu hazırlayanın yöneticisi"
 
@@ -865,7 +841,7 @@ msgstr "Formu hazırlayanın yöneticisi"
 msgid "Observer"
 msgstr "Gözlemci"
 
-#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1728
+#: inc/target_actor.class.php:85 inc/abstractitiltarget.class.php:1738
 msgid "Assigned to"
 msgstr "Atanan"
 
@@ -895,77 +871,86 @@ msgstr "Bir grup bulunamadı: %1$s"
 msgid "Failed to find a supplier: %1$s"
 msgstr "Bir sağlayıcı bulunamadı: %1$s"
 
-#: inc/formanswer.class.php:77 inc/form_validator.class.php:70
+#: inc/formanswer.class.php:77 inc/form_validator.class.php:71
+msgid "Refused"
+msgstr "Reddedilmiş"
+
+#: inc/formanswer.class.php:78 inc/form_validator.class.php:70
 msgid "Accepted"
 msgstr "Onaylanmış"
 
-#: inc/formanswer.class.php:183
+#: inc/formanswer.class.php:184
 msgid "Form answer"
 msgid_plural "Form answers"
 msgstr[0] "Form yanıtı"
 msgstr[1] "Form yanıtları"
 
-#: inc/formanswer.class.php:527
+#: inc/formanswer.class.php:529
 msgid "Print this form"
 msgstr "Bu formu yazdır"
 
-#: inc/formanswer.class.php:551
+#: inc/formanswer.class.php:554
 msgid "Form accepted by validator."
 msgstr "Form değerlendirici tarafından onaylandı"
 
-#: inc/formanswer.class.php:553
+#: inc/formanswer.class.php:556
 msgid "Form successfully saved."
 msgstr "Form kaydedildi"
 
-#: inc/formanswer.class.php:623 inc/formaccesstype.class.php:122
+#: inc/formanswer.class.php:626 inc/formaccesstype.class.php:122
 msgid "Save"
 msgstr "Kaydet"
 
-#: inc/formanswer.class.php:635
+#: inc/formanswer.class.php:638
 msgid "Required if refused"
 msgstr "Reddedildi ise zorunlu"
 
-#: inc/formanswer.class.php:641
+#: inc/formanswer.class.php:644
 msgid "Refuse"
 msgstr "Reddet"
 
-#: inc/formanswer.class.php:649
+#: inc/formanswer.class.php:652
 msgid "Edit answers"
 msgstr "Yanıtları düzenle"
 
-#: inc/formanswer.class.php:655
+#: inc/formanswer.class.php:658
 msgid "Cancel edition"
 msgstr "Düzenlemeyi iptal et"
 
-#: inc/formanswer.class.php:662
+#: inc/formanswer.class.php:665
 msgid "Accept"
 msgstr "Onayla"
 
-#: inc/formanswer.class.php:685
+#: inc/formanswer.class.php:688
 msgid "Refused comment is required!"
 msgstr "Red açıklaması zorunludur!"
 
-#: inc/formanswer.class.php:759
+#: inc/formanswer.class.php:762
 msgid "You are not the validator of these answers"
 msgstr "Bu yanıtların değerlendireni değilsiniz"
 
-#: inc/formanswer.class.php:966 inc/formanswer.class.php:968
+#: inc/formanswer.class.php:895
+#, php-format
+msgid "Item sucessfully added: %1$s (%2$s: %3$s)"
+msgstr ""
+
+#: inc/formanswer.class.php:977 inc/formanswer.class.php:979
 msgid "Form data"
 msgstr "Form verileri"
 
-#: inc/formanswer.class.php:1094 inc/formanswer.class.php:1144
+#: inc/formanswer.class.php:1105 inc/formanswer.class.php:1157
 msgid "Cannot generate targets!"
 msgstr "Hedefler oluşturulamadı!"
 
-#: inc/formanswer.class.php:1268
+#: inc/formanswer.class.php:1281
 msgid "No turing test set"
 msgstr "Herhangi bir Turing sınaması ayarlanmamış"
 
-#: inc/formanswer.class.php:1273
+#: inc/formanswer.class.php:1286
 msgid "You failed the Turing test"
 msgstr "Turing sınamasını geçemediniz"
 
-#: inc/formanswer.class.php:1315
+#: inc/formanswer.class.php:1326
 msgid "You must select validator!"
 msgstr "Bir değerlendiren seçmelisiniz!"
 
@@ -977,15 +962,15 @@ msgstr "Bu sorunu silemezsiniz. Değerlendirmeye alınmış olabilir."
 msgid "Failed to delete this issue. An internal error occured."
 msgstr "Bu sorun silinemedi. Bir iç sorun çıktı."
 
-#: inc/common.class.php:777
+#: inc/common.class.php:780
 msgid "Seek assistance"
 msgstr "Destek iste"
 
-#: inc/common.class.php:782
+#: inc/common.class.php:785
 msgid "My requests for assistance"
 msgstr "Destek isteklerim"
 
-#: inc/common.class.php:812
+#: inc/common.class.php:815
 msgid "Consult feeds"
 msgstr "Akışlara bak"
 
@@ -1017,15 +1002,15 @@ msgid_plural "Form languages"
 msgstr[0] "Form dili"
 msgstr[1] "Form dilleri"
 
-#: inc/form_language.class.php:72 inc/form_language.class.php:348
+#: inc/form_language.class.php:72
 msgid "Translation"
 msgid_plural "Translations"
 msgstr[0] "Çeviri"
 msgstr[1] "Çeviriler"
 
-#: inc/form_language.class.php:111 inc/form.class.php:1046
-#: inc/form.class.php:1171 inc/abstracttarget.class.php:161
-#: inc/abstractitiltarget.class.php:1545
+#: inc/form_language.class.php:111 inc/form.class.php:1076
+#: inc/form.class.php:1201 inc/abstracttarget.class.php:161
+#: inc/abstractitiltarget.class.php:1544
 msgid "The name cannot be empty!"
 msgstr "Ad boş olamaz!"
 
@@ -1037,7 +1022,7 @@ msgstr "Forma bir dil atanmalıdır."
 msgid "Add a translation"
 msgstr "Bir çeviri ekle"
 
-#: inc/form_language.class.php:283 js/scripts.js:1160
+#: inc/form_language.class.php:283 js/scripts.js:1156
 msgid "Update a translation"
 msgstr "Bir çeviriyi güncelle"
 
@@ -1058,7 +1043,7 @@ msgid "Do you want to delete the selected items?"
 msgstr "Seçilmiş ögeleri silmek ister misiniz?"
 
 #: inc/form_language.class.php:337 inc/form_language.class.php:376
-#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1619
+#: inc/form.class.php:527 inc/abstractitiltarget.class.php:1629
 msgid "Delete"
 msgstr "Sil"
 
@@ -1075,32 +1060,38 @@ msgstr "Dil ekle"
 msgid "Language"
 msgstr "Dil"
 
-#: inc/form_validator.class.php:68 inc/targetticket.class.php:98
-#: inc/abstractitiltarget.class.php:179
+#: inc/form_validator.class.php:68 inc/targetticket.class.php:97
+#: inc/abstractitiltarget.class.php:178
 msgid "None"
 msgstr "Yok"
 
-#: inc/form_validator.class.php:122
+#: inc/form_validator.class.php:76
+msgid "Validator"
+msgid_plural "Validators"
+msgstr[0] "Değerlendiren"
+msgstr[1] "Değerlendirenler"
+
+#: inc/form_validator.class.php:114
 msgid "Need validaton?"
 msgstr "Değerlendirme gerekli"
 
-#: inc/form_validator.class.php:126 inc/abstractitiltarget.class.php:2032
+#: inc/form_validator.class.php:118 inc/abstractitiltarget.class.php:2042
 msgid "No"
 msgstr "Hayır"
 
-#: inc/form_validator.class.php:303 inc/targetproblem.class.php:146
-#: inc/entityconfig.class.php:389 inc/targetchange.class.php:483
-#: inc/targetticket.class.php:317 inc/targetticket.class.php:352
-#: inc/abstractitiltarget.class.php:2021
+#: inc/form_validator.class.php:295 inc/targetproblem.class.php:146
+#: inc/entityconfig.class.php:411 inc/targetchange.class.php:483
+#: inc/targetticket.class.php:316 inc/targetticket.class.php:351
+#: inc/abstractitiltarget.class.php:2031
 msgctxt "button"
 msgid "Save"
 msgstr "Kaydet"
 
-#: inc/form_validator.class.php:717 inc/abstractitiltarget.class.php:1270
+#: inc/form_validator.class.php:709 inc/abstractitiltarget.class.php:1269
 msgid "Validation"
 msgstr "Değerlendirme"
 
-#: inc/form_validator.class.php:719
+#: inc/form_validator.class.php:711
 msgid "Choose a validator"
 msgstr "Bir değerlendiren seçin"
 
@@ -1110,14 +1101,14 @@ msgid_plural "Target problems"
 msgstr[0] "Hedef sorun"
 msgstr[1] "Hedef sorunlar"
 
-#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:577
+#: inc/targetproblem.class.php:108 inc/targetproblem.class.php:578
 #: inc/targetchange.class.php:104 inc/targetchange.class.php:440
-#: inc/targetticket.class.php:134 inc/targetticket.class.php:237
+#: inc/targetticket.class.php:133 inc/targetticket.class.php:236
 msgid "Properties"
 msgstr "Özellikler"
 
-#: inc/targetproblem.class.php:521 inc/targetchange.class.php:285
-#: inc/targetticket.class.php:1409
+#: inc/targetproblem.class.php:522 inc/targetchange.class.php:285
+#: inc/targetticket.class.php:1386
 #, php-format
 msgid ""
 "Failed to add or update the %1$s %2$s: a question is missing and is used in "
@@ -1126,29 +1117,29 @@ msgstr ""
 "%1$s %2$s eklenemedi ya da güncellenemedi: Bir soru eksik ve hedefteki bir "
 "parametre tarafından kullanılıyor"
 
-#: inc/targetproblem.class.php:578 inc/targetchange.class.php:105
-#: inc/targetticket.class.php:135 inc/abstractitiltarget.class.php:1172
+#: inc/targetproblem.class.php:579 inc/targetchange.class.php:105
+#: inc/targetticket.class.php:134 inc/abstractitiltarget.class.php:1171
 msgid "Actors"
 msgstr "İlgililer"
 
-#: inc/targetproblem.class.php:631 entrée standard:48
+#: inc/targetproblem.class.php:632 entrée standard:48
 msgid "Problem title"
 msgstr "Sorun başlığı"
 
-#: inc/targetproblem.class.php:641 inc/targetchange.class.php:353
-#: inc/targetticket.class.php:198
+#: inc/targetproblem.class.php:642 inc/targetchange.class.php:353
+#: inc/targetticket.class.php:197
 msgid "Content"
 msgstr "İçerik"
 
-#: inc/targetproblem.class.php:651 inc/targetchange.class.php:363
+#: inc/targetproblem.class.php:652 inc/targetchange.class.php:363
 msgid "Impact"
 msgstr "Etki"
 
-#: inc/targetproblem.class.php:661 entrée standard:56
+#: inc/targetproblem.class.php:662 entrée standard:56
 msgid "Cause"
 msgstr "Neden"
 
-#: inc/targetproblem.class.php:671 entrée standard:58
+#: inc/targetproblem.class.php:672 entrée standard:58
 msgid "Symptom"
 msgstr "Belirti"
 
@@ -1215,73 +1206,73 @@ msgstr "Değişken yükseklik"
 msgid "Uniform height"
 msgstr "Sabit yükseklik"
 
-#: inc/entityconfig.class.php:231
+#: inc/entityconfig.class.php:253
 msgid "Helpdesk"
 msgstr "Destek merkezi"
 
-#: inc/entityconfig.class.php:239 inc/entityconfig.class.php:403 entrée
+#: inc/entityconfig.class.php:261 inc/entityconfig.class.php:425 entrée
 #: standard:44
 msgid "Helpdesk mode"
 msgstr "Destek merkezi kipi"
 
-#: inc/entityconfig.class.php:250
+#: inc/entityconfig.class.php:272
 msgid "Default Form list mode"
 msgstr "Varsayılan form listesi kipi"
 
-#: inc/entityconfig.class.php:268 inc/entityconfig.class.php:413
+#: inc/entityconfig.class.php:290 inc/entityconfig.class.php:435
 msgid "Sort order"
 msgstr "Sıralama"
 
-#: inc/entityconfig.class.php:284 inc/entityconfig.class.php:423
+#: inc/entityconfig.class.php:306 inc/entityconfig.class.php:445
 msgid "Knowledge base"
 msgstr "Bilgi bankası"
 
-#: inc/entityconfig.class.php:299
+#: inc/entityconfig.class.php:321
 msgid "Search"
 msgstr "Arama"
 
-#: inc/entityconfig.class.php:315
+#: inc/entityconfig.class.php:337
 msgid "Counters dashboard"
 msgstr "Sayaç panosu"
 
-#: inc/entityconfig.class.php:331
+#: inc/entityconfig.class.php:353
 msgid "Header message"
 msgstr "Başlık iletisi"
 
-#: inc/entityconfig.class.php:347
+#: inc/entityconfig.class.php:369
 msgid "Search issue"
 msgstr "Arama sorunu"
 
-#: inc/entityconfig.class.php:363
+#: inc/entityconfig.class.php:385
 msgid "Tile design"
 msgstr "Karo tasarımı"
 
-#: inc/entityconfig.class.php:375 inc/entityconfig.class.php:453
+#: inc/entityconfig.class.php:397 inc/entityconfig.class.php:475
 #: inc/form.class.php:239 entrée standard:84
 msgid "Header"
 msgid_plural "Headers"
 msgstr[0] "Başlık"
 msgstr[1] "Başlıklar"
 
-#: inc/entityconfig.class.php:433
+#: inc/entityconfig.class.php:455
 msgid "Display search field"
 msgstr "Arama alanı görüntülensin"
 
-#: inc/entityconfig.class.php:443
+#: inc/entityconfig.class.php:465
 msgid "Display header"
 msgstr "Başlık görüntülensin"
 
-#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:57
+#: inc/questionrange.class.php:52 inc/questionparameter/range.class.php:56
 msgid "Question range"
 msgid_plural "Question ranges"
 msgstr[0] "Soru aralığı"
 msgstr[1] "Soru aralıkları"
 
-#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:68
+#: inc/questionrange.class.php:62 inc/questionparameter/range.class.php:66
 msgid "Minimum range"
 msgstr "En küçük aralık"
 
-#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:77
+#: inc/questionrange.class.php:71 inc/questionparameter/range.class.php:75
 msgid "maximum range"
 msgstr "En büyük aralık"
 
@@ -1301,7 +1292,7 @@ msgstr "Kısıtlı erişim"
 msgid "Answers waiting for validation"
 msgstr "Değerlendirilmeyi bekleyen yanıtlar"
 
-#: inc/form.class.php:124 inc/form.class.php:1589 inc/form.class.php:1615
+#: inc/form.class.php:124 inc/form.class.php:1619 inc/form.class.php:1645
 msgid "Import forms"
 msgstr "Formları içe aktar"
 
@@ -1364,7 +1355,7 @@ msgstr[1] "Hedefler"
 msgid "Actions"
 msgstr "İşlemler"
 
-#: inc/form.class.php:544 inc/form.class.php:2114
+#: inc/form.class.php:544 inc/form.class.php:2145
 msgid "Add a target"
 msgstr "Bir hedef ekle"
 
@@ -1380,121 +1371,121 @@ msgstr "özellikler"
 msgid "What are you looking for?"
 msgstr "Ne arıyorsunuz?"
 
-#: inc/form.class.php:892
+#: inc/form.class.php:893
 #, php-format
 msgid "My %1$d last forms (requester)"
 msgstr "Son %1$d formum (istekte bulunan)"
 
-#: inc/form.class.php:895
+#: inc/form.class.php:920
 msgid "No form posted yet"
 msgstr "Henüz bir form gönderilmemiş"
 
-#: inc/form.class.php:925
+#: inc/form.class.php:948
 msgid "All my forms (requester)"
 msgstr "Tüm formlarım (istekte bulunan)"
 
-#: inc/form.class.php:938
+#: inc/form.class.php:961
 #, php-format
 msgid "My %1$d last forms (validator)"
 msgstr "Son %1$d formum (değerlendiren)"
 
-#: inc/form.class.php:946
+#: inc/form.class.php:988
 msgid "No form waiting for validation"
 msgstr "Değerlendirilmeyi bekleyen bir form yok"
 
-#: inc/form.class.php:981
+#: inc/form.class.php:1016
 msgid "All my forms (validator)"
 msgstr "Tüm formlarım (değerlendiren)"
 
-#: inc/form.class.php:1182
+#: inc/form.class.php:1212
 msgid "Cannot use empty name for form answers. Keeping the previous value."
 msgstr "Form yanıtlarının adı boş olamaz. Önceki değer korunuyor."
 
-#: inc/form.class.php:1277
+#: inc/form.class.php:1307
 #, php-format
 msgid "The question %s is not compatible with public forms"
 msgstr "%s sorusu herkese açık formlar ile uyumlu değil"
 
-#: inc/form.class.php:1357
+#: inc/form.class.php:1387
 msgid "Errored duplicate"
 msgstr "Hatalı kopya"
 
-#: inc/form.class.php:1368
+#: inc/form.class.php:1398
 msgid "Duplicate"
 msgstr "Kopyala"
 
-#: inc/form.class.php:1415
+#: inc/form.class.php:1445
 msgctxt "button"
 msgid "Post"
 msgstr "İleti"
 
-#: inc/form.class.php:1433
+#: inc/form.class.php:1463
 #, php-format
 msgid "Form duplicated: %s"
 msgstr "Form kopyalandı: %s"
 
-#: inc/form.class.php:1444
+#: inc/form.class.php:1474
 #, php-format
 msgid "Form Transfered: %s"
 msgstr "Form aktarıldı: %s"
 
-#: inc/form.class.php:1463
+#: inc/form.class.php:1493
 msgid "Back"
 msgstr "Geri"
 
-#: inc/form.class.php:1562
+#: inc/form.class.php:1592
 msgid "Upload of JSON files not allowed."
 msgstr "JSON dosyalarının yüklenmesine izin verilmiyor."
 
-#: inc/form.class.php:1565
+#: inc/form.class.php:1595
 msgid "You may allow JSON files right now."
 msgstr "JSON dosyalarına şimdi izin verebilirsiniz."
 
-#: inc/form.class.php:1566
+#: inc/form.class.php:1596
 msgctxt "button"
 msgid "Create"
 msgstr "Ekle"
 
-#: inc/form.class.php:1569 inc/form.class.php:1580
+#: inc/form.class.php:1599 inc/form.class.php:1610
 msgid "Please contact your GLPI administrator."
 msgstr "Lütfen GLPI yöneticiniz ile görüşün."
 
-#: inc/form.class.php:1570 inc/form.class.php:1581
+#: inc/form.class.php:1600 inc/form.class.php:1611
 msgctxt "button"
 msgid "Back"
 msgstr "Geri"
 
-#: inc/form.class.php:1573
+#: inc/form.class.php:1603
 msgid "Upload of JSON files not enabled."
 msgstr "JSON dosyası yükleme seçeneği etkinleştirilmemiş."
 
-#: inc/form.class.php:1576 inc/form.class.php:1579
+#: inc/form.class.php:1606 inc/form.class.php:1609
 msgid "You may enable JSON files right now."
 msgstr "JSON dosyaları yükleme seçeneğini şimdi etkinleştirebilirsiniz."
 
-#: inc/form.class.php:1577
+#: inc/form.class.php:1607
 msgctxt "button"
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: inc/form.class.php:1624
+#: inc/form.class.php:1654
 msgctxt "button"
 msgid "Send"
 msgstr "Gönder"
 
-#: inc/form.class.php:1643
+#: inc/form.class.php:1673
 msgid "Forms import impossible, the file is empty"
 msgstr "Form içe aktarılamadı, dosya boş"
 
-#: inc/form.class.php:1647 inc/form.class.php:1651
+#: inc/form.class.php:1677 inc/form.class.php:1681
 msgid "Forms import impossible, the file seems corrupt"
 msgstr "Form içe aktarılamadı, dosya bozulmuş gibi görünüyor"
 
-#: inc/form.class.php:1657
+#: inc/form.class.php:1687
 msgid "Forms import impossible, the file was generated with another version"
 msgstr "Form içe aktarılamadı, dosya başka bir sürümde oluşturulmuş"
 
-#: inc/form.class.php:1664
+#: inc/form.class.php:1694
 msgid ""
 "The file does not specifies the schema version. It was probably generated "
 "with a version older than 2.10. Giving up."
@@ -1502,61 +1493,61 @@ msgstr ""
 "Dosyada şema sürümü belirtilmemiş. Dosya büyük olasılıkla 2.10 öncesindeki "
 "bir sürüm tarafından oluşturulmuş. İşlemden vaz geçiliyor."
 
-#: inc/form.class.php:1690
+#: inc/form.class.php:1720
 #, php-format
 msgid "Failed to import %s"
 msgstr "%s içe aktarılamadı"
 
-#: inc/form.class.php:1695
+#: inc/form.class.php:1725
 #, php-format
 msgid "Forms successfully imported from %s"
 msgstr "Form %s üzerinden içe aktarıldı"
 
-#: inc/form.class.php:1758
+#: inc/form.class.php:1788
 #, php-format
 msgid "The form %1$s already exists and is in an unmodifiable entity."
 msgstr "%1$s formu zaten var ve değiştirilemez bir birim."
 
-#: inc/form.class.php:1766
+#: inc/form.class.php:1796
 #, php-format
 msgid "You don't have right to update the entity %1$s."
 msgstr "%1$s birimini güncelleme yetkiniz yok."
 
-#: inc/form.class.php:1776
+#: inc/form.class.php:1806
 #, php-format
 msgid "The entity %1$s is required for the form %2$s."
 msgstr "%2$s formu için %1$s birimi gereklidir"
 
-#: inc/form.class.php:1858
+#: inc/form.class.php:1888
 msgid "Failed to create JSON document type"
 msgstr "JSON belge türü oluşturulamadı"
 
-#: inc/form.class.php:1865
+#: inc/form.class.php:1895
 msgid "JSON document type not found"
 msgstr "JSON belge türü bulunamadı"
 
-#: inc/form.class.php:1872
+#: inc/form.class.php:1902
 msgid "Failed to update JSON document type"
 msgstr "JSON belge türü güncellenemedi"
 
-#: inc/form.class.php:1892
+#: inc/form.class.php:1922
 msgid "Forms without category"
 msgstr "Kategorisi bulunmayan formlar"
 
-#: inc/form.class.php:1913
+#: inc/form.class.php:1943
 msgid "No form available"
 msgstr "Kullanılabilecek bir form yok"
 
-#: inc/form.class.php:2145 inc/targetticket.class.php:392
-#: inc/abstractitiltarget.class.php:1738 inc/abstractitiltarget.class.php:2021
+#: inc/form.class.php:2176 inc/targetticket.class.php:391
+#: inc/abstractitiltarget.class.php:1748 inc/abstractitiltarget.class.php:2031
 msgid "Add"
 msgstr "Ekle"
 
-#: inc/form.class.php:2163 inc/form.class.php:2186
+#: inc/form.class.php:2194 inc/form.class.php:2217
 msgid "Unsupported target type."
 msgstr "Hedef türü desteklenmiyor."
 
-#: inc/form.class.php:2225
+#: inc/form.class.php:2251
 msgid "plugin_formcreator_load_check"
 msgstr "plugin_formcreator_load_check"
 
@@ -1602,11 +1593,8 @@ msgstr "Başlık zorunludur"
 msgid "Failed to find %1$s %2$s"
 msgstr "%1$s %2$s bulunamadı"
 
-#: inc/question.class.php:70 inc/targetticket.class.php:1132
-#: inc/targetticket.class.php:1171 inc/abstractitiltarget.class.php:968
-#: inc/abstractitiltarget.class.php:1005 inc/abstractitiltarget.class.php:1083
-#: inc/abstractitiltarget.class.php:1214 inc/abstractitiltarget.class.php:1295
-#: entrée standard:41
+#: inc/question.class.php:70 inc/abstractitiltarget.class.php:1082 entrée
+#: standard:41
 msgid "Question"
 msgid_plural "Questions"
 msgstr[0] "Soru"
@@ -1641,48 +1629,48 @@ msgstr "Bu soru türü için parametrelerin belirtilmesi gerekli"
 msgid "A parameter is missing for this question type"
 msgstr "Bu soru türü için bir parametre eksik"
 
-#: inc/question.class.php:1274
+#: inc/question.class.php:1178
 msgid "Service levels"
 msgstr "Hizmet düzeyleri"
 
-#: inc/question.class.php:1275 inc/abstractitiltarget.class.php:806
+#: inc/question.class.php:1179 inc/abstractitiltarget.class.php:805
 msgid "SLA"
 msgstr "HDA"
 
-#: inc/question.class.php:1276 inc/abstractitiltarget.class.php:879
+#: inc/question.class.php:1180 inc/abstractitiltarget.class.php:878
 msgid "OLA"
 msgstr "ODA"
 
-#: inc/question.class.php:1293 inc/question.class.php:1333
-#: inc/question.class.php:1336
+#: inc/question.class.php:1197 inc/question.class.php:1237
+#: inc/question.class.php:1240
 msgid "Assets"
 msgstr "Varlıklar"
 
-#: inc/question.class.php:1307 hook.php:677 hook.php:694
+#: inc/question.class.php:1211 hook.php:643 hook.php:660
 msgid "Assistance"
 msgstr "Destek"
 
-#: inc/question.class.php:1312
+#: inc/question.class.php:1216
 msgid "Management"
 msgstr "Yönetim"
 
-#: inc/question.class.php:1321
+#: inc/question.class.php:1225
 msgid "Tools"
 msgstr "Araçlar"
 
-#: inc/question.class.php:1322
+#: inc/question.class.php:1226
 msgid "Notes"
 msgstr "Notlar"
 
-#: inc/question.class.php:1323
+#: inc/question.class.php:1227
 msgid "RSS feed"
 msgstr "RSS akışı"
 
-#: inc/question.class.php:1325
+#: inc/question.class.php:1229
 msgid "Administration"
 msgstr "İdari"
 
-#: inc/question.class.php:1333 inc/question.class.php:1336
+#: inc/question.class.php:1237 inc/question.class.php:1240
 msgid "Plugin"
 msgid_plural "Plugins"
 msgstr[0] "Uygulama eki"
@@ -1806,119 +1794,119 @@ msgid_plural "Composite ticket relations"
 msgstr[0] "Birleşik destek kaydı ilişkisi"
 msgstr[1] "Birleşik destek kaydı ilişkileri"
 
-#: inc/targetticket.class.php:56 entrée standard:43
+#: inc/targetticket.class.php:55 entrée standard:43
 msgid "Target ticket"
 msgid_plural "Target tickets"
 msgstr[0] "Hedef destek kaydı"
 msgstr[1] "Hedef destek kayıtları"
 
-#: inc/targetticket.class.php:99
+#: inc/targetticket.class.php:98
 msgid "Specific asset"
 msgstr "Belirli varlık"
 
-#: inc/targetticket.class.php:100 inc/targetticket.class.php:116
-#: inc/abstractitiltarget.class.php:199 inc/abstractitiltarget.class.php:207
-#: inc/abstractitiltarget.class.php:215 inc/abstractitiltarget.class.php:223
-#: inc/abstractitiltarget.class.php:232
+#: inc/targetticket.class.php:99 inc/targetticket.class.php:115
+#: inc/abstractitiltarget.class.php:198 inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:214 inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:231
 msgid "Equals to the answer to the question"
 msgstr "Sorunun yanıtına eşit olan"
 
-#: inc/targetticket.class.php:101 inc/abstractitiltarget.class.php:224
-#: inc/abstractitiltarget.class.php:233
+#: inc/targetticket.class.php:100 inc/abstractitiltarget.class.php:223
+#: inc/abstractitiltarget.class.php:232
 msgid "Last valid answer"
 msgstr "Geçerli son yanıt"
 
-#: inc/targetticket.class.php:107
+#: inc/targetticket.class.php:106
 msgid "Source from template or user default or GLPI default"
 msgstr ""
 "Kalıptan ya da kullanıcı varsayılanından ya da GLPI varsayılanından kaynak "
 
-#: inc/targetticket.class.php:108
+#: inc/targetticket.class.php:107
 msgid "Formcreator"
 msgstr "Formcreator"
 
-#: inc/targetticket.class.php:114
+#: inc/targetticket.class.php:113
 msgid "Default or from a template"
 msgstr "Varsayılan ya da bir kalıptan"
 
-#: inc/targetticket.class.php:115
+#: inc/targetticket.class.php:114
 msgid "Specific type"
 msgstr "Belirli tür"
 
-#: inc/targetticket.class.php:188 entrée standard:48
+#: inc/targetticket.class.php:187 entrée standard:48
 msgid "Ticket title"
 msgstr "Çağrı başlığı"
 
-#: inc/targetticket.class.php:301
+#: inc/targetticket.class.php:300
 msgid "Add validation message as first ticket followup"
 msgstr "İlk çağrı izlemesine değerlendirme iletisi eklensin"
 
-#: inc/targetticket.class.php:335
+#: inc/targetticket.class.php:334
 msgid "Add a field"
 msgstr "Alan ekle"
 
-#: inc/targetticket.class.php:363
+#: inc/targetticket.class.php:362
 msgid "Managed fields"
 msgstr "Yönetilen alanlar"
 
-#: inc/targetticket.class.php:370
+#: inc/targetticket.class.php:369
 msgid "No managed field"
 msgstr "Herhangi bir yönetilen alan yok"
 
-#: inc/targetticket.class.php:390
+#: inc/targetticket.class.php:389
 msgid "Link to an other ticket"
 msgstr "Başka bir çağrıya bağlantı"
 
-#: inc/targetticket.class.php:399
+#: inc/targetticket.class.php:398
 msgid "An other destination of this form"
 msgstr "Bu form için farklı bir hedef"
 
-#: inc/targetticket.class.php:400
+#: inc/targetticket.class.php:399
 msgid "An existing ticket"
 msgstr "Var olan bir çağrı"
 
-#: inc/targetticket.class.php:401
+#: inc/targetticket.class.php:400
 msgid "A ticket from an answer to a question"
 msgstr "Bir sorunun bir yanıtından bir destek kaydı"
 
-#: inc/targetticket.class.php:482
+#: inc/targetticket.class.php:481
 msgctxt "button"
 msgid "Delete permanently"
 msgstr "Kalıcı olarak sil"
 
-#: inc/targetticket.class.php:741
+#: inc/targetticket.class.php:722
 msgid "Invalid link type"
 msgstr "Bağlantı türü geçersiz"
 
-#: inc/targetticket.class.php:761
+#: inc/targetticket.class.php:742
 msgid "Invalid linked item type"
 msgstr "Bağlantılı öge türü geçersiz"
 
-#: inc/targetticket.class.php:774
+#: inc/targetticket.class.php:755
 msgid "Linked item does not exists"
 msgstr "Bağlantılı öge bulunamadı"
 
-#: inc/targetticket.class.php:787
+#: inc/targetticket.class.php:768
 msgid "Failed to link the item"
 msgstr "Öge bağlantısı kurulamadı"
 
-#: inc/targetticket.class.php:957 install/install.php:347
+#: inc/targetticket.class.php:924 install/install.php:421
 msgid "Your form has been accepted by the validator"
 msgstr "Formunuz değerlendiren tarafından onaylandı"
 
-#: inc/targetticket.class.php:1108
+#: inc/targetticket.class.php:1082
 msgid "Request source"
 msgstr "İstek kaynağı"
 
-#: inc/targetticket.class.php:1133
+#: inc/targetticket.class.php:1107
 msgid "Type "
 msgstr "Tür"
 
-#: inc/targetticket.class.php:1161
+#: inc/targetticket.class.php:1135
 msgid "Associated elements"
 msgstr "İlgili bileşenler"
 
-#: inc/targetticket.class.php:1172
+#: inc/targetticket.class.php:1146
 msgid "Item "
 msgstr "Öge"
 
@@ -1938,206 +1926,237 @@ msgstr "Form bulunamadı."
 msgid "Failed to add the translation."
 msgstr "Çeviri eklenemedi."
 
-#: inc/abstractitiltarget.class.php:180
+#: inc/abstractitiltarget.class.php:179
 msgid "Tags from questions"
 msgstr "Sorulardan etiketler"
 
-#: inc/abstractitiltarget.class.php:181
+#: inc/abstractitiltarget.class.php:180
 msgid "Specific tags"
 msgstr "Belirli etiketler"
 
-#: inc/abstractitiltarget.class.php:182
+#: inc/abstractitiltarget.class.php:181
 msgid "Tags from questions and specific tags"
 msgstr "Sorulardan etiketler ve belirli etiketler"
 
-#: inc/abstractitiltarget.class.php:183
+#: inc/abstractitiltarget.class.php:182
 msgid "Tags from questions or specific tags"
 msgstr "Sorulardan etiketler ya da belirli etiketler"
 
-#: inc/abstractitiltarget.class.php:189
+#: inc/abstractitiltarget.class.php:188
 msgid "equals to the answer to the question"
 msgstr "sorunun yanıtına eşit olan"
 
-#: inc/abstractitiltarget.class.php:190
+#: inc/abstractitiltarget.class.php:189
 msgid "calculated from the ticket creation date"
 msgstr "çağrı oluşturma zamanından hesaplanan"
 
-#: inc/abstractitiltarget.class.php:191
+#: inc/abstractitiltarget.class.php:190
 msgid "calculated from the answer to the question"
 msgstr "sorunun yanıtından hesaplanan"
 
-#: inc/abstractitiltarget.class.php:197
+#: inc/abstractitiltarget.class.php:196
 msgid "SLA from template or none"
 msgstr "Kalıptan HDA ya da yok"
 
-#: inc/abstractitiltarget.class.php:198
+#: inc/abstractitiltarget.class.php:197
 msgid "Specific SLA"
 msgstr "Belirli hizmet düzeyi anlaşması"
 
-#: inc/abstractitiltarget.class.php:205
+#: inc/abstractitiltarget.class.php:204
 msgid "OLA from template or none"
 msgstr "Kalıptan operasyon düzeyi anlaşması ya da yok"
 
-#: inc/abstractitiltarget.class.php:206
+#: inc/abstractitiltarget.class.php:205
 msgid "Specific OLA"
 msgstr "Belirli bir operasyon düzeyi anlaşması"
 
-#: inc/abstractitiltarget.class.php:213
+#: inc/abstractitiltarget.class.php:212
 msgid "Urgency from template or Medium"
 msgstr "Önem düzeyi kalıp ya da ortamdan"
 
-#: inc/abstractitiltarget.class.php:214
+#: inc/abstractitiltarget.class.php:213
 msgid "Specific urgency"
 msgstr "Belirli önem düzeyi"
 
-#: inc/abstractitiltarget.class.php:221
+#: inc/abstractitiltarget.class.php:220
 msgid "Category from template or none"
 msgstr "Temadan kategori ya da yok"
 
-#: inc/abstractitiltarget.class.php:222
+#: inc/abstractitiltarget.class.php:221
 msgid "Specific category"
 msgstr "Belirli kategori"
 
-#: inc/abstractitiltarget.class.php:230
+#: inc/abstractitiltarget.class.php:229
 msgid "Location from template or none"
 msgstr "Temadan konum ya da yok"
 
-#: inc/abstractitiltarget.class.php:231
+#: inc/abstractitiltarget.class.php:230
 msgid "Specific location"
 msgstr "Belirli konum"
 
-#: inc/abstractitiltarget.class.php:239
+#: inc/abstractitiltarget.class.php:238
 msgid "No validation"
 msgstr "Değerlendirme yok"
 
-#: inc/abstractitiltarget.class.php:240
+#: inc/abstractitiltarget.class.php:239
 msgid "Specific user or group"
 msgstr "Belirli bir kullanıcı ya da grup"
 
-#: inc/abstractitiltarget.class.php:241
+#: inc/abstractitiltarget.class.php:240
 msgid "User from question answer"
 msgstr "Soru yanıtından kullanıcı"
 
-#: inc/abstractitiltarget.class.php:242
+#: inc/abstractitiltarget.class.php:241
 msgid "Group from question answer"
 msgstr "Soru yanıtından grup"
 
-#: inc/abstractitiltarget.class.php:741
+#: inc/abstractitiltarget.class.php:740
 msgid "Time to resolve"
 msgstr "Çözümlenme zamanı"
 
-#: inc/abstractitiltarget.class.php:794
+#: inc/abstractitiltarget.class.php:793
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "dakika"
 msgstr[1] "dakika"
 
-#: inc/abstractitiltarget.class.php:795
+#: inc/abstractitiltarget.class.php:794
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "saat"
 msgstr[1] "saat"
 
-#: inc/abstractitiltarget.class.php:796
+#: inc/abstractitiltarget.class.php:795
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "gün"
 msgstr[1] "gün"
 
-#: inc/abstractitiltarget.class.php:797
+#: inc/abstractitiltarget.class.php:796
 msgid "Month"
 msgid_plural "Months"
 msgstr[0] "ay"
 msgstr[1] "ay"
 
-#: inc/abstractitiltarget.class.php:829
+#: inc/abstractitiltarget.class.php:828
 msgid "SLA (TTO/TTR)"
 msgstr "HDA (EAZ/ÇÖZ)"
 
-#: inc/abstractitiltarget.class.php:830 inc/abstractitiltarget.class.php:903
+#: inc/abstractitiltarget.class.php:829 inc/abstractitiltarget.class.php:902
 msgid "Question (TTO/TTR)"
 msgstr "Soru (EAZ/ÇÖZ)"
 
-#: inc/abstractitiltarget.class.php:902
+#: inc/abstractitiltarget.class.php:901
 msgid "OLA (TTO/TTR)"
 msgstr "ODA (EAZ/ÇÖZ)"
 
-#: inc/abstractitiltarget.class.php:1006
+#: inc/abstractitiltarget.class.php:1005
 msgid "Urgency "
 msgstr "Önem düzeyi"
 
-#: inc/abstractitiltarget.class.php:1036
+#: inc/abstractitiltarget.class.php:1035
 msgid "Ticket tags"
 msgstr "Çağrı etiketleri"
 
-#: inc/abstractitiltarget.class.php:1084
+#: inc/abstractitiltarget.class.php:1083
 msgid "Tags"
 msgstr "Etiketler"
 
-#: inc/abstractitiltarget.class.php:1203
+#: inc/abstractitiltarget.class.php:1202
 msgid "Location"
 msgstr "Konum"
 
-#: inc/abstractitiltarget.class.php:1215
+#: inc/abstractitiltarget.class.php:1214
 msgid "Location "
 msgstr "Konum"
 
-#: inc/abstractitiltarget.class.php:1551
+#: inc/abstractitiltarget.class.php:1554
 msgid "The description cannot be empty!"
 msgstr "Açıklama boş olamaz!"
 
-#: inc/abstractitiltarget.class.php:1721
+#: inc/abstractitiltarget.class.php:1731
 msgid "Watcher"
 msgid_plural "Watchers"
 msgstr[0] "İzleyen"
 msgstr[1] "İzleyenler"
 
-#: inc/abstractitiltarget.class.php:1740
+#: inc/abstractitiltarget.class.php:1750
 msgid "Cancel"
 msgstr "İptal"
 
-#: inc/abstractitiltarget.class.php:2015 inc/abstractitiltarget.class.php:2031
-#: inc/abstractitiltarget.class.php:2032
+#: inc/abstractitiltarget.class.php:2025 inc/abstractitiltarget.class.php:2041
+#: inc/abstractitiltarget.class.php:2042
 msgid "Email followup"
 msgstr "E-posta izlemesi"
 
-#: inc/abstractitiltarget.class.php:2029 inc/abstractitiltarget.class.php:2057
+#: inc/abstractitiltarget.class.php:2038 inc/abstractitiltarget.class.php:2056
+msgid "User"
+msgstr "Kullanıcı"
+
+#: inc/abstractitiltarget.class.php:2039 inc/abstractitiltarget.class.php:2067
 msgid "Group"
 msgstr "Grup"
 
-#: inc/abstractitiltarget.class.php:2030 inc/abstractitiltarget.class.php:2086
+#: inc/abstractitiltarget.class.php:2040 inc/abstractitiltarget.class.php:2096
 msgid "Supplier"
 msgstr "Sağlayıcı"
 
-#: inc/abstractitiltarget.class.php:2031
+#: inc/abstractitiltarget.class.php:2041
 msgid "Yes"
 msgstr "Evet"
 
-#: inc/abstractitiltarget.class.php:2068
+#: inc/abstractitiltarget.class.php:2078
 msgid "Group from the object"
 msgstr "Nesneden grup"
 
-#: inc/abstractitiltarget.class.php:2074
+#: inc/abstractitiltarget.class.php:2084
 msgid "Tech group from the object"
 msgstr "Nesneden teknik grup"
 
-#: install/install.php:131
-msgid ""
-"Upgrade tables to innoDB; run php bin/console "
-"glpi:migration:myisam_to_innodb"
+#: install/install.php:130
+#, php-format
+msgid "Upgrade tables to innoDB; run %s"
 msgstr ""
-"Tabloları innoDB olarak değiştirmek için php bin/console "
-"glpi:migration:myisam_to_innodb komutunu yürütün"
 
-#: install/install.php:328
+#: install/install.php:160
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs run the command %s"
+msgstr ""
+
+#: install/install.php:169
+#, php-format
+msgid "To ignore the inconsistencies and upgrade anyway run %s"
+msgstr ""
+
+#: install/install.php:187
+msgid ""
+"Upgrade from version older than 2.5.0 is no longer supported. Please upgrade"
+" to GLPI 9.5.7, upgrade Formcreator to version 2.12.5, then upgrade again to"
+" GLPI 10 or later and Formcreator 2.13 or later."
+msgstr ""
+
+#: install/install.php:239
+#, php-format
+msgid ""
+"The database schema is not consistent with the installed Formcreator %s. To "
+"see the logs enable the plugin and run the command %s"
+msgstr ""
+
+#: install/install.php:250
+msgid "The tables of the plugin passed the schema integrity check."
+msgstr ""
+
+#: install/install.php:402
 msgid "A form has been created"
 msgstr "Bir form eklendi"
 
-#: install/install.php:329
+#: install/install.php:403
 msgid "Your request has been saved"
 msgstr "İsteğiniz kaydedildi"
 
-#: install/install.php:330
+#: install/install.php:404
 msgid ""
 "Hi,\\nYour request from GLPI has been successfully saved with number "
 "##formcreator.request_id## and transmitted to the helpdesk team.\\nYou can "
@@ -2147,11 +2166,11 @@ msgstr ""
 "kaydedilerek destek ekibimize iletildi.\\nİsteğinize verilen yanıtları şu "
 "bağlantıdan görebilirsiniz:\\n##formcreator.validation_link##"
 
-#: install/install.php:335
+#: install/install.php:409
 msgid "A form from GLPI need to be validate"
 msgstr "Değerlendirilmesi gereken bir GLPI formu var"
 
-#: install/install.php:336
+#: install/install.php:410
 msgid ""
 "Hi,\\nA form from GLPI need to be validate and you have been choosen as the "
 "validator.\\nYou can access it by clicking onto this "
@@ -2161,12 +2180,12 @@ msgstr ""
 "üzere seçildiniz.\\nAşağıdaki bağlantıya tıklayarak forma "
 "erişebilirsiniz:\\n##formcreator.validation_link##"
 
-#: install/install.php:341
+#: install/install.php:415
 msgid "Your form has been refused by the validator"
 msgstr ""
 "Formunuzdaki bilgiler hatalı olduğundan değerlendiren tarafından reddedildi"
 
-#: install/install.php:342
+#: install/install.php:416
 msgid ""
 "Hi,\\nWe are sorry to inform you that your form has been refused by the "
 "validator for the reason "
@@ -2178,7 +2197,7 @@ msgstr ""
 "düzenleyip yeniden göndermek için şu bağlantıyı "
 "kullanabilirsiniz:\\n##formcreator.validation_link##"
 
-#: install/install.php:348
+#: install/install.php:422
 msgid ""
 "Hi,\\nWe are pleased to inform you that your form has been accepted by the "
 "validator.\\nYour request will be considered soon."
@@ -2186,53 +2205,72 @@ msgstr ""
 "Merhaba,\\nFormunuz değerlendiren tarafından kabul edildi.\\nİsteğiniz kısa "
 "süre içinde değerlendirilecek."
 
-#: install/install.php:353
+#: install/install.php:427
 msgid "Your form has been deleted by an administrator"
 msgstr "Formunuz bir yönetici tarafından silindi"
 
-#: install/install.php:354
+#: install/install.php:428
 msgid ""
 "Hi,\\nWe are sorry to inform you that your request cannot be considered and "
 "has been deleted by an administrator."
 msgstr ""
 "Merhaba,\\nİsteğiniz dikkate alınmadı ve bir yönetici tarafından silindi."
 
-#: install/install.php:580
+#: install/install.php:654
 msgid "Formcreator - Sync service catalog issues"
 msgstr "Formcreator - Eşitleme hizmeti katalog sorunları"
 
-#: hook.php:305
+#: install/install.php:842
+msgid "Failed to check the sanity of the tables!"
+msgstr ""
+
+#: install/install.php:856
+#, php-format
+msgid "Table schema differs for table \"%s\"."
+msgstr ""
+
+#: install/install.php:859
+#, php-format
+msgid "Table \"%s\" is missing."
+msgstr ""
+
+#: install/install.php:862
+#, php-format
+msgid "Unknown table \"%s\" has been found in database."
+msgstr ""
+
+#: hook.php:317
 msgctxt "button"
 msgid "Duplicate"
 msgstr "Kopyala"
 
-#: hook.php:306
+#: hook.php:318
 msgid "Transfer"
 msgstr "Aktar"
 
-#: hook.php:307
+#: hook.php:319
 msgctxt "button"
 msgid "Export"
 msgstr "Dışa aktar"
 
-#: hook.php:653
+#: hook.php:619
 msgid "Cancel my ticket"
 msgstr "Çağrı kaydımı iptal et"
 
-#: hook.php:671
+#: hook.php:637
 msgid "Old"
 msgstr "Eski"
 
-#: hook.php:678
+#: hook.php:644
 #, php-format
 msgid "Number of %s"
 msgstr "%s sayısı"
 
-#: hook.php:695
+#: hook.php:661
 msgid "Issues summary"
 msgstr "Sorun özeti"
 
-#: hook.php:733
+#: hook.php:699
 msgid ""
 "Formcreator's mini dashboard not usable as default. This Setting has been "
 "ignored."
@@ -2240,35 +2278,39 @@ msgstr ""
 "Formcreator mini panosu varsayılan olarak kullanılamaz. Bu ayar yok "
 "sayılacak."
 
-#: js/scripts.js:315
+#: js/scripts.js:296
 msgid "No form found. Please choose a form below instead."
 msgstr "Herhangi bir form bulunamadı. Lütfen aşağıdan bir form seçin."
 
-#: js/scripts.js:317
+#: js/scripts.js:298
 msgid "No form found."
 msgstr "Herhangi bir form bulunamadı."
 
-#: js/scripts.js:321
+#: js/scripts.js:302
 msgid "No FAQ item found."
 msgstr "Herhangi bir SSS ögesi bulunamadı."
 
-#: js/scripts.js:690
+#: js/scripts.js:686
 msgid "Are you sure you want to delete this question?"
 msgstr "Bu soruyu silmek istediğinize emin misiniz?"
 
-#: js/scripts.js:873
+#: js/scripts.js:869
 msgid "Are you sure you want to delete this section?"
 msgstr "Bu bölümü silmek istediğinize emin misiniz?"
 
-#: js/scripts.js:1113
+#: js/scripts.js:1109
 msgid "Add translations"
 msgstr "Çeviriler ekle"
 
-#: js/scripts.js:1260 js/scripts.js:1284
+#: js/scripts.js:1256 js/scripts.js:1280
 msgid "An error occured while querying forms"
 msgstr "Formlar alınırken bir sorun çıktı"
 
-#: js/scripts.js:1398
+#: js/scripts.js:1400
+msgid "An internal error occurred. Please report it to administrator."
+msgstr ""
+
+#: js/scripts.js:1441
 msgid "Are you sure you want to delete this target:"
 msgstr "Bu hedefi silmek istediğinize emin misiniz:"
 
@@ -2319,13 +2361,17 @@ msgstr "Açılışa doğrudan erişim"
 msgid "Default form in service catalog"
 msgstr "Hizmet kataloğundaki varsayılan form"
 
-#: entrée standard:106 standard:107
+#: entrée standard:113 standard:114
 msgid "Are you a robot ?"
 msgstr "Robot musunuz?"
 
-#: entrée standard:132
+#: entrée standard:139
 msgid "Send"
 msgstr "Gönder"
+
+#: entrée standard:64
+msgid "Condition to show the section"
+msgstr "Bölümün görüntülenme koşulu"
 
 #: entrée standard:40
 msgid "Condition to generate the target"

--- a/templates/pages/form.html.twig
+++ b/templates/pages/form.html.twig
@@ -81,7 +81,7 @@
 
     {{ fields.textField('description', item.fields['description'], __('Description')) }}
 
-    {{ fields.textareaField('content', item.fields['content'], __('Header', 'formcreator'), { 'enable_richtext': true }) }}
+    {{ fields.textareaField('content', item.fields['content'], _n('Header', 'Headers', 1, 'formcreator'), { 'enable_richtext': true }) }}
 
     {{ fields.dropdownYesNo('is_default', item.fields['is_default'], __('Default form in service catalog', 'formcreator')) }}
 

--- a/templates/pages/question.html.twig
+++ b/templates/pages/question.html.twig
@@ -50,7 +50,7 @@
       'PluginFormcreatorSection',
       'plugin_formcreator_sections_id',
       item.fields['plugin_formcreator_sections_id'],
-      __('Section', 'formcreator'),
+      _n('Section', 'Sections', 1, 'formcreator'),
       {
          'display_emptychoice': false,
          'condition': {'plugin_formcreator_forms_id': section.fields['plugin_formcreator_forms_id']},

--- a/templates/pages/section.html.twig
+++ b/templates/pages/section.html.twig
@@ -61,7 +61,7 @@
 
                     {{ fields.hiddenField('plugin_formcreator_forms_id', item.fields['plugin_formcreator_forms_id'], '', { 'include_field': false }) }}
 
-                    {{ fields.smallTitle(__('Condition to show the question', 'formcreator')) }}
+                    {{ fields.smallTitle(__('Condition to show the section', 'formcreator')) }}
 
                     {{ fields.dropdownArrayField('show_rule', item.fields['show_rule'], item.getEnumShowrule(), '', { 'no_label': true, 'on_change': 'plugin_formcreator_toggleCondition(this);' }) }}
                     {% set parent = item %}


### PR DESCRIPTION
Resolve warnings with gettext when extracting locales
fix a typo in section's condition 
![image](https://user-images.githubusercontent.com/14139801/195876399-974f7b5b-bca0-4b80-8430-4d28d8b8eb24.png)
