### PR TITLE
fix: Support new core option for assets visibility

### DIFF
--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -63,6 +63,7 @@ use QueryUnion;
 use GlpiPlugin\Formcreator\Exception\ComparisonException;
 use Glpi\Application\View\TemplateRenderer;
 use QueryExpression;
+use State;
 
 class DropdownField extends PluginFormcreatorAbstractField
 {
@@ -510,8 +511,8 @@ class DropdownField extends PluginFormcreatorAbstractField
 
    public function getRenderedHtml($domain, $canEdit = true): string {
       $itemtype = $this->getSubItemtype();
+      $item = new $itemtype();
       if (!$canEdit) {
-         $item = new $itemtype();
          $value = '';
          if ($item->getFromDB($this->value)) {
             $column = 'name';
@@ -532,6 +533,9 @@ class DropdownField extends PluginFormcreatorAbstractField
       $dparams = $this->buildParams($rand);
       $dparams['display'] = false;
       $dparams['_idor_token'] = Session::getNewIDORToken($itemtype);
+      if ($item->isField('states_id')) {
+         $dparams['condition'] = State::getDisplayConditionForAssistance();
+      }
       $html .= $itemtype::dropdown($dparams);
       $html .= PHP_EOL;
       $html .= Html::scriptBlock("$(function() {

--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -533,7 +533,7 @@ class DropdownField extends PluginFormcreatorAbstractField
       $dparams = $this->buildParams($rand);
       $dparams['display'] = false;
       $dparams['_idor_token'] = Session::getNewIDORToken($itemtype);
-      if ($item->isField('states_id')) {
+      if (version_compare(GLPI_VERSION, '10.1') >= 0 && $item->isField('states_id')) {
          $dparams['condition'] = State::getDisplayConditionForAssistance();
       }
       $html .= $itemtype::dropdown($dparams);


### PR DESCRIPTION
### Changes description

Support new option added in GLPI 10.1: [13832](https://github.com/glpi-project/glpi/pull/13832)

I assume formcreator 2.14 would be for GLPI 10.1 only but I'm not 100% sure (can't remember what's been decided on that).
If that's not the case then I'll add some methodExist check to not break things with GLPI 10.0.