### PR TITLE
Fix: remove unrelated items when a ticket target is set

### DIFF
--- a/inc/field/dropdownfield.class.php
+++ b/inc/field/dropdownfield.class.php
@@ -246,6 +246,7 @@ class DropdownField extends PluginFormcreatorAbstractField
                $canViewAllHardware = Session::haveRight('helpdesk_hardware', pow(2, Ticket::HELPDESK_ALL_HARDWARE));
                $canViewMyHardware = Session::haveRight('helpdesk_hardware', pow(2, Ticket::HELPDESK_MY_HARDWARE));
                $canViewGroupHardware = Session::haveRight('show_group_hardware', '1');
+               $target_ticket = (new \PluginFormcreatorTargetTicket())->getTargetsForForm($form->getID());
                $groups = [];
                if ($canViewGroupHardware) {
                   $groups = $this->getMyGroups(Session::getLoginUserID());
@@ -266,7 +267,7 @@ class DropdownField extends PluginFormcreatorAbstractField
                   ];
                }
                // Check if helpdesk availability is fine tunable on a per item basis
-               if (Session::getCurrentInterface() == "helpdesk" && $DB->fieldExists($itemtype::getTable(), 'is_helpdesk_visible')) {
+               if ($DB->fieldExists($itemtype::getTable(), 'is_helpdesk_visible') && count($target_ticket) > 0) {
                   $dparams_cond_crit[] = [
                      'is_helpdesk_visible' => '1',
                   ];


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

This PR prevents the user from selecting a GLPI itemtype if it is declared as not associable to a ticket and that the form has for purpose to create a ticket.

Form with no ticket target to specify
![Capture d’écran du 2025-02-11 11-27-07](https://github.com/user-attachments/assets/b43de90c-671d-48d9-a3f8-0a6181e16177) 

Form with ticket target to specify
![Capture d’écran du 2025-02-11 11-27-41](https://github.com/user-attachments/assets/eec861d5-5387-409b-b1a5-db95c86cb60d)


Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #36317