### PR TITLE
fix(FormAnswer): fix lost file when editing formanswer

### DIFF
--- a/inc/field/filefield.class.php
+++ b/inc/field/filefield.class.php
@@ -73,27 +73,27 @@ class FileField extends PluginFormcreatorAbstractField
    }
 
    public function getRenderedHtml($domain, $canEdit = true): string {
-      if (!$canEdit) {
-         $html = '';
-         $doc = new Document();
-         $answer = $this->uploadData;
-         if (!is_array($this->uploadData)) {
-            $answer = [$this->uploadData];
+
+      $html = '';
+      $doc = new Document();
+      $answer = $this->uploadData;
+      if (!is_array($this->uploadData)) {
+         $answer = [$this->uploadData];
+      }
+      foreach ($answer as $item) {
+         if (is_numeric($item) && $doc->getFromDB($item)) {
+            $html .= $doc->getDownloadLink($this->form_answer);
          }
-         foreach ($answer as $item) {
-            if (is_numeric($item) && $doc->getFromDB($item)) {
-               $html .= $doc->getDownloadLink($this->form_answer);
-            }
-         }
-         return $html;
       }
 
-      return Html::file([
-         'name'    => 'formcreator_field_' . $this->question->getID(),
-         'display' => false,
-         'multiple' => 'multiple',
-         'uploads' => $this->uploads,
-      ]);
+      if ($canEdit) {
+         $html .= Html::file([
+            'name'    => 'formcreator_field_' . $this->question->getID(),
+            'display' => false,
+            'multiple' => 'multiple',
+            'uploads' => $this->uploads,
+         ]);
+      }
    }
 
    public function serializeValue(PluginFormcreatorFormAnswer $formanswer): string {

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1239,9 +1239,20 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
                'plugin_formcreator_formanswers_id' => $formAnswerId,
                'plugin_formcreator_questions_id' => $questionId,
             ]);
+
+            $answer_value = $field->serializeValue($this);
+
+            //if question type file
+            //keep the old uploaded files
+            if ($field->getQuestion()->fields['fieldtype'] == 'file') {
+               $old_files = json_decode($answer->fields['answer'], true); //added by users
+               $new_files = $field->getDocumentsForTarget(); //added by approver
+               $answer_value = json_encode(array_merge($old_files, $new_files), true);
+            }
+
             $answer->update([
                'id'     => $answer->getID(),
-               'answer' => $field->serializeValue($this),
+               'answer' => $answer_value,
             ], 0);
             foreach ($field->getDocumentsForTarget() as $documentId) {
                $docItem = new Document_Item();


### PR DESCRIPTION
### Changes description

During the approval phase of the form
if the approver edits the answers the file(s) uploaded by the requester are not attached to the tickets (only to ```Formanswer```)

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A