### PR TITLE
fix(issue): waiting status is not being computed correctly

### DIFF
--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -2005,13 +2005,13 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
             continue;
          }
          $ticketStatus = PluginFormcreatorCommon::getTicketStatusForIssue($generatedTarget);
-         if ($ticketStatus >= PluginFormcreatorFormAnswer::STATUS_WAITING) {
-            // force pending approval status to be seen from to_validate dashboard
-            if ($ticketStatus == PluginFormcreatorFormAnswer::STATUS_WAITING) {
-               return PluginFormcreatorFormAnswer::STATUS_WAITING;
-            } else {
-               continue;
-            }
+         if ($ticketStatus > PluginFormcreatorFormAnswer::STATUS_WAITING) {
+            continue;
+         }
+
+         // force pending approval status to be seen from to_validate dashboard
+         if ($ticketStatus == PluginFormcreatorFormAnswer::STATUS_WAITING) {
+            return PluginFormcreatorFormAnswer::STATUS_WAITING;
          }
 
          if ($ticketStatus == CommonITILObject::WAITING) {

--- a/inc/formanswer.class.php
+++ b/inc/formanswer.class.php
@@ -2006,9 +2006,12 @@ class PluginFormcreatorFormAnswer extends CommonDBTM
          }
          $ticketStatus = PluginFormcreatorCommon::getTicketStatusForIssue($generatedTarget);
          if ($ticketStatus >= PluginFormcreatorFormAnswer::STATUS_WAITING) {
-            // Ignore tickets refused or pending for validation
-            // getTicketStatusForIssue() does not returns STATUS_ACCEPTED
-            continue;
+            // force pending approval status to be seen from to_validate dashboard
+            if ($ticketStatus == PluginFormcreatorFormAnswer::STATUS_WAITING) {
+               return PluginFormcreatorFormAnswer::STATUS_WAITING;
+            } else {
+               continue;
+            }
          }
 
          if ($ticketStatus == CommonITILObject::WAITING) {


### PR DESCRIPTION
### Changes description

If a target that was linked to an issue had a pending validation request, the issue would not have the status “validation pending” but the status “assigned”.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes !37694