### PR TITLE
fix(composite): ignore link to non existing ticket

### DIFF
--- a/inc/composite.class.php
+++ b/inc/composite.class.php
@@ -146,6 +146,13 @@ class PluginFormcreatorComposite
                   if ($answer->isNewItem()) {
                      break;
                   }
+                  if (Ticket::isNewID($answer->fields['answer'])) {
+                     break;
+                  }
+                  $ticket = new Ticket();
+                  if (!$ticket->getFromDB($answer->fields['answer'])) {
+                     break;
+                  }
                   $this->ticket_ticket->add([
                      'link' => $row['link'],
                      'tickets_id_1' => $generatedObject->getID(),


### PR DESCRIPTION
### Changes description

When creating a link to a generated ticket from a question, when the requester does not chooses a ticket, the link may be done with a ticket having its ID=0. This makes an invalid link.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

internal ref 26267