### PR TITLE
Bad question id in section condition

### DIFF
--- a/inc/condition.class.php
+++ b/inc/condition.class.php
@@ -153,14 +153,8 @@ class PluginFormcreatorCondition extends CommonDBChild implements PluginFormcrea
       // set ID for linked objects
       $linked = $linker->getObject($input['plugin_formcreator_questions_id'], PluginFormcreatorQuestion::class);
       if ($linked === false) {
-         $linked = new PluginFormcreatorQuestion();
-         $linked->getFromDBByCrit([
-            $idKey => $input['plugin_formcreator_questions_id']
-         ]);
-         if ($linked->isNewItem()) {
-            $linker->postpone($input[$idKey], $item->getType(), $input, $containerId);
-            return false;
-         }
+         $linker->postpone($input[$idKey], $item->getType(), $input, $containerId);
+         return false;
       }
       /** @var CommonDBTM $linked */
       $input['plugin_formcreator_questions_id'] = $linked->getID();


### PR DESCRIPTION
### Changes description

When a form is being duplicated, and a section condition refers to a question not duplicated yet, the plugins picks the ID of the question in the source form instead of the duplicated form. The new form will break when evaluating visibility

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

internal ref 28061