### PR TITLE
fix(form): better theme compatibility, UI enhancement

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -105,7 +105,7 @@
 
       > .plugin_formcreator_section {
          line-height: 32px;
-         background: #CCC;
+         background-color: var(--table-head-bg);
          padding-bottom: 1px;
          display: flex;
          flex-wrap: wrap;
@@ -118,6 +118,7 @@
             text-overflow: ellipsis;
             flex: 1;
             margin: 5px 0 0 5px;
+            color: inherit;
          }
       }
    }
@@ -149,9 +150,13 @@
       padding-left: 16px;
       padding-right: 10px;
       margin: 0 2px;
-      background: #F0F0F0;
+      background-color: var(--light-mix);
       display: flex;
       align-items: center;
+
+      > i {
+         min-width: 14px;
+      }
    }
 
    .grid-stack-item .grid-stack-item-content a[data-field=name] {
@@ -175,10 +180,14 @@
    }
 
    .plugin_formcreator_question {
-      background: #F0F0F0;
+      background-color: var(--tabs-active-bg);
       margin: 5px 2px;
       padding-left: 15px;
       flex: 1;
+
+      a {
+         color: inherit;
+      }
    }
 
    /* actions on sections or questions */
@@ -350,7 +359,7 @@ form#plugin_formcreator_form {
 }
 #plugin_formcreator_form .form-group > .help-block {
    font-size: 0.8em;
-   color: #333;
+   color: var(--text-muted);
    padding: 3px 0;
 
    p {
@@ -996,7 +1005,8 @@ a.plugin_formcreator_formTile_title {
 /* Count of conditions in design view */
 .plugin_formcreator_conditions_count {
    border-radius: 50%;
-   background-color: #FFF;
+   background-color: var(--contrast-dark);
+   color: var(--contrast-light);
    min-width: 18px;
    height: 18px;
    text-align: center;

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -250,13 +250,13 @@ PluginFormcreatorTranslatableInterface
       $html .= "</span>";
 
       // Toggle mandatory for the question
+      $html .= "<span class='form_control pointer'>";
       if ($fieldType::canRequire()) {
-         $html .= "<span class='form_control pointer'>";
          $required = ($this->fields['required'] == '0') ? 'far fa-circle' : 'far fa-check-circle';
          $html .= '<i class="' . $required .'"
                   onclick="plugin_formcreator.toggleRequired(this)"></i> ';
-         $html .= "</span>";
       }
+      $html .= "</span>";
 
       $html .= '</div>'; // grid stack item content
 


### PR DESCRIPTION
### Changes description

Use CSS variables to enhance compatibility with themes.

Also force alignment of elements in questions designer. Image below is with Midnight theme
![image](https://github.com/pluginsGLPI/formcreator/assets/14139801/dade8520-eba7-478b-a77c-5819a49d0f40)



### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #29710