### PR TITLE
fix(tag): tag was always deleted

### DIFF
--- a/inc/targetchange.class.php
+++ b/inc/targetchange.class.php
@@ -712,8 +712,6 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
          return null;
       }
 
-      $this->saveTags($formanswer, $changeID);
-
       // Add link between Change and FormAnswer
       $itemlink = $this->getItem_Item();
       $itemlink->add([
@@ -721,6 +719,8 @@ class PluginFormcreatorTargetChange extends PluginFormcreatorAbstractItilTarget
          'items_id'     => $formanswer->fields['id'],
          'changes_id'  => $changeID,
       ]);
+
+      $this->saveTags($formanswer, $changeID);
 
       return $change;
    }

--- a/inc/targetproblem.class.php
+++ b/inc/targetproblem.class.php
@@ -232,8 +232,6 @@ class PluginFormcreatorTargetProblem extends PluginFormcreatorAbstractItilTarget
          return null;
       }
 
-      $this->saveTags($formanswer, $problemID);
-
       // Add link between Problem and FormAnswer
       $itemlink = $this->getItem_Item();
       $itemlink->add([
@@ -241,6 +239,8 @@ class PluginFormcreatorTargetProblem extends PluginFormcreatorAbstractItilTarget
          'items_id'     => $formanswer->fields['id'],
          'problems_id'  => $problemID,
       ]);
+
+      $this->saveTags($formanswer, $problemID);
 
       return $problem;
    }

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -922,8 +922,6 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
          }
       }
 
-      $this->saveTags($formanswer, $ticketID);
-
       // Add link between Ticket and FormAnswer
       $itemlink = $this->getItem_Item();
       $itemlink->add([
@@ -931,6 +929,8 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
          'items_id'   => $formanswer->fields['id'],
          'tickets_id' => $ticketID,
       ]);
+
+      $this->saveTags($formanswer, $ticketID);
 
       // Attach validation message as first ticket followup if validation is required and
       // if is set in ticket target configuration


### PR DESCRIPTION
### Changes description

When a ticket with a TAG was created, it was added and deleted immediately. As can be seen in the ticket logs:

![image](https://github.com/pluginsGLPI/formcreator/assets/8530352/ddb32286-4263-43ab-aa10-0ca8b747b485)

By simply moving the function, it is no longer deleted:

![image](https://github.com/pluginsGLPI/formcreator/assets/8530352/94e6a4e1-fdd1-409b-bbdc-c9fd32a7a824)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

!29196

Closes #N/A