### PR TITLE
fix: display supplier input field when selecting a supplier from the …

### DIFF
--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -1807,6 +1807,8 @@ SCRIPT;
             break;
          case CommonITILActor::OBSERVER:
             $type = 'watcher';
+            unset($dropdownItems[PluginFormcreatorTarget_Actor::ACTOR_TYPE_SUPPLIER]);
+            unset($dropdownItems[PluginFormcreatorTarget_Actor::ACTOR_TYPE_QUESTION_SUPPLIER]);
             $changeActorJSFunction = 'plugin_formcreator.changeActor("watcher", this.value)';
             $actorRole = PluginFormcreatorTarget_Actor::ACTOR_ROLE_OBSERVER;
             break;
@@ -1999,7 +2001,7 @@ SCRIPT;
       );
       echo '</div>';
 
-      if ($actorType == CommonITILActor::ASSIGN || $actorType == CommonITILActor::OBSERVER) {
+      if ($actorType == CommonITILActor::ASSIGN) {
          echo '<div style="display:none" data-actor-type="' . $type . "_" . PluginFormcreatorTarget_Actor::ACTOR_TYPE_SUPPLIER . '">';
          // find already used items
          $request = $DB->request([

--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -1999,7 +1999,7 @@ SCRIPT;
       );
       echo '</div>';
 
-      if ($actorType == CommonITILActor::ASSIGN) {
+      if ($actorType == CommonITILActor::ASSIGN || $actorType == CommonITILActor::OBSERVER) {
          echo '<div style="display:none" data-actor-type="' . $type . "_" . PluginFormcreatorTarget_Actor::ACTOR_TYPE_SUPPLIER . '">';
          // find already used items
          $request = $DB->request([


### PR DESCRIPTION
### Changes description

It's fixes !36575

This RP corrects the display of the supplier drop-down menu for observer actors, so that it is no longer visible when creating an observer target in a form because suppliers cannot be observers in a ticket.

![Capture d’écran du 2025-03-04 09-27-31](https://github.com/user-attachments/assets/156fda7d-c964-479c-bf6c-1481611a1c5f)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

