### PR TITLE
fix(files): entity

### DIFF
--- a/inc/field/filefield.class.php
+++ b/inc/field/filefield.class.php
@@ -238,9 +238,17 @@ class FileField extends PluginFormcreatorAbstractField
          return;
       }
 
+      $entities_id = $form->fields['entities_id'];
+      if ($form->fields['is_recursive']) {
+         $entities_sons = getSonsOf('glpi_entities', $form->fields['entities_id']);
+         if (in_array($_SESSION['glpiactive_entity'], $entities_sons)) {
+            $entities_id = $_SESSION['glpiactive_entity'];
+         }
+      }
+
       $file_data = [
          'name'             => Toolbox::addslashes_deep($form->fields['name'] . ' - ' . $this->question->fields['name']),
-         'entities_id'      => $_SESSION['glpiactive_entity'] ?? $form->getField('entities_id'),
+         'entities_id'      => $entities_id,
          'is_recursive'     => $form->getField('is_recursive'),
          '_filename'        => [$file],
          '_prefix_filename' => [$prefix],

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -853,7 +853,13 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
       $input = $this->setValidator($input, $form);
 
-      $input['entities_id'] = $_SESSION['glpiactive_entity'] ?? $form->fields['entities_id'];
+      $input['entities_id'] = $form->fields['entities_id'];
+      if ($form->fields['is_recursive']) {
+         $entities_sons = getSonsOf('glpi_entities', $form->fields['entities_id']);
+         if (in_array($_SESSION['glpiactive_entity'], $entities_sons)) {
+            $input['entities_id'] = $_SESSION['glpiactive_entity'];
+         }
+      }
 
       $input['is_recursive']                = $form->fields['is_recursive'];
       $input['plugin_formcreator_forms_id'] = $form->getID();


### PR DESCRIPTION
### Changes description

If a user is logged in at the root entity level and responds to a form from a child entity (creating a ticket in the same child entity), the documents from this form were created in the root entity instead of the child entity (as well as the answer).

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

!36416