### PR TITLE
Prevent redirect to unavailable item

### DIFF
--- a/ajax/formanswer.php
+++ b/ajax/formanswer.php
@@ -88,28 +88,29 @@ if ($_SESSION['glpiname'] == 'formcreator_temp_user') {
 }
 
 // redirect to created item
-if ($_SESSION['glpibackcreated'] && Ticket::canView()) {
-   if (strpos($_SERVER['HTTP_REFERER'], 'form.form.php') === false) {
-      // User was not testing the form from preview
-      if (count($formAnswer->targetList) == 1) {
-         $target = current($formAnswer->targetList);
-         echo json_encode(
-            [
-               'redirect' => $target->getFormURLWithID($target->getID()),
-            ], JSON_FORCE_OBJECT
-         );
-         die();
-      }
+if ($_SESSION['glpibackcreated']) {
+   if (strpos($_SERVER['HTTP_REFERER'], 'form.form.php') !== false) {
       echo json_encode(
          [
-            'redirect' => $formAnswer->getFormURLWithID($formAnswer->getID()),
+            'redirect' => (new PluginFormcreatorForm())->getFormURLWithID($formAnswer->fields['plugin_formcreator_forms_id']),
+         ], JSON_FORCE_OBJECT
+      );
+      die();
+   }
+   // User was not testing the form from preview
+   reset($formAnswer->targetList);
+   $target = current($formAnswer->targetList);
+   if (count($formAnswer->targetList) == 1 && $target::canView()) {
+      echo json_encode(
+         [
+            'redirect' => $target->getFormURLWithID($target->getID()),
          ], JSON_FORCE_OBJECT
       );
       die();
    }
    echo json_encode(
       [
-         'redirect' => (new PluginFormcreatorForm())->getFormURLWithID($formAnswer->fields['plugin_formcreator_forms_id']),
+         'redirect' => $formAnswer->getFormURLWithID($formAnswer->getID()),
       ], JSON_FORCE_OBJECT
    );
    die();

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -1209,6 +1209,10 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
             'plugin_formcreator_questions_id'    => $questionId,
             'answer'                             => Toolbox::addslashes_deep($answer_value),
          ], [], 0);
+         if ($answer->isNewItem()) {
+            $formanswerId = $this->getID();
+            trigger_error("Formcreator: failed to save answer for question $questionId in formanswer ID $formanswerId. Value was: $answer_value", E_USER_WARNING);
+         }
          foreach ($field->getDocumentsForTarget() as $documentId) {
             $docItem = new Document_Item();
             $docItem->add([


### PR DESCRIPTION
### Changes description

If a self-service user submits a form which generates 1 target of type change, and has redirect to created item enabled in personal preferences, then the user is redirected to this page

![image](https://github.com/pluginsGLPI/formcreator/assets/14139801/211aca35-1092-440e-8b8b-53008e709b48)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->
Internal ref 29699