### PR TITLE
fix(TargetChange: use richText instead of plaintext

### DIFF
--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -664,11 +664,11 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
          $data[$changeField] = $this->prepareTemplate(
             Sanitizer::unsanitize(__($this->fields[$changeField], $domain)) ?? '',
             $formanswer,
-            $changeField == 'content' // only content supports rich text
+            true // all *content supports rich text
          );
          $data[$changeField] = $data[$changeField] ?? '';
 
-         $data[$changeField] = $formanswer->parseTags($data[$changeField], $this, $changeField == 'content');
+         $data[$changeField] = $formanswer->parseTags($data[$changeField], $this, true); // all *content supports rich text
       }
 
       $data['_users_id_recipient'] = $formanswer->fields['requester_id'];


### PR DESCRIPTION
### Changes description

Now ```Change``` fields are compatible with ```RichText```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

!28624