### PR TITLE
Conditions don't work when not sanitized

### DIFF
--- a/install/upgrade_to_2.13.6.php
+++ b/install/upgrade_to_2.13.6.php
@@ -46,6 +46,7 @@ class PluginFormcreatorUpgradeTo2_13_6 {
    public function upgrade(Migration $migration) {
       $this->migration = $migration;
       $this->migrateToRichText();
+      $this->sanitizeConditions();
    }
 
    public function migrateToRichText() {
@@ -80,6 +81,26 @@ class PluginFormcreatorUpgradeTo2_13_6 {
             }
             $DB->update($table, $row, ['id' => $row['id']]);
          }
+      }
+   }
+
+   /**
+    * Conditions written in Formcreator < 2.13.0 are not sanitized.
+    * With versions >= 2.13.0, comparisons require sanitization
+    *
+    * @return void
+    */
+   protected function sanitizeConditions() {
+      global $DB;
+
+      $table = 'glpi_plugin_formcreator_conditions';
+      $request = $DB->request([
+         'SELECT' => ['id', 'show_value'],
+         'FROM' => $table,
+      ]);
+      foreach ($request as $row) {
+         $row['show_value'] = Sanitizer::sanitize($row['show_value'], true);
+         $DB->update($table, $row, ['id' => $row['id']]);
       }
    }
 }


### PR DESCRIPTION
may occur whern a condition contains characters like &, > and created in Formcreator < 2.13.0

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

internal ref 27230