### PR TITLE
fix(target) Removes the default user when a group requester is defined in targets

### DIFF
--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -834,7 +834,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
 
       $this->prepareActors($form, $formanswer);
 
-      if (count($this->requesters['_users_id_requester']) == 0) {
+      if (count($this->requesters['_users_id_requester']) == 0 && count($this->requesterGroups['_groups_id_requester']) == 0) {
          $this->addActor(PluginFormcreatorTarget_Actor::ACTOR_ROLE_REQUESTER, $formanswer->fields['requester_id'], true);
          $requesters_id = $formanswer->fields['requester_id'];
       } else {


### PR DESCRIPTION


### Changes description

If a group is set to requester, but no users are specified by default for the target tickets, the created ticket will add the form’s author as requester in addition to the group when it is created.

![Capture d’écran du 2025-01-22 10-29-52](https://github.com/user-attachments/assets/90cac364-e4da-4ec6-a8d1-fe1ee9792ae5)

![Capture d’écran du 2025-01-22 10-30-48](https://github.com/user-attachments/assets/c88113ee-203a-4eb0-b988-bca69be22c4c)

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Ticket !36028