### PR TITLE
feat: Link documents to form

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -619,6 +619,7 @@ PluginFormcreatorTranslatableInterface
       $this->addStandardTab(self::class, $ong, $options);
       $this->addStandardTab(PluginFormcreatorFormAnswer::class, $ong, $options);
       $this->addStandardTab(PluginFormcreatorForm_Language::class, $ong, $options);
+      $this->addStandardTab(Document_Item::class, $ong, $options);
       $this->addStandardTab(Log::class, $ong, $options);
       return $ong;
    }

--- a/setup.php
+++ b/setup.php
@@ -130,6 +130,7 @@ function plugin_init_formcreator() {
 
    array_push($CFG_GLPI["ticket_types"], PluginFormcreatorFormAnswer::class);
    array_push($CFG_GLPI["document_types"], PluginFormcreatorFormAnswer::class);
+   array_push($CFG_GLPI["document_types"], PluginFormcreatorForm::class);
 
    $plugin = new Plugin();
    if (!$plugin->isActivated('formcreator')) {


### PR DESCRIPTION
### Changes description

Allow documents to be linked to forms.

![image](https://user-images.githubusercontent.com/42734840/221586999-ad58c751-d3c4-4d0d-9ea6-7caa3f6d86cb.png)

This is useful as some users want to add links to their documents (a documentation for example) in their forms.
The issue is that this link can't be reached if you don't have the rights to read documents.  

As GLPI allow users to see documents of items they are allowed to see (e.g. a technician seeing documents from his assigned tickets), linking one or more documents to a form allow any users that can see the form to access their download link.

### References

!26929