### PR TITLE
Fix: Lists button on formanswer.php

### DIFF
--- a/front/formanswer.php
+++ b/front/formanswer.php
@@ -49,7 +49,8 @@ if (Session::getCurrentInterface() == 'helpdesk') {
       __('Form Creator', 'formcreator'),
       '',
       'admin',
-      PluginFormcreatorForm::class
+      PluginFormcreatorForm::class,
+      'answer'
    );
 }
 

--- a/inc/form.class.php
+++ b/inc/form.class.php
@@ -129,6 +129,15 @@ PluginFormcreatorTranslatableInterface
       $menu['links'][$validation_image] = PluginFormcreatorFormAnswer::getSearchURL(false).'?criteria[0][link]=AND&criteria[0][field]=8&criteria[0][searchtype]=equals&criteria[0][value]=' . PluginFormcreatorFormAnswer::STATUS_WAITING;
       $menu['links'][$import_image]     = PluginFormcreatorForm::getFormURL(false)."?import_form=1";
       $menu['links'][$requests_image]   = PluginFormcreatorIssue::getSearchURL(false);
+
+      $menu['options']['answer'] = [
+         'title' => PluginFormcreatorFormAnswer::getTypeName(Session::getPluralNumber()),
+         'page'  => PluginFormcreatorFormAnswer::getSearchURL(false),
+         'icon'  => PluginFormcreatorFormAnswer::getIcon(),
+         'links' => [
+            'search' => PluginFormcreatorFormAnswer::getSearchURL(false),
+         ],
+      ];
       return $menu;
    }
 


### PR DESCRIPTION
### Changes description

On the `formcreator/front/formanswer.php` page, the “Lists” button didn't work, clicking on it did nothing.

Before:
![image](https://github.com/user-attachments/assets/83808654-721c-4e41-bed1-81c1e9922e2e)

After:
![image](https://github.com/user-attachments/assets/40d0f180-766a-49e4-a58e-b42e6950e6c8)

_Similarly, the “Add” button is irrelevant because it doesn't add an answer._

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes !37676