### PR TITLE
Fix search options

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -624,7 +624,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
                   'table'                => PluginFormcreatorFormAnswer::getTable(),
                   'joinparams'           => [
                      'jointype'          => 'itemtype_item_revert',
-                     'specific_itemtype'  => PluginFormcreatorFormAnswer::class,
+                     'specific_itemtype'  => Ticket::class,
                   ]
                ],
             ],


### PR DESCRIPTION
This condition break search options for forms with at least one target.
On the other hand, I'm not sure how this fix will impact forms without targets, can you confirm that it looks good to you @btry ?

!28799