### PR TITLE
Restoring ticket may create inconsistency in DB

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -527,7 +527,8 @@ function plugin_formcreator_hook_delete_ticket(CommonDBTM $item) {
       }
    }
 
-   // Delete the issue
+   // Delete the issue associated to the ticlet
+   // (when a form generated one and only one ticket)
    // TODO: add is_deleted column to issue ?
    $issue = new PluginFormcreatorIssue();
    $issue->deleteByCriteria([
@@ -539,7 +540,14 @@ function plugin_formcreator_hook_delete_ticket(CommonDBTM $item) {
 function plugin_formcreator_hook_restore_ticket(CommonDBTM $item) {
    $formAnswer = new PluginFormcreatorFormAnswer();
    if ($formAnswer->getFromDbByTicket($item)) {
-      $formAnswer->createIssue();
+      $relations = (new Item_Ticket())->find([
+         'itemtype' => $formAnswer->getType(),
+         'items_id' => $formAnswer->getID(),
+      ]);
+      if (count($relations) === 1) {
+         // Recreate the issue when one and only one ticket has been created by the form
+         $formAnswer->createIssue();
+      }
       $minimalStatus = $formAnswer->getAggregatedStatus();
       if ($minimalStatus !== null) {
          $formAnswer->updateStatus($minimalStatus);


### PR DESCRIPTION
### Changes description

When a form generates several tickets, the requester cancels one of them, then the admin restores it, the plugin creates a duplicate entry in issues table.

This breaks requester's access to the generated tickets.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #3359