### PR TITLE
fix(issues): Tooltip consistency with core

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -893,9 +893,10 @@ class PluginFormcreatorIssue extends CommonDBTM {
             }
 
             $key = 'id';
-            $tooltip = Html::showToolTip(nl2br(RichText::getTextFromHtml($content)), [
-               'applyto' => $itemtype.$data['raw'][$key],
-               'display' => false,
+            $tooltip = Html::showToolTip(RichText::getEnhancedHtml($content), [
+               'applyto'        => $itemtype.$data['raw'][$key],
+               'display'        => false,
+               'images_gallery' => false
             ]);
             return '<a id="' . $itemtype.$data['raw'][$key] . '" href="' . $link . '">'
                . sprintf(__('%1$s %2$s'), $name, $tooltip)


### PR DESCRIPTION
### Changes description

Rich text is not interpreted in issues' tooltips:

![image](https://user-images.githubusercontent.com/42734840/209962421-2aec4435-4cce-407f-9414-9e29c1addf05.png)

GLPI core does show rich text in tickets tooltip so I've updated formcreator's code to be consistent with the core behavior.
Core code for reference :

![image](https://user-images.githubusercontent.com/42734840/209962755-3aaeb03a-7059-4290-8c6b-cf3f4e32cec0.png)

After applying the changes, the tooltips are displayed as expected:

![image](https://user-images.githubusercontent.com/42734840/209962809-e3c09e81-4e70-47cd-b29d-492d35d98079.png)

### References

!26015