### PR TITLE
form category translation

### DIFF
--- a/inc/category.class.php
+++ b/inc/category.class.php
@@ -130,9 +130,7 @@ class PluginFormcreatorCategory extends CommonTreeDropdown
       ]);
       $request = [
          'SELECT' => [
-            'id',
-            'name',
-            'comment',
+            self::getTableField('id'),
             "$categoryFk as parent",
             'level',
             new QueryExpression(
@@ -140,8 +138,43 @@ class PluginFormcreatorCategory extends CommonTreeDropdown
             ),
          ],
          'FROM' => $cat_table,
+         'LEFT JOIN' => [],
          'ORDER' => ["level DESC", "name DESC"],
       ];
+      $translation_table = DropdownTranslation::getTable();
+      if (Session::haveTranslations(self::getType(), 'name')) {
+         $request['LEFT JOIN']["$translation_table as namet"] = [
+            'FKEY' => [
+               $cat_table => 'id',
+               'namet' => 'items_id',
+               ['AND' => [
+                  'namet.language' => $_SESSION['glpilanguage'],
+                  'namet.itemtype' => self::getType(),
+                  'namet.field' => 'name',
+               ]],
+            ],
+         ];
+         $request['SELECT'][] = 'namet.value as name';
+      } else {
+         $request['SELECT'][] = 'name';
+         $request['SELECT'][] = 'comment';
+      }
+      if (Session::haveTranslations(self::getType(), 'comment')) {
+         $request['LEFT JOIN']["$translation_table as commentt"] = [
+            'FKEY' => [
+               $cat_table => 'id',
+               'commentt' => 'items_id',
+               ['AND' => [
+                  'namet.language' => $_SESSION['glpilanguage'],
+                  'namet.itemtype' => self::getType(),
+                  'namet.field' => 'comment',
+               ]],
+            ],
+         ];
+         $request['SELECT'][] = 'commentt.value as comment';
+      } else {
+         $request['SELECT'][] = 'comment';
+      }
       $result = $DB->request($request);
 
       $categories = [];


### PR DESCRIPTION
### Changes description

GLPI provides translation feature for dropdowns, but Formcreator ignores translations when showing categories in assistance pages.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

internal ref: 29548