### PR TITLE
Translation cleanup warning

### DIFF
--- a/inc/translatable.class.php
+++ b/inc/translatable.class.php
@@ -113,7 +113,7 @@ trait PluginFormcreatorTranslatable
             continue;
          }
          $strings[$type] = array_unique($strings[$type]);
-         $strings[$type] = array_filter($strings[$type]);
+         $strings[$type] = array_filter($strings[$type], function ($value) { return $value != ''; });
       }
 
       return $strings;


### PR DESCRIPTION
### Changes description

PHP error caused by empty values filtering in translation.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Internal ref 26201