### PR TITLE
Fix(Dashboard): fix `pending` and `to be validated` counter

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -309,6 +309,10 @@ function plugin_formcreator_addWhere($link, $nott, $itemtype, $ID, $val, $search
                   $tocheck = $item->getPendingStatusArray();
                   break;
 
+               case PluginFormcreatorFormAnswer::STATUS_WAITING:
+                  $tocheck = $item->getPendingValidationStatusArray();
+                  break;
+
                case Ticket::CLOSED:
                   $tocheck = $item->getClosedStatusArray();
                   break;

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -75,9 +75,9 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
 
    public static function getStatuses() {
       return [
-         self::STATUS_WAITING  => __('Waiting', 'formcreator'),
-         self::STATUS_REFUSED  => __('Refused', 'formcreator'),
-         self::STATUS_ACCEPTED => __('Accepted', 'formcreator'),
+         self::STATUS_WAITING  => __('To validate', 'formcreator'),
+         self::STATUS_REFUSED  => __('Validation Refused', 'formcreator'),
+         self::STATUS_ACCEPTED => __('Validation Accepted', 'formcreator'),
       ];
    }
 

--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -1135,7 +1135,11 @@ class PluginFormcreatorIssue extends CommonDBTM {
    }
 
    static function getPendingStatusArray() {
-      return [Ticket::WAITING, PluginFormcreatorFormAnswer::STATUS_WAITING];
+      return [Ticket::WAITING];
+   }
+
+   static function getPendingValidationStatusArray() {
+      return [PluginFormcreatorFormAnswer::STATUS_WAITING];
    }
 
    static function getProcessStatusArray() {


### PR DESCRIPTION
### Changes description

The issue concerns the `Pending` and `To Be Validated` indicators in GLPI (Formcreator). Currently, these indicators mix ticket status with validation status, which can lead to confusion.

For example, a ticket with the status New and a `pending` validation request appears in both indicators, whereas it should logically only appear in the one related to validation.

An improvement has been made to clarify this behavior:

The `Pending` indicator now displays only tickets whose status is actually `Pending`.

The `To Be Validated `indicator now lists only tickets whose global validation status is `Pending validation`, as well as Issues `pending` validation.

### References

Issue : !37105

