### PR TITLE
Import access restrictions may ignore uuids

### DIFF
--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -1904,15 +1904,20 @@ PluginFormcreatorTranslatableInterface
          $input[$key] = $DB->escape($input[$key]);
       }
 
+      // Do not process theses fields when adding / updating forms
+      // They will be imported later; see the variable $subItems below
+      $input2 = $input;
+      unset($input2['users'], $input2['groups'], $input2['profiles']);
+
       // Add or update the form
       $originalId = $input[$idKey];
       $item->skipChecks = true;
       if ($itemId !== false) {
-         $input['id'] = $itemId;
-         $item->update($input);
+         $input2['id'] = $itemId;
+         $item->update($input2);
       } else {
-         unset($input['id']);
-         $itemId = $item->add($input);
+         unset($input2['id']);
+         $itemId = $item->add($input2);
       }
       $item->skipChecks = false;
       if ($itemId === false) {

--- a/tests/3-unit/PluginFormcreatorForm.php
+++ b/tests/3-unit/PluginFormcreatorForm.php
@@ -38,6 +38,7 @@ use PluginFormcreatorQuestion;
 use PluginFormcreatorForm_Language;
 use PluginFormcreatorForm_Profile;
 use PluginFormcreatorForm_Validator;
+use PluginFormcreatorLinker;
 use Central;
 use User;
 use UserEmail;
@@ -110,7 +111,7 @@ class PluginFormcreatorForm extends CommonTestCase {
 
    public function testGetEnumAccessType() {
       $testedClassName = $this->getTestedClassName();
-      $output = \PluginFormcreatorForm::getEnumAccessType();
+      $output = $testedClassName::getEnumAccessType();
       $this->array($output)->isEqualTo([
          $testedClassName::ACCESS_PUBLIC     => __('Public access', 'formcreator'),
          $testedClassName::ACCESS_PRIVATE    => __('Private access', 'formcreator'),
@@ -714,12 +715,13 @@ class PluginFormcreatorForm extends CommonTestCase {
    }
 
    public function testImport() {
+      $testedClassName = $this->getTestedClassName();
       $uuid = plugin_formcreator_getUuid();
       $input = [
          'name' => $this->getUniqueString(),
          '_entity' => 'Root entity',
          'is_recursive' => '0',
-         'access_rights' => \PluginFormcreatorForm::ACCESS_RESTRICTED,
+         'access_rights' => $testedClassName::ACCESS_RESTRICTED,
          'description' => '',
          'content' => '',
          '_plugin_formcreator_category' => '',
@@ -735,21 +737,21 @@ class PluginFormcreatorForm extends CommonTestCase {
          'uuid' => $uuid,
       ];
 
-      $linker = new \PluginFormcreatorLinker ();
-      $formId = \PluginFormcreatorForm::import($linker, $input);
+      $linker = new PluginFormcreatorLinker ();
+      $formId = $testedClassName::import($linker, $input);
       $this->integer($formId)->isGreaterThan(0);
 
       unset($input['uuid']);
 
       $this->exception(
-         function() use($linker, $input) {
-            \PluginFormcreatorForm::import($linker, $input);
+         function() use($testedClassName, $linker, $input) {
+            $testedClassName::import($linker, $input);
          }
       )->isInstanceOf(\GlpiPlugin\Formcreator\Exception\ImportFailureException::class)
       ->hasMessage('UUID or ID is mandatory for Form'); // passes
 
       $input['id'] = $formId;
-      $formId2 = \PluginFormcreatorForm::import($linker, $input);
+      $formId2 = $testedClassName::import($linker, $input);
       $this->variable($formId2)->isNotFalse();
       $this->integer((int) $formId)->isNotEqualTo($formId2);
    }
@@ -937,7 +939,7 @@ class PluginFormcreatorForm extends CommonTestCase {
       $this->integer($newForm_id)->isGreaterThan(0);
 
       // get cloned form
-      $new_form = new \PluginFormcreatorForm();
+      $new_form = $this->newTestedInstance();
       $new_form->getFromDB($newForm_id);
 
       // check uuid


### PR DESCRIPTION
### Changes description

When adding or updating a form, if $input contains keys 'users', 'profiles' or 'groups' they are processed in post_addItem() or post_updateItem(). We need to prevent this when the form is being imported, or UUIDs of rows in forms_profiles, forms_groups and forms_users will be added without their UUID

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A