### PR TITLE
include answers with multi ticket for actor filter

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -102,7 +102,7 @@ function plugin_formcreator_addDefaultJoin($itemtype, $ref_table, &$already_link
                $ref_table,
                $already_link_tables,
                $issueSo[9]['table'],
-               'users_id_validator',
+               $issueSo[9]['linkfield'],
                0,
                0,
                $issueSo[9]['joinparams']
@@ -112,7 +112,7 @@ function plugin_formcreator_addDefaultJoin($itemtype, $ref_table, &$already_link
                $ref_table,
                $already_link_tables,
                $issueSo[11]['table'],
-               'users_id_validate',
+               $issueSo[11]['linkfield'],
                0,
                0,
                $issueSo[11]['joinparams']
@@ -122,10 +122,40 @@ function plugin_formcreator_addDefaultJoin($itemtype, $ref_table, &$already_link
                $ref_table,
                $already_link_tables,
                $issueSo[16]['table'],
-               'groups_id_validator',
+               $issueSo[16]['linkfield'],
                0,
                0,
                $issueSo[16]['joinparams']
+            );
+            $join .= Search::addLeftJoin(
+               $itemtype,
+               $ref_table,
+               $already_link_tables,
+               $issueSo[42]['table'],
+               $issueSo[42]['linkfield'],
+               0,
+               0,
+               $issueSo[42]['joinparams']
+            );
+            $join .= Search::addLeftJoin(
+               $itemtype,
+               $ref_table,
+               $already_link_tables,
+               $issueSo[43]['table'],
+               $issueSo[43]['linkfield'],
+               0,
+               0,
+               $issueSo[43]['joinparams']
+            );
+            $join .= Search::addLeftJoin(
+               $itemtype,
+               $ref_table,
+               $already_link_tables,
+               $issueSo[44]['table'],
+               $issueSo[44]['linkfield'],
+               0,
+               0,
+               $issueSo[44]['joinparams']
             );
          }
          break;
@@ -185,6 +215,19 @@ function plugin_formcreator_addDefaultWhere($itemtype) {
          // condition where current user is a validator of a issue of type ticket
          $complexJoinId = Search::computeComplexJoinID($issueSearchOptions[11]['joinparams']);
          $condition .= " OR `glpi_users_users_id_validate_$complexJoinId`.`id` = '$currentUser'";
+
+         // condition where the current user is a requester of a ticket linked to a form answer typed issue
+         $complexJoinId = Search::computeComplexJoinID($issueSearchOptions[42]['joinparams']);
+         $condition .= " OR `glpi_users_$complexJoinId`.`id` = '$currentUser'";
+
+         // condition where the current user is a watcher of a ticket linked to a form answer typed issue
+         $complexJoinId = Search::computeComplexJoinID($issueSearchOptions[43]['joinparams']);
+         $condition .= " OR `glpi_users_$complexJoinId`.`id` = '$currentUser'";
+
+         // condition where the current user is assigned of a ticket linked to a form answer typed issue
+         $complexJoinId = Search::computeComplexJoinID($issueSearchOptions[44]['joinparams']);
+         $condition .= " OR `glpi_users_$complexJoinId`.`id` = '$currentUser'";
+
          // Add users_id_recipient
          $condition .= " OR `glpi_plugin_formcreator_issues`.`users_id_recipient` = $currentUser ";
          return "($condition)";

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -164,6 +164,40 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          }
       }
 
+      // Check if the current user is a requester of a ticket linked to a form answer typed
+      // Matches search option 42, 43 and 44 of PluginFormcreatorIssue (requester, watcher, assigned)
+      $ticket_table = Ticket::getTable();
+      $ticket_user_table = Ticket_User::getTable();
+      $item_ticket_table = Item_Ticket::getTable();
+      $request = [
+         'SELECT' => Ticket_User::getTableField(User::getForeignKeyField()),
+         'FROM' => $ticket_user_table,
+         'INNER JOIN' => [
+            $ticket_table => [
+               'FKEY' => [
+                  $ticket_table => 'id',
+                  $ticket_user_table => 'tickets_id',
+               ],
+            ],
+            $item_ticket_table => [
+               'FKEY' => [
+                  $item_ticket_table => 'tickets_id',
+                  $ticket_table => 'id',
+                  ['AND' => [
+                     Item_Ticket::getTableField('itemtype') =>  self::getType(),
+                  ]],
+               ],
+            ],
+
+         ]
+      ];
+
+      foreach ($DB->request($request) as $row) {
+         if ($row[User::getForeignKeyField()] == $currentUser) {
+            return true;
+         }
+      }
+
       return false;
    }
 

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -455,7 +455,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
       $rows = $DB->request([
          'FROM'  => Item_Ticket::getTable(),
          'WHERE' => [
-            'itemtype' => 'PluginFormcreatorFormAnswer',
+            'itemtype' => PluginFormcreatorFormAnswer::getType(),
             'items_id' => $item->getID() // $item is a PluginFormcreatorFormAnswer
          ],
          'ORDER' => 'tickets_id ASC'

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -472,8 +472,8 @@ class PluginFormcreatorIssue extends CommonDBTM {
                $item = $ticket;
             }
          } else {
-            // multiple tickets, ticket specified, then substitute the ticket to the form answer
             if (isset($options['tickets_id'])) {
+               // multiple tickets, ticket specified, then substitute the ticket to the form answer
                $ticket = Ticket::getById((int) $options['tickets_id']);
                if ($ticket) {
                   $item = $ticket;
@@ -645,17 +645,50 @@ class PluginFormcreatorIssue extends CommonDBTM {
          'massiveaction'      => false,
          'joinparams'         => [
             'beforejoin'         => [
-               'table'              => TicketValidation::getTable(),
-               'joinparams'         => [
-                  'jointype'           => 'child',
-                  'beforejoin'         => [
-                     'table'              => Ticket::getTable(),
-                     'joinparams'         => [
-                        'jointype'        => 'itemtype_item_revert',
-                        'specific_itemtype'  => Ticket::class,
+               [
+                  'table'              => TicketValidation::getTable(),
+                  'joinparams'         => [
+                     'jointype'           => 'child',
+                     'beforejoin'         => [
+                        'table'              => Ticket::getTable(),
+                        'joinparams'         => [
+                           'jointype'        => 'itemtype_item_revert',
+                           'specific_itemtype'  => Ticket::class,
+                        ]
                      ]
                   ]
-               ]
+               ],
+               [
+                  'table'              => TicketValidation::getTable(),
+                  'joinparams'         => [
+                     'jointype'           => 'child',
+                     'beforejoin'         => [
+                        'table'              => Ticket::getTable(),
+                        'joinparams'      => [
+                           'jointype'        => 'empty',
+                           'condition'       => [
+                              new \QueryExpression(
+                                 '1=1'
+                              ),
+                           ],
+                           'beforejoin'      => [
+                              'table'           => Item_Ticket::getTable(),
+                              'joinparams'      => [
+                                 'jointype'        => 'itemtype_item',
+                                 'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                                 'beforejoin'      => [
+                                    'table'           => PluginFormcreatorFormAnswer::getTable(),
+                                    'joinparams'      => [
+                                       'jointype'          => 'itemtype_item_revert',
+                                       'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                                    ],
+                                 ],
+                              ],
+                           ],
+                        ],
+                     ]
+                  ]
+               ],
             ],
          ]
       ];
@@ -799,6 +832,149 @@ class PluginFormcreatorIssue extends CommonDBTM {
             $tab[] = $so;
          }
       }
+
+      $tab[] = [
+         'id'                 => '42',
+         'table'              => User::getTable(),
+         'field'              => 'name',
+         'name'               => __('Ticket requester', 'formcreator'),
+         'massiveaction'      => false,
+         'datatype'           => 'dropdown',
+         'forcegroupby'       => true,
+         'joinparams'         => [
+            'jointype'        => 'empty',
+            'beforejoin'      => [
+               'table'           => Ticket_User::getTable(),
+               'joinparams'      => [
+                  'jointype'        => 'child',
+                  'condition'       => [
+                     'NEWTABLE.type' => CommonITILActor::REQUESTER,
+                  ],
+                  'beforejoin'      => [
+                     'table'           => Ticket::getTable(),
+                     'joinparams'      => [
+                        'jointype'        => 'empty',
+                        'condition'       => [
+                           new \QueryExpression(
+                              '1=1'
+                           ),
+                        ],
+                        'beforejoin'      => [
+                           'table'           => Item_Ticket::getTable(),
+                           'joinparams'      => [
+                              'jointype'        => 'itemtype_item',
+                              'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                              'beforejoin'      => [
+                                 'table'           => PluginFormcreatorFormAnswer::getTable(),
+                                 'joinparams'      => [
+                                    'jointype'          => 'itemtype_item_revert',
+                                    'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                                 ],
+                              ],
+                           ],
+                        ],
+                     ],
+                  ],
+               ],
+            ],
+         ],
+      ];
+
+      $tab[] = [
+         'id'                 => '43',
+         'table'              => User::getTable(),
+         'field'              => 'name',
+         'name'               => __('Ticket observer', 'formcreator'),
+         'massiveaction'      => false,
+         'nosearch'           => true,
+         'datatype'           => 'dropdown',
+         'forcegroupby'       => true,
+         'joinparams'         => [
+            'jointype'        => 'empty',
+            'beforejoin'      => [
+               'table'           => Ticket_User::getTable(),
+               'joinparams'      => [
+                  'jointype'        => 'child',
+                  'condition'       => [
+                     'NEWTABLE.type' => CommonITILActor::OBSERVER,
+                  ],
+                  'beforejoin'      => [
+                     'table'           => Ticket::getTable(),
+                     'joinparams'      => [
+                        'jointype'        => 'empty',
+                        'condition'       => [
+                           new \QueryExpression(
+                              '1=1'
+                           ),
+                        ],
+                        'beforejoin'      => [
+                           'table'           => Item_Ticket::getTable(),
+                           'joinparams'      => [
+                              'jointype'        => 'itemtype_item',
+                              'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                              'beforejoin'      => [
+                                 'table'           => PluginFormcreatorFormAnswer::getTable(),
+                                 'joinparams'      => [
+                                    'jointype'          => 'itemtype_item_revert',
+                                    'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                                 ],
+                              ],
+                           ],
+                        ],
+                     ],
+                  ],
+               ],
+            ],
+         ],
+      ];
+
+      $tab[] = [
+         'id'                 => '44',
+         'table'              => User::getTable(),
+         'field'              => 'name',
+         'name'               => __('Ticket technician', 'formcreator'),
+         'massiveaction'      => false,
+         'nosearch'           => true,
+         'datatype'           => 'dropdown',
+         'forcegroupby'       => true,
+         'joinparams'         => [
+            'jointype'        => 'empty',
+            'beforejoin'      => [
+               'table'           => Ticket_User::getTable(),
+               'joinparams'      => [
+                  'jointype'        => 'child',
+                  'condition'       => [
+                     'NEWTABLE.type' => CommonITILActor::ASSIGN,
+                  ],
+                  'beforejoin'      => [
+                     'table'           => Ticket::getTable(),
+                     'joinparams'      => [
+                        'jointype'        => 'empty',
+                        'condition'       => [
+                           new \QueryExpression(
+                              '1=1'
+                           ),
+                        ],
+                        'beforejoin'      => [
+                           'table'           => Item_Ticket::getTable(),
+                           'joinparams'      => [
+                              'jointype'        => 'itemtype_item',
+                              'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                              'beforejoin'      => [
+                                 'table'           => PluginFormcreatorFormAnswer::getTable(),
+                                 'joinparams'      => [
+                                    'jointype'          => 'itemtype_item_revert',
+                                    'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                                 ],
+                              ],
+                           ],
+                        ],
+                     ],
+                  ],
+               ],
+            ],
+         ],
+      ];
 
       return $tab;
    }


### PR DESCRIPTION
### Changes description

Solves the following use case (was not supported)

- a user **A** fills a form
- the form generates at least 2 tickets
- one of the tickets have the user **B** in the actors 
- the user **B**, using the service catalog cannot access the generated ticket where he is an actor

Solution : 
- add search options to check the actors of the generated tickets and use them in default join / default where.
- enhance search option to access ticket validator, supporting multiple tickets.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

internal ref: 25942