### PR TITLE
fix (form): Invalid event target and debouncing

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -865,6 +865,8 @@ var plugin_formcreator = new function() {
       });
    };
 
+   this.showFieldsDebounced = _.debounce(this.showFields, 400, false);
+
    // === SECTIONS ===
 
    this.deleteSection = function (item) {
@@ -1759,15 +1761,16 @@ function pluginFormcreatorInitializeTextarea(fieldName, rand) {
    var i = 0;
    var e;
    while (e = tinymce.get(i++)) {
-      var field = $('[name="' + fieldName + '"]');
-      var form = field[0].form;
-      if (e.formElement != form) {
+      if ($(e.targetElm).prop('name') != fieldName) {
          continue;
       }
+
+      const field = $('[name="' + fieldName + '"]');
+      const form = field[0].form
       // https://stackoverflow.com/a/63342064
       e.on('input NodeChange', function(e) {
          tinyMCE.triggerSave();
-         plugin_formcreator.showFields($(form));
+         plugin_formcreator.showFieldsDebounced($(form));
       });
       return;
   }


### PR DESCRIPTION
### Changes description

Form with multiple textarea have terrible performance, resulting easily in thousands of AJAX request when editing a single field.

Two issues :

1\) Wrong event target

`input` event watcher are not assigned to the correct textarea, they all go to the first one.
So if you have 10 textarea, the first one will watch for `input` 10 times (thus triggering 10 ajax request to `showfields.php` per change) and the others will not be watched at all.

2\) No debouncing

Typing a few words into a textarea may generate close to one hundred `input` events (and thus an hundred ajax request to `showfields.php`).
We solve this with debouncing, grouping multiple events into one if they are less than 400ms apart.

### References

!25974