### PR TITLE
Show save button for followup edit in simplified service catalog

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -388,7 +388,9 @@ class PluginFormcreatorIssue extends CommonDBTM {
          echo '#itil-object-container .form-buttons span { display: none !important }';
          echo '#itil-object-container .form-buttons { flex: inherit; width: auto}';
          echo "#itil-object-container .timeline-buttons { flex: 1 1 auto }";
-         echo "#itil-object-container button[type='submit'][name='update'] { display: none }";
+         // The following line becomes useless with GLPI 10.0.5 as the save button of side panel does no longer show for extended service catalog
+         // To drop when GLPI 10.0.5 is the minimum version
+         echo "#itil-object-container .form-buttons button[type='submit'][name='update'] { display: none }";
          echo '</style>';
          $item->showForm($item->getID());
          echo "</div>";


### PR DESCRIPTION
internal refs 24073, 25658

### Changes description

When a user in simplified service catalog edits a followup, he cannot save his work. Button is hidden.

Save button of side panel was disabled in 24073, but it also disabled the followup edition button. The fix exclused this button to hide only the save button of side panel.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A