### PR TITLE
Fix translation domains computation

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -2248,7 +2248,7 @@ PluginFormcreatorTranslatableInterface
       if ($language != $this->fields['language']) {
          $eventManagerEnabled = $TRANSLATE->isEventManagerEnabled();
          $TRANSLATE->enableEventManager();
-         $domain = PluginFormcreatorForm::getTranslationDomain($language, $formId);
+         $domain = PluginFormcreatorForm::getTranslationDomain($formId, $language);
          $TRANSLATE->getEventManager()->attach(
             Laminas\I18n\Translator\Translator::EVENT_MISSING_TRANSLATION,
             static function (Laminas\EventManager\EventInterface $event) use ($formId, $domain, $TRANSLATE) {

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -647,7 +647,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
       }
 
       echo '<ol>';
-      $domain = PluginFormcreatorForm::getTranslationDomain($_SESSION['glpilanguage'], $form->getID());
+      $domain = PluginFormcreatorForm::getTranslationDomain($form->getID(), $_SESSION['glpilanguage']);
 
       // Get fields populated with answers
       $this->loadAnswers();


### PR DESCRIPTION
### Changes description

Arguments in calls to `PluginFormcreatorForm::getTranslationDomain()` seems to be inverted at some places.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Closes #N/A