### PR TITLE
Fix identical status label in simplified dashboard

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -75,7 +75,7 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
    public static function getStatuses() {
       return [
-         self::STATUS_WAITING  => __('Waiting', 'formcreator'),
+         self::STATUS_WAITING  => __('Waiting for approval'),
          self::STATUS_REFUSED  => __('Refused', 'formcreator'),
          self::STATUS_ACCEPTED => __('Accepted', 'formcreator'),
       ];


### PR DESCRIPTION
### Changes description

Update the STATUS_WAITING label to avoid an identical status label with PENDING. This confusion appears in `My requests for assistance` (Simplified dashboard) when GLPI is in French for example.
 
Before :
![Capture d’écran du 2024-02-09 14-19-33](https://github.com/pluginsGLPI/formcreator/assets/102067890/54dd881b-ee6f-4b79-8b87-4883e52dfee9)
 
After : 
![Capture d’écran du 2024-02-09 14-20-09](https://github.com/pluginsGLPI/formcreator/assets/102067890/802fbddc-bb41-47c3-bea7-d9a11efdf45b)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Ticket [31528](https://support.teclib.com/front/ticket.form.php?id=31528)