### PR TITLE
fix(FormAnswer): redirect to FormAnswer or to list if needed

### DIFF
--- a/front/formanswer.form.php
+++ b/front/formanswer.form.php
@@ -48,7 +48,7 @@ if (isset($_POST['update'])) {
 } else if (isset($_POST['refuse_formanswer']) || isset($_POST['accept_formanswer'])) {
    if ($formanswer->update($_POST)) {
       $formanswer->redirectToList();
-   }else{
+   } else {
       //redirect to formanswer if update failed (ex : missing mandatory field)
       Html::back();
    }

--- a/front/formanswer.form.php
+++ b/front/formanswer.form.php
@@ -45,14 +45,13 @@ if (isset($_POST['update'])) {
    $formanswer->update($_POST);
    Html::back();
 
-} else if (isset($_POST['refuse_formanswer'])) {
-   $formanswer->update($_POST);
-   $formanswer->redirectToList();
-
-} else if (isset($_POST['accept_formanswer'])) {
-   $formanswer->update($_POST);
-   $formanswer->redirectToList();
-
+} else if (isset($_POST['refuse_formanswer']) || isset($_POST['accept_formanswer'])) {
+   if ($formanswer->update($_POST)) {
+      $formanswer->redirectToList();
+   }else{
+      //redirect to formanswer if update failed (ex : missing mandatory field)
+      Html::back();
+   }
 } else if (isset($_POST['save_formanswer'])) {
    if (!$formanswer->update($_POST)) {
       Html::back();


### PR DESCRIPTION
### Changes description

When an approver try to accept or reject ```formanswer```, 

if for any reason the action failed, it is redirected to the ```formanswer``` list instead of the ```formanswer```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A