### PR TITLE
Fix IDOR tokens generation

### DIFF
--- a/inc/field/actorfield.class.php
+++ b/inc/field/actorfield.class.php
@@ -128,7 +128,7 @@ class ActorField extends PluginFormcreatorAbstractField
          'display_emptychoice' => false,
          'values'          => array_keys($value),
          'valuesnames'     => array_values($value),
-         '_idor_token'     => Session::getNewIDORToken(User::getType()),
+         '_idor_token'     => Session::getNewIDORToken(User::getType(), ['entity_restrict' => -1]),
       ];
       $html .= \PluginFormcreatorCommon::jsAjaxDropdown(
          $fieldName . '[]',

--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -383,7 +383,15 @@ class DropdownField extends PluginFormcreatorAbstractField
       $dparams = [];
       $dparams = $this->buildParams($rand);
       $dparams['display'] = false;
-      $dparams['_idor_token'] = Session::getNewIDORToken($itemtype);
+
+      $idor_params = [];
+      foreach (['condition', 'displaywith', 'entity_restrict', 'right'] as $sensitive_param) {
+         if (array_key_exists($sensitive_param, $dparams)) {
+            $idor_params[$sensitive_param] = $dparams[$sensitive_param];
+         }
+      }
+      $dparams['_idor_token'] = Session::getNewIDORToken($itemtype, $idor_params);
+
       $html .= $itemtype::dropdown($dparams);
       $html .= PHP_EOL;
       $html .= Html::scriptBlock("$(function() {

--- a/inc/form_validator.class.php
+++ b/inc/form_validator.class.php
@@ -192,7 +192,12 @@ PluginFormcreatorExportableInterface
          'valuesnames'     => array_values($selectedValidatorUsers),
          'condition'       => Dropdown::addNewCondition($usersCondition),
       ];
-      $params['_idor_token'] = Session::getNewIDORToken(User::getType());
+      $params['_idor_token'] = Session::getNewIDORToken(
+          User::getType(),
+          [
+              'condition' => $params['condition'],
+          ]
+      );
       echo Html::jsAjaxDropdown(
          '_validator_users[]',
          '_validator_users' . mt_rand(),
@@ -274,7 +279,12 @@ PluginFormcreatorExportableInterface
          'condition'       => Dropdown::addNewCondition($groupsCondition),
          'display_emptychoice' => false,
       ];
-      $params['_idor_token'] = Session::getNewIDORToken(Group::getType());
+      $params['_idor_token'] = Session::getNewIDORToken(
+          Group::getType(),
+          [
+              'condition' => $params['condition'],
+          ]
+      );
       echo Html::jsAjaxDropdown(
          '_validator_groups[]',
          '_validator_groups' . mt_rand(),
@@ -567,8 +577,13 @@ PluginFormcreatorExportableInterface
          'entity_restrict' => -1,
          'itemtype'        => User::getType(),
          'condition'       => Dropdown::addNewCondition($usersCondition),
-         '_idor_token'     => Session::getNewIDORToken(User::getType()),
       ];
+      $params['_idor_token'] = Session::getNewIDORToken(
+          User::getType(),
+          [
+              'condition' => $params['condition'],
+          ]
+      );
 
       return Html::jsAjaxDropdown(
          '_validator_users[]',
@@ -646,8 +661,13 @@ PluginFormcreatorExportableInterface
          'itemtype'            => Group::getType(),
          'condition'           => Dropdown::addNewCondition($groupsCondition),
          'display_emptychoice' => false,
-         '_idor_token'         => Session::getNewIDORToken(Group::getType()),
       ];
+      $params['_idor_token'] = Session::getNewIDORToken(
+          Group::getType(),
+          [
+              'condition' => $params['condition'],
+          ]
+      );
 
       return Html::jsAjaxDropdown(
          '_validator_groups[]',


### PR DESCRIPTION
### Changes description

In GLPI 10.0.13, to be validated, a IDOR token must contains the condition parameter used by the dropdown, unless this parameter is empty.
Without this change, the corresponding dropdown values could not be loaded.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Closes #N/A