### PR TITLE
3221 username display

### DIFF
--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -357,11 +357,17 @@ class DropdownField extends PluginFormcreatorAbstractField
          $item = new $itemtype();
          $value = '';
          if ($item->getFromDB($this->value)) {
-            $column = 'name';
+            $value = $item->fields['name'];
             if ($item instanceof CommonTreeDropdown) {
-               $column = 'completename';
+               $value = $item->fields['completename'];
+            } else {
+               /** @var CommonDBTM $item */
+               switch ($item->getType()) {
+                  case User::class:
+                     $value = (new DbUtils())->getUserName($item->getID());
+                     break;
+               }
             }
-            $value = $item->fields[$column];
          }
 
          return $value;

--- a/tests/3-unit/GlpiPlugin/Formcreator/Field/GlpiSelectField.php
+++ b/tests/3-unit/GlpiPlugin/Formcreator/Field/GlpiSelectField.php
@@ -33,6 +33,7 @@
 namespace GlpiPlugin\Formcreator\Field\tests\units;
 use GlpiPlugin\Formcreator\Tests\CommonTestCase;
 use Computer;
+use User;
 
 class GlpiselectField extends CommonTestCase {
 
@@ -329,5 +330,44 @@ class GlpiselectField extends CommonTestCase {
       $instance->deserializeValue($input);
       $output = $instance->getValueForApi();
       $this->array($output)->isEqualTo($expected);
+   }
+
+
+   public function providerGetRenderedHtml() {
+      $question = $this->getQuestion([
+         'fieldtype' => 'glpiselect',
+         'itemtype' => User::class,
+      ]);
+      $field = $question->getSubField();
+
+      yield [
+         'field' => $field,
+         'value' => User::getIdByName('glpi'),
+         'expectFunction' => function () use ($field) {
+            $this->string($field->getRenderedHtml('', false))->isEqualTo('glpi');
+         },
+      ];
+
+      $login = $this->getUniqueString();
+      $this->getGlpiCoreItem(User::class, [
+         'name' => $login,
+         'firstname' => 'Alan',
+         'realname'  => 'Turing'
+      ]);
+      yield [
+         'field' => $field,
+         'value' => User::getIdByName($login),
+         'expectFunction' => function () use ($field) {
+            $this->string($field->getRenderedHtml('', false))->isEqualTo('Turing Alan');
+         },
+      ];
+   }
+
+   /**
+    * @dataProvider providerGetRenderedHtml
+    */
+   public function testGetRenderedHtml($field, $value, $expectFunction) {
+      $field->deserializeValue($value);
+      $expectFunction();
    }
 }

--- a/tests/3-unit/PluginFormcreatorForm.php
+++ b/tests/3-unit/PluginFormcreatorForm.php
@@ -485,7 +485,7 @@ class PluginFormcreatorForm extends CommonTestCase {
 
       $form = $this->getForm([
          'name'                  => 'validation notification',
-         'validation_required'   => \PluginFormcreatorForm_Validator::VALIDATION_USER,
+         'validation_required'   => PluginFormcreatorForm_Validator::VALIDATION_USER,
          '_validator_users'      => [$validator->getID()],
       ]);
       $this->getSection([


### PR DESCRIPTION
### Changes description

In Formcreator 2.4.2 user names were displayed with firstname and last name.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #3221