### PR TITLE
fix: handle negative due date for service levels

### DIFF
--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -1424,7 +1424,10 @@ SCRIPT;
             $period = "month";
             break;
       }
-      $str    = "+" . $this->fields['due_date_value'] . " $period";
+      $str = $this->fields['due_date_value'] . " $period";
+      if ($str[0] !== '-') {
+         $str = '+' . $str;
+      }
 
       switch ($this->fields['due_date_rule']) {
          case self::DUE_DATE_RULE_ANSWER:


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A

The plugin allows you to use the response of a date-type question to define a service level. In the properties configuration of a form destination, you can define the TTR from a specific question and deduct/add days. When the number of days/hours/minutes... was negative, the value was always interpreted as a positive value.