### PR TITLE
Php warnings anonymization

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -493,13 +493,25 @@ class PluginFormcreatorIssue extends CommonDBTM {
       $hide_technician = false;
       $hide_technician_group = false;
       if (!Session::isCron()) {
-         $user = new User();
-         if (empty($user->getAnonymizedName(Session::getActiveEntity()))) {
-            $hide_technician = true;
-         }
-         $group = new Group();
-         if (empty($group->getAnonymizedName(Session::getActiveEntity()))) {
-            $hide_technician_group = true;
+         $anonymisation = Entity::getUsedConfig(
+            'anonymize_support_agents',
+            Session::getActiveEntity()
+         );
+         switch ($anonymisation) {
+            case Entity::ANONYMIZE_USE_GENERIC:
+            case Entity::ANONYMIZE_USE_NICKNAME:
+               $hide_technician       = true;
+               $hide_technician_group = true;
+               break;
+
+            case Entity::ANONYMIZE_USE_GENERIC_USER:
+            case Entity::ANONYMIZE_USE_NICKNAME_USER:
+               $hide_technician       = true;
+               break;
+
+            case Entity::ANONYMIZE_USE_GENERIC_GROUP:
+               $hide_technician_group = true;
+               break;
          }
       }
 


### PR DESCRIPTION
### Changes description

We need to get feedback from bug reporter.

When anonymisation is enabled with user's nickname, getting search options of issues breaks. Service catalog counters are broken, among others.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Internal ref 28425