### PR TITLE
fix: set the default value of the dropdown as empty string

### DIFF
--- a/inc/field/fieldsfield.class.php
+++ b/inc/field/fieldsfield.class.php
@@ -208,13 +208,19 @@ class FieldsField extends PluginFormcreatorAbstractField
          $field['value'] = $value;
       } else {
          //get default value
-         if ($this->getField()->fields['default_value'] !== "") {
+         if (
+            $this->getField()->fields['default_value'] !== ""
+            && $this->getField()->fields['default_value'] !== null
+            && $this->getField()->fields['default_value'] !== 0
+         ) {
             $value = $this->getField()->fields['default_value'];
             // shortcut for date/datetime
             if (in_array($this->getField()->fields['type'], ['date', 'datetime'])
                   && $value == 'now') {
                $value = $_SESSION["glpi_currenttime"];
             }
+         } else {
+            $value = '';
          }
          $field['value'] = $value;
       }
@@ -506,7 +512,7 @@ class FieldsField extends PluginFormcreatorAbstractField
    private function isAdditionalFieldEmpty(): bool {
       switch ($this->getField()->fields['type']) {
          case 'dropdown':
-            return $this->getField()->fields['mandatory'] && $this->value == 0;
+            return $this->getField()->fields['mandatory'] && ($this->value == 0 || $this->value == '' || $this->value == null);
       }
 
       return $this->getField()->fields['mandatory'] && $this->value == '';

--- a/inc/field/fieldsfield.class.php
+++ b/inc/field/fieldsfield.class.php
@@ -208,11 +208,7 @@ class FieldsField extends PluginFormcreatorAbstractField
          $field['value'] = $value;
       } else {
          //get default value
-         if (
-            $this->getField()->fields['default_value'] !== ""
-            && $this->getField()->fields['default_value'] !== null
-            && $this->getField()->fields['default_value'] !== 0
-         ) {
+         if (!empty($this->getField()->fields['default_value'])) {
             $value = $this->getField()->fields['default_value'];
             // shortcut for date/datetime
             if (in_array($this->getField()->fields['type'], ['date', 'datetime'])
@@ -512,7 +508,7 @@ class FieldsField extends PluginFormcreatorAbstractField
    private function isAdditionalFieldEmpty(): bool {
       switch ($this->getField()->fields['type']) {
          case 'dropdown':
-            return $this->getField()->fields['mandatory'] && ($this->value == 0 || $this->value == '' || $this->value == null);
+            return $this->getField()->fields['mandatory'] && empty($this->value);
       }
 
       return $this->getField()->fields['mandatory'] && $this->value == '';


### PR DESCRIPTION
### Changes description

the mandatory dropdown created with the plugin fields was not checked if the value was empty or not. In the database, the value could be a null value, an empty string or 0 and only the case where the value is equal to 0 is checked which validates the other two cases.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

#36030