### PR TITLE
Prevent warning on null value

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1661,7 +1661,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
       $this->loadAnswers();
       $answers_values = $this->getAnswers();
-      foreach (array_keys($this->questionFields) as $id) {
+      foreach (array_keys($this->questionFields ?? []) as $id) {
          if (!$this->questionFields[$id]->hasInput($answers_values)) {
             continue;
          }


### PR DESCRIPTION
Prevent the following warning:
```
[2022-11-21 11:32:53] glpiphplog.WARNING:   *** PHP Warning (2): array_keys() expects parameter 1 to be array, null given in /var/www/html/glpi/plugins/formcreator/inc/formanswer.class.php at line 1595
  Backtrace :
  plugins/formcreator/inc/formanswer.class.php:1595  array_keys()
  plugins/formcreator/inc/formanswer.class.php:1208  PluginFormcreatorFormAnswer->deserializeAnswers()
  plugins/formcreator/inc/issue.class.php:837        PluginFormcreatorFormAnswer->parseTags()
  plugins/formcreator/hook.php:329                   PluginFormcreatorIssue::giveItem()
  src/Plugin.php:1557                                plugin_formcreator_giveItem()
  src/Search.php:6359                                Plugin::doOneHook()
  src/Search.php:1690                                Search::giveItem()
  src/Search.php:447                                 Search::constructData()
  plugins/formcreator/inc/issue.class.php:1075       Search::getDatas()
  :                                                  PluginFormcreatorIssue::nbIssues()
  src/Dashboard/Grid.php:958                         call_user_func_array()
```
!25474