### PR TITLE
fix(DropdownField): fix array key value format

### DIFF
--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -854,7 +854,7 @@ class DropdownField extends PluginFormcreatorAbstractField
       switch ($restrictionPolicy) {
          case self::ENTITY_RESTRICT_FORM:
             $form = PluginFormcreatorForm::getByItem($this->getQuestion());
-            $formEntities = [$form->fields['entities_id']];
+            $formEntities = [$form->fields['entities_id'] => $form->fields['entities_id']];
             if ($form->fields['is_recursive']) {
                $formEntities = $formEntities + (new DBUtils())->getSonsof(Entity::getTable(), $form->fields['entities_id']);
             }
@@ -863,7 +863,7 @@ class DropdownField extends PluginFormcreatorAbstractField
 
          case self::ENTITY_RESTRICT_BOTH:
             $form = PluginFormcreatorForm::getByItem($this->getQuestion());
-            $formEntities = [$form->fields['entities_id']];
+            $formEntities = [$form->fields['entities_id'] => $form->fields['entities_id']];
             if ($form->fields['is_recursive']) {
                $formEntities = $formEntities + (new DBUtils())->getSonsof(Entity::getTable(), $form->fields['entities_id']);
             }


### PR DESCRIPTION
### Changes description


While trying to solve a problem of visibility of GLPI objects in a drop-down list
I realized that ```array_intersect_key``` returned an empty ```array```
because of common entity array (generated from ```form```) that is poorly formed (bad ```key```)

Generated array from ```form```
```php
Array
  (
      [0] => 3
  )
```

Generated array from ```$_SESSION['glpiactiveentities']```

```php
Array
  (
      [3] => 3
      [7] => 7
      [5] => 5
      [2] => 2
      [9] => 9
      [10] => 10
      [6] => 6
      [8] => 8
      [11] => 11
  )
```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A