### PR TITLE
fix(textfield) remove invalid '\r\n' tokens

### DIFF
--- a/inc/field/textfield.class.php
+++ b/inc/field/textfield.class.php
@@ -226,7 +226,7 @@ class TextField extends PluginFormcreatorAbstractField
          return false;
       }
 
-      $this->value = Toolbox::stripslashes_deep($input[$key]);
+      $this->value = Toolbox::stripslashes_deep(str_replace('\r\n', "\r\n", $input[$key]));
       return true;
    }
 

--- a/inc/field/textfield.class.php
+++ b/inc/field/textfield.class.php
@@ -226,7 +226,11 @@ class TextField extends PluginFormcreatorAbstractField
          return false;
       }
 
-      $this->value = Toolbox::stripslashes_deep(str_replace('\r\n', "\r\n", $input[$key]));
+      if (version_compare(GLPI_VERSION, '9.5.10', '>=')) {
+         $input[$key] = str_replace('\r\n', "\r\n", $input[$key]);
+      }
+
+      $this->value = Toolbox::stripslashes_deep($input[$key]);
       return true;
    }
 


### PR DESCRIPTION
### Changes description

In GLPI 9.5.10, `\r\n` tokens are no more removed when richtext is produced by `tinymce` (see https://github.com/glpi-project/glpi/issues/13202). I think it could be logical to apply same transformation as it is already done for default value:
https://github.com/pluginsGLPI/formcreator/blob/69088c09d63b826339bbb2db99ad54860cc0c5d8/inc/field/textareafield.class.php#L208

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Internal ref: 25456
<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A