### PR TITLE
fix: SQL error when user ID missing

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -229,7 +229,7 @@ function plugin_formcreator_addDefaultWhere($itemtype) {
          $condition .= " OR `glpi_users_$complexJoinId`.`id` = '$currentUser'";
 
          // Add users_id_recipient
-         $condition .= " OR `glpi_plugin_formcreator_issues`.`users_id_recipient` = $currentUser ";
+         $condition .= " OR `glpi_plugin_formcreator_issues`.`users_id_recipient` = '$currentUser' ";
          return "($condition)";
       break;
 


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->


Prevent SQL error :

```
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ') AND  ( glpi_plugin_formcreator_issues.entities_id = '0'  )  AND (   `gl...' at line 48
  Backtrace :
  src/Search.php:1460                                DBmysql->doQuery()
  src/SavedSearch.php:1340                           Search::constructData()
  src/SavedSearch.php:1266                           SavedSearch->execute()
  src/CronTask.php:1035                              SavedSearch::croncountAll()
  front/cron.php:87                                  CronTask::launch()

```

![image_paste6272085](https://github.com/user-attachments/assets/5699a49c-3deb-4d9e-971f-64272747c87f)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

ref !33894
