### PR TITLE
Merge 2 search options

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
 }
 
 use Glpi\RichText\RichText;
+
 class PluginFormcreatorIssue extends CommonDBTM {
    static $rightname = 'ticket';
 
@@ -684,7 +685,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
                         'joinparams'      => [
                            'jointype'        => 'empty',
                            'condition'       => [
-                              new \QueryExpression(
+                              new QueryExpression(
                                  '1=1'
                               ),
                            ],
@@ -721,34 +722,36 @@ class PluginFormcreatorIssue extends CommonDBTM {
       }
       $tab[] = $newtab;
 
-      $newtab = [
-         'id'                 => '14',
-         'table'              => User::getTable(),
-         'field'              => 'name',
-         'name'               => __('Technician'),
-         'datatype'           => 'dropdown',
-         'massiveaction'      => false,
-         'nodisplay'          => $hide_technician,
-         'nosearch'           => $hide_technician,
-         'right'              => 'interface',
-         'joinparams'         => [
-            'beforejoin'         => [
-               'table'              => Ticket_User::getTable(),
-               'joinparams'         => [
-                  'condition'          => "AND NEWTABLE.`type` = '2'", // Assign
-                  'jointype'           => 'child',
-                  'beforejoin'         => [
-                     'table'              => Ticket::getTable(),
-                     'joinparams'         => [
-                        'jointype'           => 'itemtype_item_revert',
-                        'specific_itemtype'  => Ticket::class,
-                     ],
-                  ]
-               ]
-            ]
-         ]
-      ];
-      $tab[] = $newtab;
+      // $newtab = [
+      //    'id'                 => '14',
+      //    'table'              => User::getTable(),
+      //    'field'              => 'name',
+      //    'name'               => __('Technician'),
+      //    'datatype'           => 'dropdown',
+      //    'massiveaction'      => false,
+      //    'nodisplay'          => $hide_technician,
+      //    'nosearch'           => $hide_technician,
+      //    'right'              => 'interface',
+      //    'joinparams'         => [
+      //       'beforejoin'         => [
+      //          'table'              => Ticket_User::getTable(),
+      //          'joinparams'         => [
+      //             'condition'          => [
+      //                'NEWTABLE.type' => CommonITILActor::ASSIGN, // Assign
+      //             ],
+      //             'jointype'           => 'child',
+      //             'beforejoin'         => [
+      //                'table'              => Ticket::getTable(),
+      //                'joinparams'         => [
+      //                   'jointype'           => 'itemtype_item_revert',
+      //                   'specific_itemtype'  => Ticket::class,
+      //                ],
+      //             ]
+      //          ]
+      //       ]
+      //    ]
+      // ];
+      // $tab[] = $newtab;
 
       if (!Session::isCron() // no filter for cron
           && Session::getCurrentInterface() != 'helpdesk') {
@@ -920,7 +923,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
                      'joinparams'      => [
                         'jointype'        => 'empty',
                         'condition'       => [
-                           new \QueryExpression(
+                           new QueryExpression(
                               '1=1'
                            ),
                         ],
@@ -951,37 +954,57 @@ class PluginFormcreatorIssue extends CommonDBTM {
          'field'              => 'name',
          'name'               => __('Ticket technician', 'formcreator'),
          'massiveaction'      => false,
-         'nosearch'           => true,
+         'nodisplay'          => $hide_technician,
+         'nosearch'           => $hide_technician,
          'datatype'           => 'dropdown',
          'forcegroupby'       => true,
          'joinparams'         => [
-            'jointype'        => 'empty',
+            // 'jointype'        => 'empty',
             'beforejoin'      => [
                'table'           => Ticket_User::getTable(),
                'joinparams'      => [
                   'jointype'        => 'child',
                   'condition'       => [
-                     'NEWTABLE.type' => CommonITILActor::ASSIGN,
+                     // glpi_tickets_a89eed976546dbc70964a86fe8724e95 matches the table in the 1st item in before join below
+                     new QueryExpression(
+                        'NEWTABLE.type = ' . CommonITILActor::ASSIGN .
+                        ' OR ' . '`glpi_tickets_a89eed976546dbc70964a86fe8724e95`.`id` = `NEWTABLE`.`tickets_id`' .
+                        'AND NEWTABLE.type = ' . CommonITILActor::ASSIGN
+                     ),
                   ],
                   'beforejoin'      => [
-                     'table'           => Ticket::getTable(),
-                     'joinparams'      => [
-                        'jointype'        => 'empty',
-                        'condition'       => [
-                           new \QueryExpression(
-                              '1=1'
-                           ),
+                     [
+                        'table'           => Ticket::getTable(),
+                        'joinparams'      => [
+                           'jointype'        => 'itemtype_item_revert',
+                           'specific_itemtype'  => Ticket::class,
+                           'condition'       => [
+                              new QueryExpression(
+                                 '2=2'
+                              ),
+                           ],
                         ],
-                        'beforejoin'      => [
-                           'table'           => Item_Ticket::getTable(),
-                           'joinparams'      => [
-                              'jointype'        => 'itemtype_item',
-                              'specific_itemtype' => PluginFormcreatorFormAnswer::class,
-                              'beforejoin'      => [
-                                 'table'           => PluginFormcreatorFormAnswer::getTable(),
-                                 'joinparams'      => [
-                                    'jointype'          => 'itemtype_item_revert',
-                                    'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                     ],
+                     [
+                        'table'           => Ticket::getTable(),
+                        'joinparams'      => [
+                           'jointype'        => 'empty',
+                           'condition'       => [
+                              new QueryExpression(
+                                 '3=3'
+                              ),
+                           ],
+                           'beforejoin'      => [
+                              'table'           => Item_Ticket::getTable(),
+                              'joinparams'      => [
+                                 'jointype'        => 'itemtype_item',
+                                 'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                                 'beforejoin'      => [
+                                    'table'           => PluginFormcreatorFormAnswer::getTable(),
+                                    'joinparams'      => [
+                                       'jointype'          => 'itemtype_item_revert',
+                                       'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                                    ],
                                  ],
                               ],
                            ],

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -182,7 +182,7 @@ class PluginFormcreatorIssue extends CommonDBTM {
                   'DISTINCT' => true,
                   'FROM'  => $ticketUserTable,
                   'WHERE' => [
-                     'type' => CommonITILActor::REQUESTER,
+                  'type' => CommonITILActor::REQUESTER,
                   ],
                   'GROUPBY' => 'tickets_id',
                   'ORDER' => ['id ASC']
@@ -661,54 +661,6 @@ class PluginFormcreatorIssue extends CommonDBTM {
          ],
          'forcegroupby'       => true,
          'massiveaction'      => false,
-         'joinparams'         => [
-            'beforejoin'         => [
-               [
-                  'table'              => TicketValidation::getTable(),
-                  'joinparams'         => [
-                     'jointype'           => 'child',
-                     'beforejoin'         => [
-                        'table'              => Ticket::getTable(),
-                        'joinparams'         => [
-                           'jointype'        => 'itemtype_item_revert',
-                           'specific_itemtype'  => Ticket::class,
-                        ]
-                     ]
-                  ]
-               ],
-               [
-                  'table'              => TicketValidation::getTable(),
-                  'joinparams'         => [
-                     'jointype'           => 'child',
-                     'beforejoin'         => [
-                        'table'              => Ticket::getTable(),
-                        'joinparams'      => [
-                           'jointype'        => 'empty',
-                           'condition'       => [
-                              new QueryExpression(
-                                 '1=1'
-                              ),
-                           ],
-                           'beforejoin'      => [
-                              'table'           => Item_Ticket::getTable(),
-                              'joinparams'      => [
-                                 'jointype'        => 'itemtype_item',
-                                 'specific_itemtype' => PluginFormcreatorFormAnswer::class,
-                                 'beforejoin'      => [
-                                    'table'           => PluginFormcreatorFormAnswer::getTable(),
-                                    'joinparams'      => [
-                                       'jointype'          => 'itemtype_item_revert',
-                                       'specific_itemtype' => PluginFormcreatorFormAnswer::class,
-                                    ],
-                                 ],
-                              ],
-                           ],
-                        ],
-                     ]
-                  ]
-               ],
-            ],
-         ]
       ];
       if (version_compare(GLPI_VERSION, '10.1') >= 0) {
          $newtab['linkfield'] = 'items_id_target';
@@ -965,52 +917,47 @@ class PluginFormcreatorIssue extends CommonDBTM {
                'joinparams'      => [
                   'jointype'        => 'child',
                   'condition'       => [
-                     // glpi_tickets_a89eed976546dbc70964a86fe8724e95 matches the table in the 1st item in before join below
-                     new QueryExpression(
-                        'NEWTABLE.type = ' . CommonITILActor::ASSIGN .
-                        ' OR ' . '`glpi_tickets_a89eed976546dbc70964a86fe8724e95`.`id` = `NEWTABLE`.`tickets_id`' .
-                        'AND NEWTABLE.type = ' . CommonITILActor::ASSIGN
-                     ),
+                     'NEWTABLE.type = ' . CommonITILActor::ASSIGN
                   ],
-                  'beforejoin'      => [
-                     [
-                        'table'           => Ticket::getTable(),
-                        'joinparams'      => [
-                           'jointype'        => 'itemtype_item_revert',
-                           'specific_itemtype'  => Ticket::class,
-                           'condition'       => [
-                              new QueryExpression(
-                                 '2=2'
-                              ),
-                           ],
-                        ],
-                     ],
-                     [
-                        'table'           => Ticket::getTable(),
-                        'joinparams'      => [
-                           'jointype'        => 'empty',
-                           'condition'       => [
-                              new QueryExpression(
-                                 '3=3'
-                              ),
-                           ],
-                           'beforejoin'      => [
-                              'table'           => Item_Ticket::getTable(),
-                              'joinparams'      => [
-                                 'jointype'        => 'itemtype_item',
-                                 'specific_itemtype' => PluginFormcreatorFormAnswer::class,
-                                 'beforejoin'      => [
-                                    'table'           => PluginFormcreatorFormAnswer::getTable(),
-                                    'joinparams'      => [
-                                       'jointype'          => 'itemtype_item_revert',
-                                       'specific_itemtype' => PluginFormcreatorFormAnswer::class,
-                                    ],
-                                 ],
-                              ],
-                           ],
-                        ],
-                     ],
-                  ],
+                  // 'beforejoin'      => [
+                  //    [
+                  //       'table'           => Ticket::getTable(),
+                  //       'joinparams'      => [
+                  //          'jointype'        => 'itemtype_item_revert',
+                  //          'specific_itemtype'  => Ticket::class,
+                  //          'condition'       => [
+                  //             new QueryExpression(
+                  //                '2=2'
+                  //             ),
+                  //          ],
+                  //       ],
+                  //    ],
+                  //    [
+                  //       'table'           => Ticket::getTable(),
+                  //       'joinparams'      => [
+                  //          'jointype'        => 'empty',
+                  //          'condition'       => [
+                  //             new QueryExpression(
+                  //                '3=3'
+                  //             ),
+                  //          ],
+                  //          'beforejoin'      => [
+                  //             'table'           => Item_Ticket::getTable(),
+                  //             'joinparams'      => [
+                  //                'jointype'        => 'itemtype_item',
+                  //                'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                  //                'beforejoin'      => [
+                  //                   'table'           => PluginFormcreatorFormAnswer::getTable(),
+                  //                   'joinparams'      => [
+                  //                      'jointype'          => 'itemtype_item_revert',
+                  //                      'specific_itemtype' => PluginFormcreatorFormAnswer::class,
+                  //                   ],
+                  //                ],
+                  //             ],
+                  //          ],
+                  //       ],
+                  //    ],
+                  // ],
                ],
             ],
          ],


### PR DESCRIPTION
### Changes description

Search options 14 and 44 both provide the same information, but handle 2 different cases
- single ticket for an issue
- multiple tickets for an issue

The solution is hacky, must be improved if possible to remove the hardcoded table with MD5 hash from complex join (see Search.php in GLPI)

Alternative to #3327 

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Internal ref 28799