### PR TITLE
Fix breaking change introduced by #3449

### DIFF
--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -2539,4 +2539,20 @@ SCRIPT;
       $input['_skip_create_actors'] = true;
       return $input;
    }
+
+   protected static function getTemplateByName(string $name): int {
+      global $DB;
+
+      $targetTemplateType = (new static())->getTemplateItemtypeName();
+      $targetTemplate = new $targetTemplateType();
+      $targetTemplate->getFromDBByCrit([
+         'name' => $DB->escape($name),
+      ]);
+
+      if ($targetTemplate->isNewItem()) {
+         return 0;
+      }
+
+      return $targetTemplate->getID();
+   }
 }

--- a/inc/abstracttarget.class.php
+++ b/inc/abstracttarget.class.php
@@ -79,8 +79,6 @@ abstract class PluginFormcreatorAbstractTarget extends CommonDBChild implements
     */
    abstract protected function getTaggableFields();
 
-   abstract protected function getTemplateItemtypeName();
-
    const DESTINATION_ENTITY_CURRENT = 1;
    const DESTINATION_ENTITY_REQUESTER = 2;
    const DESTINATION_ENTITY_REQUESTER_DYN_FIRST = 3;
@@ -573,19 +571,4 @@ abstract class PluginFormcreatorAbstractTarget extends CommonDBChild implements
       return $input;
    }
 
-   protected static function getTemplateByName(string $name): int {
-      global $DB;
-
-      $targetTemplateType = (new static())->getTemplateItemtypeName();
-      $targetTemplate = new $targetTemplateType();
-      $targetTemplate->getFromDBByCrit([
-         'name' => $DB->escape($name),
-      ]);
-
-      if ($targetTemplate->isNewItem()) {
-         return 0;
-      }
-
-      return $targetTemplate->getID();
-   }
 }


### PR DESCRIPTION
### Changes description

#3449 introduce a breaking change by adding a new `getTemplateItemtypeName` abstract method to a base class in a minor release.
This breaks any code that extends this class.

Fixed by moving the `getTemplateByName` method to `PluginFormcreatorAbstractItilTarget` (which already has a `getTemplateItemtypeName` abstract method) as it is only used by CommonITILObject anyway.

### References

Internal ref: 35312.