### PR TITLE
fix(notifications): missing lang tags

### DIFF
--- a/inc/notificationtargetformanswer.class.php
+++ b/inc/notificationtargetformanswer.class.php
@@ -70,6 +70,13 @@ class PluginFormcreatorNotificationTargetFormAnswer extends NotificationTarget
       $this->data['##formcreator.validation_comment##'] = $this->obj->fields['comment'];
       $this->data['##formcreator.validation_link##']    = $link;
       $this->data['##formcreator.request_id##']         = $this->obj->fields['id'];
+
+      $this->getTags();
+      foreach ($this->tag_descriptions[NotificationTarget::TAG_LANGUAGE] as $tag => $values) {
+         if (!isset($this->data[$tag])) {
+            $this->data[$tag] = $values['label'];
+         }
+      }
    }
 
    public function getTags() {


### PR DESCRIPTION
### Changes description

Seems like some code is missing from the `PluginFormcreatorNotificationTargetFormAnswer` class.
This code snippet is pasted in every notification class and handle the lang tags.

If this code is mandatory and always the same (I count 18 identical instances in my GLPI 10 + plugins) then perhaps it should be moved to a parent class or something.
@cedric-anne something to change in the next major ?

### References

!26805