### PR TITLE
Fix FormcreatorIssues requester not updated

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -443,6 +443,19 @@ function plugin_formcreator_hook_add_ticket(CommonDBTM $item) {
    ]);
 }
 
+function plugin_formcreator_hook_update_ticket_actors(CommonITILActor $item)
+{
+    if ($item::$itemtype_1 == Ticket::class) {
+        if ($item->fields['type'] == CommonITILActor::REQUESTER) {
+            $ticket_id = $item->fields['tickets_id'];
+            $ticket = new Ticket();
+            if ($ticket->getFromDB($ticket_id)) {
+                plugin_formcreator_hook_update_ticket($ticket);
+            }
+        }
+    }
+}
+
 function plugin_formcreator_hook_update_ticket(CommonDBTM $item) {
    global $DB;
 
@@ -490,6 +503,7 @@ function plugin_formcreator_hook_update_ticket(CommonDBTM $item) {
          'entities_id'        => $item->fields['entities_id'],
          'is_recursive'       => '0',
          'requester_id'       => $requester,
+         'users_id_recipient' => $item->fields['users_id_recipient'],
          'comment'            => $DB->escape($item->fields['content']),
       ]);
    }

--- a/hook.php
+++ b/hook.php
@@ -443,17 +443,16 @@ function plugin_formcreator_hook_add_ticket(CommonDBTM $item) {
    ]);
 }
 
-function plugin_formcreator_hook_update_ticket_actors(CommonITILActor $item)
-{
-    if ($item::$itemtype_1 == Ticket::class) {
-        if ($item->fields['type'] == CommonITILActor::REQUESTER) {
-            $ticket_id = $item->fields['tickets_id'];
-            $ticket = new Ticket();
-            if ($ticket->getFromDB($ticket_id)) {
-                plugin_formcreator_hook_update_ticket($ticket);
-            }
-        }
-    }
+function plugin_formcreator_hook_update_ticket_actors(CommonITILActor $item) {
+   if ($item::$itemtype_1 == Ticket::class) {
+      if ($item->fields['type'] == CommonITILActor::REQUESTER) {
+         $ticket_id = $item->fields['tickets_id'];
+         $ticket = new Ticket();
+         if ($ticket->getFromDB($ticket_id)) {
+            plugin_formcreator_hook_update_ticket($ticket);
+         }
+      }
+   }
 }
 
 function plugin_formcreator_hook_update_ticket(CommonDBTM $item) {
@@ -503,7 +502,7 @@ function plugin_formcreator_hook_update_ticket(CommonDBTM $item) {
          'entities_id'        => $item->fields['entities_id'],
          'is_recursive'       => '0',
          'requester_id'       => $requester,
-         'users_id_recipient' => $item->fields['users_id_recipient'],
+         'users_id_recipient' => $requester,
          'comment'            => $DB->escape($item->fields['content']),
       ]);
    }

--- a/setup.php
+++ b/setup.php
@@ -281,6 +281,7 @@ function plugin_formcreator_permanent_hook(): void {
    $PLUGIN_HOOKS[Hooks::ITEM_ADD]['formcreator'] = [
       Ticket::class => 'plugin_formcreator_hook_add_ticket',
       ITILFollowup::class => 'plugin_formcreator_hook_update_itilFollowup',
+      Ticket_User::class => 'plugin_formcreator_hook_update_ticket_actors',
    ];
    $PLUGIN_HOOKS[Hooks::PRE_ITEM_UPDATE]['formcreator'] = [
       User::class  => 'plugin_formcreator_hook_update_user',
@@ -299,6 +300,7 @@ function plugin_formcreator_permanent_hook(): void {
    $PLUGIN_HOOKS[Hooks::ITEM_PURGE]['formcreator'] = [
       Ticket::class => 'plugin_formcreator_hook_purge_ticket',
       TicketValidation::class => 'plugin_formcreator_hook_purge_ticketvalidation',
+      Ticket_User::class => 'plugin_formcreator_hook_update_ticket_actors',
    ];
    $PLUGIN_HOOKS[Hooks::PRE_ITEM_PURGE]['formcreator'] = [
       PluginFormcreatorTargetTicket::class => 'plugin_formcreator_hook_pre_purge_targetTicket',


### PR DESCRIPTION
### Changes description

When the requester of a ticket is changed to a new requester, the original writer continues to see the ticket in the simplified and extended service catalog interface.
When the Simplified/Extended Service Catalog is changed to GLPI Support, the original ticket writer no longer sees the ticket.

This is due to the requester in the glpi_plugin_formcreator_issues table not being updated when the ticket's actors are updated, as the hook on Ticket_User is not triggered.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

It fixes !35730