### PR TITLE
Actors ID not converted when duplicating a form

### DIFF
--- a/inc/target_actor.class.php
+++ b/inc/target_actor.class.php
@@ -172,51 +172,52 @@ class PluginFormcreatorTarget_Actor extends CommonDBChild implements PluginFormc
             'uuid',
             $input['uuid']
          );
-         // Convert UUIDs or names into IDs
-         switch ($input['actor_type']) {
-            case self::ACTOR_TYPE_QUESTION_PERSON :
-            case self::ACTOR_TYPE_QUESTION_GROUP :
-            case self::ACTOR_TYPE_QUESTION_SUPPLIER :
-            case self::ACTOR_TYPE_QUESTION_ACTORS :
-            case self::ACTOR_TYPE_GROUP_FROM_OBJECT :
-            case self::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT :
-               /** @var PluginFormcreatorQuestion $question */
-               $question = $linker->getObject($input['actor_value'], PluginFormcreatorQuestion::class);
-               if ($question === false) {
-                  $linker->postpone($input[$idKey], $item->getType(), $input, $containerId);
-                  return false;
-               }
-               $input['actor_value'] = $question->getID();
-               break;
+      }
 
-            case self::ACTOR_TYPE_PERSON:
-            case self::ACTOR_TYPE_AUTHORS_SUPERVISOR:
-               $user = new User;
-               $users_id = plugin_formcreator_getFromDBByField($user, 'name', $input['actor_value']);
-               if ($users_id === false) {
-                  throw new ImportFailureException(sprintf(__('Failed to find a user: %1$s'), $input['actor_value']));
-               }
-               $input['actor_value'] = $users_id;
-               break;
+      // Convert UUIDs or names into IDs
+      switch ($input['actor_type']) {
+         case self::ACTOR_TYPE_QUESTION_PERSON :
+         case self::ACTOR_TYPE_QUESTION_GROUP :
+         case self::ACTOR_TYPE_QUESTION_SUPPLIER :
+         case self::ACTOR_TYPE_QUESTION_ACTORS :
+         case self::ACTOR_TYPE_GROUP_FROM_OBJECT :
+         case self::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT :
+            /** @var PluginFormcreatorQuestion $question */
+            $question = $linker->getObject($input['actor_value'], PluginFormcreatorQuestion::class);
+            if ($question === false) {
+               $linker->postpone($input[$idKey], $item->getType(), $input, $containerId);
+               return false;
+            }
+            $input['actor_value'] = $question->getID();
+            break;
 
-            case self::ACTOR_TYPE_GROUP:
-               $group = new Group;
-               $groups_id = plugin_formcreator_getFromDBByField($group, 'completename', $input['actor_value']);
-               if ($groups_id === false) {
-                  throw new ImportFailureException(sprintf(__('Failed to find a group: %1$s'), $input['actor_value']));
-               }
-               $input['actor_value'] = $groups_id;
-               break;
+         case self::ACTOR_TYPE_PERSON:
+         case self::ACTOR_TYPE_AUTHORS_SUPERVISOR:
+            $user = new User;
+            $users_id = plugin_formcreator_getFromDBByField($user, 'name', $input['actor_value']);
+            if ($users_id === false) {
+               throw new ImportFailureException(sprintf(__('Failed to find a user: %1$s'), $input['actor_value']));
+            }
+            $input['actor_value'] = $users_id;
+            break;
 
-            case self::ACTOR_TYPE_SUPPLIER:
-               $supplier = new Supplier;
-               $suppliers_id = plugin_formcreator_getFromDBByField($supplier, 'name', $input['actor_value']);
-               if ($suppliers_id === false) {
-                  throw new ImportFailureException(sprintf(__('Failed to find a supplier: %1$s'), $input['actor_value']));
-               }
-               $input['actor_value'] = $suppliers_id;
-               break;
-         }
+         case self::ACTOR_TYPE_GROUP:
+            $group = new Group;
+            $groups_id = plugin_formcreator_getFromDBByField($group, 'completename', $input['actor_value']);
+            if ($groups_id === false) {
+               throw new ImportFailureException(sprintf(__('Failed to find a group: %1$s'), $input['actor_value']));
+            }
+            $input['actor_value'] = $groups_id;
+            break;
+
+         case self::ACTOR_TYPE_SUPPLIER:
+            $supplier = new Supplier;
+            $suppliers_id = plugin_formcreator_getFromDBByField($supplier, 'name', $input['actor_value']);
+            if ($suppliers_id === false) {
+               throw new ImportFailureException(sprintf(__('Failed to find a supplier: %1$s'), $input['actor_value']));
+            }
+            $input['actor_value'] = $suppliers_id;
+            break;
       }
 
       $originalId = $input[$idKey];


### PR DESCRIPTION
### Changes description

When a form is being duplicated, actors of a target (ticket, change, ...) have the ID of the source form, instead of the new actors.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Internal ref: 30206