### PR TITLE
fix: backslashes in translations not working in textarea

### DIFF
--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -402,7 +402,9 @@ PluginFormcreatorTranslatableInterface
     * @return array the modified $input array
     */
    public function prepareInputForAdd($input) {
-      $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
+      if (!empty($input['default_values'])) {
+         $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
+      }
 
       if (!$this->skipChecks) {
          $input = $this->checkBeforeSave($input);
@@ -454,7 +456,9 @@ PluginFormcreatorTranslatableInterface
    public function prepareInputForUpdate($input) {
       // global $DB;
 
-      $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
+      if (!empty($input['default_values'])) {
+         $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
+      }
       if (!$this->skipChecks) {
          if (!isset($input['plugin_formcreator_sections_id'])) {
             $input['plugin_formcreator_sections_id'] = $this->fields['plugin_formcreator_sections_id'];

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -402,7 +402,6 @@ PluginFormcreatorTranslatableInterface
     * @return array the modified $input array
     */
    public function prepareInputForAdd($input) {
-
       if (!$this->skipChecks) {
          $input = $this->checkBeforeSave($input);
 

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -464,12 +464,8 @@ PluginFormcreatorTranslatableInterface
 
          $input = $this->checkBeforeSave($input);
 
-         if (
-            !empty($input['default_values'])
-            && (
-               $input['fieldtype'] === 'textarea'
-               || $this->fields['fieldtype'] === 'textarea'
-            )
+         if (!empty($input['default_values']) &&
+            ($input['fieldtype'] === 'textarea' || $this->fields['fieldtype'] === 'textarea')
          ) {
             $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
          }

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -402,7 +402,7 @@ PluginFormcreatorTranslatableInterface
     * @return array the modified $input array
     */
    public function prepareInputForAdd($input) {
-      if (!empty($input['default_values'])) {
+      if (!in_array($input['fieldtype'], ['checkboxes', 'multiselect'])) {
          $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
       }
 
@@ -456,7 +456,7 @@ PluginFormcreatorTranslatableInterface
    public function prepareInputForUpdate($input) {
       // global $DB;
 
-      if (!empty($input['default_values'])) {
+      if (!in_array($input['fieldtype'], ['checkboxes', 'multiselect'])) {
          $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
       }
       if (!$this->skipChecks) {

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -402,6 +402,8 @@ PluginFormcreatorTranslatableInterface
     * @return array the modified $input array
     */
    public function prepareInputForAdd($input) {
+      $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
+
       if (!$this->skipChecks) {
          $input = $this->checkBeforeSave($input);
 
@@ -452,6 +454,7 @@ PluginFormcreatorTranslatableInterface
    public function prepareInputForUpdate($input) {
       // global $DB;
 
+      $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
       if (!$this->skipChecks) {
          if (!isset($input['plugin_formcreator_sections_id'])) {
             $input['plugin_formcreator_sections_id'] = $this->fields['plugin_formcreator_sections_id'];

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -402,20 +402,13 @@ PluginFormcreatorTranslatableInterface
     * @return array the modified $input array
     */
    public function prepareInputForAdd($input) {
-      if (
-         (
-            isset($input['fieldtype'])
-            && $input['fieldtype'] === 'textarea'
-         ) || (
-            isset($this->fields['fieldtype'])
-            && $this->fields['fieldtype'] === 'textarea'
-         ) && !empty($input['default_values'])
-      ) {
-         $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
-      }
 
       if (!$this->skipChecks) {
          $input = $this->checkBeforeSave($input);
+
+         if (!empty($input['default_values'] && $input['fieldtype'] === 'textarea')) {
+            $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
+         }
 
          if (!$this->checkConditionSettings($input)) {
             $input['show_rule'] = PluginFormcreatorCondition::SHOW_RULE_ALWAYS;
@@ -464,23 +457,22 @@ PluginFormcreatorTranslatableInterface
    public function prepareInputForUpdate($input) {
       // global $DB;
 
-      if (
-         (
-            isset($input['fieldtype'])
-            && $input['fieldtype'] === 'textarea'
-         ) || (
-            isset($this->fields['fieldtype'])
-            && $this->fields['fieldtype'] === 'textarea'
-         ) && !empty($input['default_values'])
-      ) {
-         $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
-      }
       if (!$this->skipChecks) {
          if (!isset($input['plugin_formcreator_sections_id'])) {
             $input['plugin_formcreator_sections_id'] = $this->fields['plugin_formcreator_sections_id'];
          }
 
          $input = $this->checkBeforeSave($input);
+
+         if (
+            !empty($input['default_values'])
+            && (
+               $input['fieldtype'] === 'textarea'
+               || $this->fields['fieldtype'] === 'textarea'
+            )
+         ) {
+            $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
+         }
 
          if (!$this->checkConditionSettings($input)) {
             $input['show_rule'] = PluginFormcreatorCondition::SHOW_RULE_ALWAYS;

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -402,7 +402,15 @@ PluginFormcreatorTranslatableInterface
     * @return array the modified $input array
     */
    public function prepareInputForAdd($input) {
-      if (isset($input['fieldtype']) && isset($input['default_values']) && !in_array($input['fieldtype'], ['checkboxes', 'multiselect'])) {
+      if (
+         (
+            isset($input['fieldtype'])
+            && $input['fieldtype'] === 'textarea'
+         ) || (
+            isset($this->fields['fieldtype'])
+            && $this->fields['fieldtype'] === 'textarea'
+         ) && !empty($input['default_values'])
+      ) {
          $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
       }
 
@@ -456,7 +464,15 @@ PluginFormcreatorTranslatableInterface
    public function prepareInputForUpdate($input) {
       // global $DB;
 
-      if (isset($input['fieldtype']) && isset($input['default_values']) && !in_array($input['fieldtype'], ['checkboxes', 'multiselect'])) {
+      if (
+         (
+            isset($input['fieldtype'])
+            && $input['fieldtype'] === 'textarea'
+         ) || (
+            isset($this->fields['fieldtype'])
+            && $this->fields['fieldtype'] === 'textarea'
+         ) && !empty($input['default_values'])
+      ) {
          $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
       }
       if (!$this->skipChecks) {

--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -402,7 +402,7 @@ PluginFormcreatorTranslatableInterface
     * @return array the modified $input array
     */
    public function prepareInputForAdd($input) {
-      if (!in_array($input['fieldtype'], ['checkboxes', 'multiselect'])) {
+      if (isset($input['fieldtype']) && isset($input['default_values']) && !in_array($input['fieldtype'], ['checkboxes', 'multiselect'])) {
          $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
       }
 
@@ -456,7 +456,7 @@ PluginFormcreatorTranslatableInterface
    public function prepareInputForUpdate($input) {
       // global $DB;
 
-      if (!in_array($input['fieldtype'], ['checkboxes', 'multiselect'])) {
+      if (isset($input['fieldtype']) && isset($input['default_values']) && !in_array($input['fieldtype'], ['checkboxes', 'multiselect'])) {
          $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
       }
       if (!$this->skipChecks) {

--- a/inc/translation.class.php
+++ b/inc/translation.class.php
@@ -211,6 +211,7 @@ class PluginFormcreatorTranslation
    public function add(array $input) : bool {
       global $TRANSLATE;
 
+      $input['value'] = str_replace('\r\n', '', $input['value']);
       $formLanguage = new PluginFormcreatorForm_Language();
       if (!$formLanguage->getFromDB($input['plugin_formcreator_forms_languages_id'])) {
          Session::addMessageAfterRedirect(__('Language not found.', 'formcreator'), false, ERROR);
@@ -229,7 +230,6 @@ class PluginFormcreatorTranslation
       $original = $translatableStrings[$type][$input['id']];
 
       $input['value'] = Sanitizer::unsanitize($input['value']);
-      $input['value'] = str_replace('\r\n', '', $input['value']);
       $translations[$original] = Sanitizer::sanitize($input['value'], false);
 
       if (!$form->setTranslations($formLanguage->fields['name'], $translations)) {

--- a/inc/translation.class.php
+++ b/inc/translation.class.php
@@ -211,7 +211,6 @@ class PluginFormcreatorTranslation
    public function add(array $input) : bool {
       global $TRANSLATE;
 
-      $input['value'] = str_replace('\r\n', '', $input['value']);
       $formLanguage = new PluginFormcreatorForm_Language();
       if (!$formLanguage->getFromDB($input['plugin_formcreator_forms_languages_id'])) {
          Session::addMessageAfterRedirect(__('Language not found.', 'formcreator'), false, ERROR);
@@ -230,6 +229,7 @@ class PluginFormcreatorTranslation
       $original = $translatableStrings[$type][$input['id']];
 
       $input['value'] = Sanitizer::unsanitize($input['value']);
+      $input['value'] = str_replace('\r\n', '', $input['value']);
       $translations[$original] = Sanitizer::sanitize($input['value'], false);
 
       if (!$form->setTranslations($formLanguage->fields['name'], $translations)) {


### PR DESCRIPTION
### Changes description

This PR corrects the translation problem if the text of a textarea to translate contains backslashes

Original :
![Capture d’écran du 2025-03-07 10-35-19](https://github.com/user-attachments/assets/a1f48a9c-b953-42d1-8efc-9c0b1800da47)

Translation :
![Capture d’écran du 2025-03-07 10-34-34](https://github.com/user-attachments/assets/851480d5-ab14-4835-aa20-3f962d147e35)

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

Closes !36722