### PR TITLE
Fix properties translations

### DIFF
--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -63,6 +63,8 @@ use QuerySubQuery;
 use QueryUnion;
 use GlpiPlugin\Formcreator\Exception\ComparisonException;
 use Glpi\Application\View\TemplateRenderer;
+use Plugin;
+
 class DropdownField extends PluginFormcreatorAbstractField
 {
    const ENTITY_RESTRICT_USER = 1;
@@ -713,6 +715,9 @@ class DropdownField extends PluginFormcreatorAbstractField
       // We need english locale to search searchOptions by name
       $oldLocale = $TRANSLATE->getLocale();
       $TRANSLATE->setLocale("en_GB");
+      if ($plug = isPluginItemType($itemtype)) {
+         Plugin::loadLang(strtolower($plug['plugin']), "en_GB");
+      }
 
       $item = new $itemtype;
       $item->getFromDB($answer);
@@ -774,6 +779,10 @@ class DropdownField extends PluginFormcreatorAbstractField
       }
       // Put the old locales on succes or if an expection was thrown
       $TRANSLATE->setLocale($oldLocale);
+      if ($plug = isPluginItemType($itemtype)) {
+         Plugin::loadLang(strtolower($plug['plugin']), $oldLocale);
+      }
+
       return $content;
    }
 


### PR DESCRIPTION
### Changes description


```tag``` like ```##answer_1.Serial_number##``` (to extract object properties)

no longer works when related object is come from plugin (ie: ```genericobject```)

```$TRANSLATE->setLocale("en_GB");``` is not enought.

We need to load language for plugin too

```
Plugin::loadLang(strtolower($plug['plugin']), "en_GB");
```

otherwise, the list of search options for objects from plugins will be in the language of the logged-in user.



### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A