### PR TITLE
Rebuild uploads for answer edition

### DIFF
--- a/inc/field/filefield.class.php
+++ b/inc/field/filefield.class.php
@@ -88,6 +88,24 @@ class FileField extends PluginFormcreatorAbstractField
          return $html;
       }
 
+      if (is_array($this->uploadData) && count($this->uploadData) > 0) {
+         $html = '';
+         $doc = new Document();
+         foreach ($this->uploadData as $item) {
+            if (is_numeric($item) && $doc->getFromDB($item)) {
+               $prefix = uniqid('', true);
+               $filename = $prefix . $doc->fields['filename'];
+               if (!copy(GLPI_DOC_DIR . '/' . $doc->fields['filepath'], GLPI_TMP_DIR . '/' . $filename)) {
+                  continue;
+               }
+               $key = 'formcreator_field_' . $this->getQuestion()->getID();
+               $this->uploads['_' . $key][] = $filename;
+               $this->uploads['_prefix_' . $key][] = $prefix;
+               $this->uploads['_tag_' . $key][] = $doc->fields['tag'];
+            }
+         }
+      }
+
       return Html::file([
          'name'    => 'formcreator_field_' . $this->question->getID(),
          'display' => false,


### PR DESCRIPTION
### Changes description

When a form validator edits answers when validating, a required file filed prevents the validator to save his changes. Also, the file uploaded by the requester is not restored.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

internal ref 27378