### PR TITLE
fix(issue): show formanswer tooltip only if readable

### DIFF
--- a/inc/issue.class.php
+++ b/inc/issue.class.php
@@ -1080,10 +1080,13 @@ class PluginFormcreatorIssue extends CommonDBTM {
                      trigger_error(sprintf("Formanswer ID %s not found", $id), E_USER_WARNING);
                      break;
                   }
-                  try {
-                     $content = $formAnswer->parseTags($formAnswer->getFullForm());
-                  } catch (Exception $e) {
-                     $content = ''; // Exception when computing the tooltip
+                  $content = '';
+                  if ($formAnswer->canViewItem()) {
+                     try {
+                        $content = $formAnswer->parseTags($formAnswer->getFullForm());
+                     } catch (Exception $e) {
+                        $content = ''; // Exception when computing the tooltip
+                     }
                   }
                   break;
             }
@@ -1095,11 +1098,14 @@ class PluginFormcreatorIssue extends CommonDBTM {
             }
 
             $key = 'id';
-            $tooltip = Html::showToolTip(RichText::getEnhancedHtml($content), [
-               'applyto'        => $itemtype.$data['raw'][$key],
-               'display'        => false,
-               'images_gallery' => false
-            ]);
+            $tooltip = '';
+            if ($content !== '') {
+               $tooltip = Html::showToolTip(RichText::getEnhancedHtml($content), [
+                  'applyto'        => $itemtype.$data['raw'][$key],
+                  'display'        => false,
+                  'images_gallery' => false
+               ]);
+            }
             return '<a id="' . $itemtype.$data['raw'][$key] . '" href="' . $link . '">'
                . sprintf(__('%1$s %2$s'), $name, $tooltip)
                . '</a>';


### PR DESCRIPTION
### Changes description

When a form generates several tickets, a user with self service who must validate at lease one of the tickets but is not allowed to view the form answer can still see its content in the tooltip. This PR fixes this problem

![image](https://github.com/user-attachments/assets/f95fc1f7-802e-4ca8-abca-93db7aab2462)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

related to internal issue 36834