### PR TITLE
fix: resize dashboard to match GLPI's core

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -871,7 +871,7 @@ JAVASCRIPT;
 
       if (PluginFormcreatorEntityconfig::getUsedConfig('is_dashboard_visible', Session::getActiveEntity()) == PluginFormcreatorEntityconfig::CONFIG_DASHBOARD_VISIBLE) {
          if (version_compare(GLPI_VERSION, '10.0.3') > 0) {
-            $dashboard = new Glpi\Dashboard\Grid('plugin_formcreator_issue_counters', 33, 1, 'mini_core');
+            $dashboard = new Glpi\Dashboard\Grid('plugin_formcreator_issue_counters', 33, 2, 'mini_core');
          } else {
             $dashboard = new Glpi\Dashboard\Grid('plugin_formcreator_issue_counters', 33, 0, 'mini_core');
          }

--- a/install/upgrade_to_2.13.7.php
+++ b/install/upgrade_to_2.13.7.php
@@ -29,6 +29,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Dashboard\Dashboard;
+use Glpi\Dashboard\Item;
 use Glpi\Toolbox\Sanitizer;
 
 class PluginFormcreatorUpgradeTo2_13_7 {
@@ -45,6 +47,7 @@ class PluginFormcreatorUpgradeTo2_13_7 {
    public function upgrade(Migration $migration) {
       $this->migration = $migration;
       $this->fixEncodingInQuestions();
+      $this->resizeWidgets();
    }
 
    /**
@@ -81,6 +84,40 @@ class PluginFormcreatorUpgradeTo2_13_7 {
             ['values' => $values],
             ['id' => $row['id']]
          );
+      }
+   }
+
+   /**
+    * Resize widgets of the `plugin_formcreator_issue_counters` dashboard to match
+    * the mini_tickets core dashboard style
+    *
+    * @return void
+    */
+   public function resizeWidgets() {
+      // Get container
+      $dashboard = new Dashboard();
+      $found = $dashboard->getFromDB("plugin_formcreator_issue_counters");
+
+      if(!$found) {
+         // Unable to fetch dashboard
+         return;
+      };
+
+      $di = new Item();
+      $cards = $di->find(['dashboards_dashboards_id' => $dashboard->fields['id']]);
+      $x = 0;
+
+      foreach ($cards as $card) {
+         $di = new Item();
+         $di->update([
+            'id'     => $card['id'],
+            'width'  => 4,
+            'height' => 2,
+            'x'      => $x,
+            'y'      => 0,
+         ]);
+
+         $x +=4;
       }
    }
 }

--- a/install/upgrade_to_2.13.7.php
+++ b/install/upgrade_to_2.13.7.php
@@ -98,7 +98,7 @@ class PluginFormcreatorUpgradeTo2_13_7 {
       $dashboard = new Dashboard();
       $found = $dashboard->getFromDB("plugin_formcreator_issue_counters");
 
-      if(!$found) {
+      if (!$found) {
          // Unable to fetch dashboard
          return;
       };


### PR DESCRIPTION
### Changes description

Resize widgets of the `plugin_formcreator_issue_counters` dashboard to match this sizes used by GLPI's core.

Before:

![image](https://github.com/pluginsGLPI/formcreator/assets/42734840/0f1b2a20-89e7-4c09-aac2-e87a73a550f6)

After;

![image](https://github.com/pluginsGLPI/formcreator/assets/42734840/c1c908c4-5191-40a8-98a2-8726b3cda8c2)

### References

!28167