### PR TITLE
Encoding problem when image inserted in content

### DIFF
--- a/inc/field/textareafield.class.php
+++ b/inc/field/textareafield.class.php
@@ -210,7 +210,6 @@ class TextareaField extends TextField
          );
          $input[$key] = $this->value; // Restore the text because we don't want image converted into A + IMG tags
          // $this->value = $input[$key];
-         $this->value = Sanitizer::unsanitize($this->value);
          foreach ($input['_tag'] as $docKey => $tag) {
             $newTag = $this->uploads['dedup'][$tag];
             $regex = '/<img[^>]+' . preg_quote($tag, '/') . '[^<]+>/im';
@@ -224,7 +223,7 @@ class TextareaField extends TextField
 
    public function deserializeValue($value) {
       $this->value = ($value !== null && $value !== '')
-         ? $value
+         ? Sanitizer::unsanitize($value)
          : '';
    }
 

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/TextareaField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/TextareaField.php
@@ -155,7 +155,7 @@ class TextareaField extends CommonTestCase {
                0 => '6e48eaef-761764d0-62ed2882556d61.27118334',
             ],
          ],
-         'expected' => '&#60;p&#62;&#60;img id=\"6e48eaef-761764d0-62ed2882556d61.27118334\" src=\"blob:http://localhost:8080/76a3e35c-b083-4127-af53-679d2550834f\" data-upload_id=\"0.7577303544485556\"&#62;&#60;/p&#62;',
+         'expected' => '<p><img id="6e48eaef-761764d0-62ed2882556d61.27118334" src="blob:http://localhost:8080/76a3e35c-b083-4127-af53-679d2550834f" data-upload_id="0.7577303544485556"></p>',
       ];
    }
 
@@ -168,7 +168,7 @@ class TextareaField extends CommonTestCase {
 
       $instance->parseAnswerValues($input);
       $instance->deserializeValue($input[$key]);
-      $output = $instance->getValueForTargetText('', false);
+      $output = $instance->getValueForTargetText('', true);
       $this->string($output)->isEqualTo($expected);
    }
 

--- a/tests/3-unit/PluginFormcreatorFormAnswer.php
+++ b/tests/3-unit/PluginFormcreatorFormAnswer.php
@@ -882,4 +882,68 @@ class PluginFormcreatorFormAnswer extends CommonTestCase {
       $this->boolean($output)->isTrue();
       $this->integer($instance->getID())->isEqualTo($expected->getID());
    }
+
+   public function providerParseTags() {
+      // Test a single text
+      $question = $this->getQuestion([
+         'fieldtype' => 'textarea',
+      ]);
+      $form = PluginFormcreatorForm::getByItem($question);
+      // Text as received in prepareInputForAdd (GLPI 10.0.6)
+      $text = '&#60;p&#62; &#60;/p&#62;\r\n&#60;p&#62; &#60;/p&#62;';
+
+      $fieldKey = 'formcreator_field_' . $question->getID();
+      $formAnswer = $this->getFormAnswer([
+         'plugin_formcreator_forms_id' => $form->getID(),
+         $fieldKey => $text,
+      ]);
+
+      yield [
+         'instance' => $formAnswer,
+         'template' => '<p>##answer_' . $question->getID() . '##</p>',
+         'expected' => '&#60;p&#62;' . $text . '&#60;/p&#62;',
+      ];
+
+      // Test a text with an embeddd image
+      $question = $this->getQuestion([
+         'fieldtype' => 'textarea',
+      ]);
+      $form = PluginFormcreatorForm::getByItem($question);
+      // Text as received in prepareInputForAdd (GLPI 10.0.6)
+      $text = '&#60;p&#62;&#60;img id=\"20a8c58a-761764d0-63e0ff1245d9f4.97274571\" src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAACCAIAAAASFvFNAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAEUlEQVQImWP8v5QBApgYYAAAHsMBqH3ykQkAAAAASUVORK5CYII=\" data-upload_id=\"0.7092882231779103\"&#62;&#60;/p&#62;';
+
+      $fieldKey = 'formcreator_field_' . $question->getID();
+      $filename = '5e5e92ffd9bd91.44444444upload55555555.txt';
+      $tag = '3e29dffe-0237ea21-5e5e7034b1d1a1.33333333';
+      copy(dirname(__DIR__) . '/fixture/upload.txt', GLPI_TMP_DIR . '/' . $filename);
+      $formAnswer = $this->getFormAnswer([
+         'plugin_formcreator_forms_id' => $form->getID(),
+         $fieldKey => $text,
+         "_{$fieldKey}" => [
+            $filename,
+         ],
+         "_prefix_{$fieldKey}" => [
+            '5e5e92ffd9bd91.44444444',
+         ],
+         "_tag_{$fieldKey}" => [
+            $tag,
+         ],
+      ]);
+
+      yield [
+         'instance' => $formAnswer,
+         'template' => '<p>##answer_' . $question->getID() . '##</p>',
+         'expected' => '&#60;p&#62;' . $text . '&#60;/p&#62;',
+      ];
+   }
+
+   /**
+    * @dataProvider providerParseTags
+    */
+   public function testParseTags($instance, $template, $expected) {
+      $ticket = new PluginFormcreatorTargetTicket();
+
+      $output = $instance->parseTags($template, $ticket, true);
+      $this->string($output)->isEqualTo($expected);
+   }
 }


### PR DESCRIPTION
### Changes description

When an image is embedded in a textarea question, a ticket generated and using this question shows HTML tags.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

internal ref 26534