### PR TITLE
fix(question): misplaced parenthesis

### DIFF
--- a/inc/question.class.php
+++ b/inc/question.class.php
@@ -405,7 +405,7 @@ PluginFormcreatorTranslatableInterface
       if (!$this->skipChecks) {
          $input = $this->checkBeforeSave($input);
 
-         if (!empty($input['default_values'] && $input['fieldtype'] === 'textarea')) {
+         if (!empty($input['default_values']) && $input['fieldtype'] === 'textarea') {
             $input['default_values'] = str_replace('\r\n', '', $input['default_values']);
          }
 


### PR DESCRIPTION
triggers a PHP warning when adding a file question, breaking the refresh of the list of question in a section (if debug mode enabled)

```
[2025-05-13 14:12:34] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "default_values" in /var/www/glpi/plugins/formcreator/inc/question.class.php at line 408
  Backtrace :
  src/CommonDBTM.php:1311                            PluginFormcreatorQuestion->prepareInputForAdd()
  plugins/formcreator/ajax/question_add.php:43       CommonDBTM->add()
  public/index.php:82                                require()
```

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A