### PR TITLE
Fix outdated usage of iterator->next()

### DIFF
--- a/inc/targetproblem.class.php
+++ b/inc/targetproblem.class.php
@@ -357,7 +357,7 @@ class PluginFormcreatorTargetProblem extends PluginFormcreatorAbstractItilTarget
             'FROM'   => ITILCategory::getTable(),
             'WHERE'  => ['id' => $data['itilcategories_id']]
          ]);
-         if ($row = $rows->next()) {
+         if ($row = $rows->current()) {
             // assign problem template according to resulting problem category
             return $row[$targetTemplateFk];
          }


### PR DESCRIPTION
Found this code while searching for occurrences of `->next()`.
See https://github.com/glpi-project/glpi/pull/9683.