### PR TITLE
Request type comparisons

### DIFF
--- a/inc/field/requesttypefield.class.php
+++ b/inc/field/requesttypefield.class.php
@@ -173,7 +173,15 @@ class RequestTypeField extends SelectField
    }
 
    public function equals($value): bool {
+      global $TRANSLATE;
+
+      $oldLocale = $TRANSLATE->getLocale();
+      $TRANSLATE->setLocale("en_GB");
+      $_SESSION['glpilanguage'] = "en_GB";
       $available = $this->getAvailableValues();
+      $TRANSLATE->setLocale($oldLocale);
+      $_SESSION['glpilanguage'] = $oldLocale;
+
       if (!isset($available[$this->value])) {
          return false;
       }
@@ -181,7 +189,15 @@ class RequestTypeField extends SelectField
    }
 
    public function notEquals($value): bool {
+      global $TRANSLATE;
+
+      $oldLocale = $TRANSLATE->getLocale();
+      $TRANSLATE->setLocale("en_GB");
+      $_SESSION['glpilanguage'] = "en_GB";
       $available = $this->getAvailableValues();
+      $TRANSLATE->setLocale($oldLocale);
+      $_SESSION['glpilanguage'] = $oldLocale;
+
       if (!isset($available[$this->value])) {
          return false;
       }
@@ -189,7 +205,15 @@ class RequestTypeField extends SelectField
    }
 
    public function greaterThan($value): bool {
+      global $TRANSLATE;
+
+      $oldLocale = $TRANSLATE->getLocale();
+      $TRANSLATE->setLocale("en_GB");
+      $_SESSION['glpilanguage'] = "en_GB";
       $available = $this->getAvailableValues();
+      $TRANSLATE->setLocale($oldLocale);
+      $_SESSION['glpilanguage'] = $oldLocale;
+
       if (!isset($available[$this->value])) {
          return false;
       }
@@ -197,7 +221,15 @@ class RequestTypeField extends SelectField
    }
 
    public function lessThan($value): bool {
+      global $TRANSLATE;
+
+      $oldLocale = $TRANSLATE->getLocale();
+      $TRANSLATE->setLocale("en_GB");
+      $_SESSION['glpilanguage'] = "en_GB";
       $available = $this->getAvailableValues();
+      $TRANSLATE->setLocale($oldLocale);
+      $_SESSION['glpilanguage'] = $oldLocale;
+
       if (!isset($available[$this->value])) {
          return false;
       }


### PR DESCRIPTION
### Changes description

Comparisons with a request type question is language sensitive, breaking when a user uses a language different from the one choosen in the form designer. This PR forces english (en_GB) to be used for comparisons.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes internal ref: 29871