### PR TITLE
feat(DropdownField): Load translation for plugin too

### DIFF
--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -715,6 +715,7 @@ class DropdownField extends PluginFormcreatorAbstractField
       // We need english locale to search searchOptions by name
       $oldLocale = $TRANSLATE->getLocale();
       $TRANSLATE->setLocale("en_GB");
+      $_SESSION['glpilanguage'] = "en_GB";
       if ($plug = isPluginItemType($itemtype)) {
          Plugin::loadLang(strtolower($plug['plugin']), "en_GB");
       }
@@ -736,6 +737,7 @@ class DropdownField extends PluginFormcreatorAbstractField
          if (count($searchOption) == 0) {
             trigger_error("No search option found for $property", E_USER_WARNING);
             $TRANSLATE->setLocale($oldLocale);
+            $_SESSION['glpilanguage'] = $oldLocale;
             return $content;
          }
 
@@ -779,6 +781,7 @@ class DropdownField extends PluginFormcreatorAbstractField
       }
       // Put the old locales on succes or if an expection was thrown
       $TRANSLATE->setLocale($oldLocale);
+      $_SESSION['glpilanguage'] = $oldLocale;
       if ($plug = isPluginItemType($itemtype)) {
          Plugin::loadLang(strtolower($plug['plugin']), $oldLocale);
       }


### PR DESCRIPTION
### Changes description
To follow https://github.com/pluginsGLPI/formcreator/pull/3367

```$_SESSION['glpilanguage']``` need to be set too.

Some plugin can check this key to load desired langage.

See ```genericobject``` for example

```php
function plugin_genericobject_includeCommonFields($force = false) {
   global $GO_FIELDS, $LANG; // Permit missing global declaration in user files

   $includes = [
       sprintf('%s/fields/field.constant.php', GENERICOBJECT_DIR), // Default common fields constants
   ];

   // User locales for common fields
   if (
      isset($_SESSION['glpilanguage'])
      && file_exists($locale_file = sprintf('%s/fields.%s.php', GENERICOBJECT_LOCALES_PATH, $_SESSION['glpilanguage']))
   ) {
      $includes[] = $locale_file;
   } elseif (file_exists($locale_file = sprintf('%s/fields.%s.php', GENERICOBJECT_LOCALES_PATH, 'en_GB'))) {
      $includes[] = $locale_file;
   }

   // User common fields constants
   if (file_exists($fields_file = sprintf('%s/field.constant.php', GENERICOBJECT_FIELDS_PATH))) {
      $includes[] = $fields_file;
   }

   foreach ($includes as $include) {
      if (!$force) {
         include_once($include);
      } else {
         include($include);
      }
   }
}
```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Internal ref 29394

Closes #N/A