### PR TITLE
fix: isPrerequisites() on null

### DIFF
--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -280,7 +280,7 @@ PluginFormcreatorTranslatableInterface
       }
 
       $field = $this->getSubField();
-      if (!$field->isPrerequisites()) {
+      if ($field == null || !$field->isPrerequisites()) {
          return '';
       }
 


### PR DESCRIPTION
### Changes description

Prevent this error message:
```
 glpiphplog.CRITICAL:   *** Twig Error (Twig\Error\RuntimeError): "An exception has been thrown during the rendering of a template ("Call to a member function isPrerequisites() on null")." in template ".../templates/pages/userform.html.twig" at line 101
  Backtrace :
  vendor/twig/twig/src/Template.php:327              Twig\Template->yield()
  vendor/twig/twig/src/TemplateWrapper.php:45        Twig\Template->display()
  src/Application/View/TemplateRenderer.php:184      Twig\TemplateWrapper->display()
  marketplace/formcreator/inc/form.class.php:1063    Glpi\Application\View\TemplateRenderer->display()
  marketplace/formcreator/inc/form.class.php:606     PluginFormcreatorForm->displayUserForm()
  src/CommonGLPI.php:694                             PluginFormcreatorForm::displayTabContentForItem()
  ajax/common.tabs.php:120                           CommonGLPI::displayStandardTab()
```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A