### PR TITLE
Itil category from template shall not take precedence

### DIFF
--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -2284,8 +2284,6 @@ SCRIPT;
       $targetTemplateFk = $targetItemtype::getForeignKeyField();
 
       $data = $targetItemtype::getDefaultValues();
-      // Determine category early, because it is used to determine the template
-      $data = $this->setTargetCategory($data, $formanswer);
 
       $this->fields[$targetTemplateFk] = $this->getTargetTemplate($data);
 
@@ -2326,6 +2324,8 @@ SCRIPT;
       }
 
       $data = array_merge($data, $predefined_fields);
+
+      $data = $this->setTargetCategory($data, $formanswer);
 
       if (($data['requesttypes_id'] ?? 0) == 0) {
          unset($data['requesttypes_id']);

--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -720,6 +720,7 @@ class DropdownField extends PluginFormcreatorAbstractField
          Plugin::loadLang(strtolower($plug['plugin']), "en_GB");
       }
 
+      /** @var CommonDBTM $item  */
       $item = new $itemtype;
       $item->getFromDB($answer);
 


### PR DESCRIPTION
When a target ticket has a template which defines an ITIL category, this setting must not take precedence over a ITIL category set from specific value or question.

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

internal ref 29707