### PR TITLE
Page switching loose filter

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -29,6 +29,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Toolbox\Sanitizer;
 use GlpiPlugin\Formcreator\Field\DropdownField;
 
@@ -207,7 +208,6 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          'table'              => 'glpi_plugin_formcreator_forms',
          'field'              => 'name',
          'name'               => PluginFormcreatorForm::getTypeName(1),
-         'searchtype'         => 'contains',
          'datatype'           => 'string',
          'massiveaction'      => false
       ];
@@ -423,32 +423,85 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
    }
 
    static function showForForm(PluginFormcreatorForm $form, $params = []) {
-      // set a session var to tweak search results
-      $_SESSION['formcreator']['form_search_answers'] = $form->getID();
+      global $DB;
 
-      // prepare params for search
-      $item            = PluginFormcreatorCommon::getFormAnswer();
-      $searchOptions   = $item->rawSearchOptions();
-      $filteredOptions = [];
-      foreach ($searchOptions as $value) {
-         if (is_numeric($value['id']) && $value['id'] <= 7) {
-            $filteredOptions[$value['id']] = $value;
+      $table = self::getTable();
+      $form_table = PluginFormcreatorForm::getTable();
+      $form_fk = PluginFormcreatorForm::getForeignKeyField();
+      $user_table = User::getTable();
+      if (version_compare(GLPI_VERSION, '10.0.5') >= 0) {
+         $userQueryExpression = User::getFriendlyNameFields('requester_name');
+      } else {
+         // Drop this alternative when the plugin requires GLPI 10.0.5+
+         $alias = 'requester_name';
+         $config = Config::getConfigurationValues('core');
+         if ($config['names_format'] == User::FIRSTNAME_BEFORE) {
+            $first = "firstname";
+            $second = "realname";
+         } else {
+            $first = "realname";
+            $second = "firstname";
          }
+
+         $first  = DBmysql::quoteName("$user_table.$first");
+         $second = DBmysql::quoteName("$user_table.$second");
+         $alias  = DBmysql::quoteName($alias);
+         $name   = DBmysql::quoteName($user_table . '.' . self::getNameField());
+
+         $userQueryExpression = new QueryExpression("IF(
+            $first <> '' && $second <> '',
+            CONCAT($first, ' ', $second),
+            $name
+         ) AS $alias");
       }
-      $searchOptions = $filteredOptions;
-      $sopt_keys     = array_keys($searchOptions);
 
-      $forcedisplay  = array_combine($sopt_keys, $sopt_keys);
+      $result = $DB->request([
+         'SELECT' => [
+            $table => [
+               'id',
+               'name',
+               'requester_id',
+               'users_id_validator',
+               'request_date'
+            ],
+            $form_table => [
+               'name as form_name'
+            ],
+            $userQueryExpression
+         ],
+         'FROM' => self::getTable(),
+         'INNER JOIN' => [
+            $form_table => [
+               'FKEY' => [
+                  $form_table => 'id',
+                  $table => $form_fk,
+               ],
+            ],
+         ],
+         'LEFT JOIN' => [
+            $user_table => [
+               'FKEY' => [
+                  $user_table => 'id',
+                  $table => 'requester_id',
+               ],
+            ],
+         ],
+         'WHERE' => [
+            $table . '.' . $form_fk => $form->getID(),
+         ],
+         'LIMIT' => 20,
+         'ORDER' => [
+            'request_date DESC',
+         ],
+      ]);
 
-      // do search
-      $params = Search::manageParams(__CLASS__, $params, false);
-      $data   = Search::prepareDatasForSearch(__CLASS__, $params, $forcedisplay);
-      Search::constructSQL($data);
-      Search::constructData($data);
-      Search::displayData($data);
+      $total_count = count($result);
 
-      // remove previous session var (restore default view)
-      unset($_SESSION['formcreator']['form_search_answers']);
+      TemplateRenderer::getInstance()->display('@formcreator/pages/form.formanswer.html.twig', [
+         'form' => $form,
+         'form_answers' => $result,
+         'total_count' => $total_count,
+      ]);
    }
 
     /**

--- a/templates/pages/form.formanswer.html.twig
+++ b/templates/pages/form.formanswer.html.twig
@@ -1,0 +1,65 @@
+{#
+ # ---------------------------------------------------------------------
+ # Formcreator is a plugin which allows creation of custom forms of
+ # easy access.
+ # ---------------------------------------------------------------------
+ # LICENSE
+ #
+ # This file is part of Formcreator.
+ #
+ # Formcreator is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # Formcreator is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with Formcreator. If not, see <http://www.gnu.org/licenses/>.
+ # ---------------------------------------------------------------------
+ # @copyright Copyright © 2011 - 2021 Teclib'
+ # @license   http://www.gnu.org/licenses/gpl.txt GPLv3+
+ # @link      https://github.com/pluginsGLPI/formcreator/
+ # @link      https://pluginsglpi.github.io/formcreator/
+ # @link      http://plugins.glpi-project.org/#/plugin/formcreator
+ # ---------------------------------------------------------------------
+ #}
+
+{% if total_count < 1 %}
+   <div class="alert alert-info">
+      {{ __('No form answer yet', 'formcreator') }}
+   </div>
+{% else %}
+   {% set criteria = '?criteria[0][field]=3&criteria[0][searchtype]=equals&criteria[0][value]=' ~ form.getID() ~ '' %}
+   <div class="center my-4">
+      {{ __('%s latest items', 'formcreator')|format(total_count) }}
+      <a href="{{ 'PluginFormcreatorFormAnswer'|itemtype_search_path ~ criteria }}">{{ __('See all', 'formcreator') }}</a>
+   </div>
+   <div class="table-responsive">
+      <table class="table table-hover">
+         <thead>
+            <tr>
+               <th>{{ __('ID') }}</th>
+               <th>{{ __('Name') }}</th>
+               <th>{{ __('Form') }}</th>
+               <th>{{ __('Requester', 'Requesters', 1) }}</th>
+               <th>{{ __('Creation date') }}</th>
+            </tr>
+         </thead>
+         <tbody>
+            {% for row in form_answers %}
+               <tr>
+                  <td>{{ row.id }}</td>
+                  <td>{{ get_item_link('PluginFormcreatorFormAnswer', row.id) }}</a></td>
+                  <td>{{ row.form_name }}</td>
+                  <td>{{ row.requester_name }}</td>
+                  <td>{{ row.request_date }}</td>
+               </tr>
+            {% endfor %}
+         </tbody>
+      </table>
+   </div>
+{% endif %}


### PR DESCRIPTION
When changing page of form answer results of a form the filter on the form foreign key is lost.

Requires: https://github.com/glpi-project/glpi/pull/13181

### Changes description

When user shows form answers of a form only the latest 20 entries are displayed. A hyperlink above the list gives access to the search page of form answers with a given FK to the current form.

This is necessary to have a quick way to access forms with customizable search options and massive actions.

GLPI cannot show a list of items generated by Search::displayData() in a tab because the tabler pushes URLs in browser's history and fails to recover the search criterias.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A

internal ref: 25339