### PR TITLE
fix(import): Export sections in logical order to fix condition import

### DIFF
--- a/inc/exportabletrait.class.php
+++ b/inc/exportabletrait.class.php
@@ -55,9 +55,17 @@ trait PluginFormcreatorExportableTrait
          }
          $export[$key] = [];
          foreach ($itemtypes as $itemtype) {
-            $allSubItems = $DB->request($itemtype::getSQLCriteriaToSearchForItem($this->getType(), $this->getID()));
-            $list = [];
+            $criteria = $itemtype::getSQLCriteriaToSearchForItem($this->getType(), $this->getID());
+
+            // Add ORDER BY clause if the itemtype has an 'order' field
+            // This ensures sections and other ordered items are exported in the correct order
             $subItem = new $itemtype();
+            if ($subItem->isField('order')) {
+               $criteria['ORDER'] = ['order ASC'];
+            }
+            
+            $allSubItems = $DB->request($criteria);
+            $list = [];
             foreach ($allSubItems as $row) {
                $subItem->getFromDB($row['id']);
                $list[] = $subItem->export($remove_uuid);

--- a/inc/exportabletrait.class.php
+++ b/inc/exportabletrait.class.php
@@ -63,7 +63,6 @@ trait PluginFormcreatorExportableTrait
             if ($subItem->isField('order')) {
                $criteria['ORDER'] = ['order ASC'];
             }
-            
             $allSubItems = $DB->request($criteria);
             $list = [];
             foreach ($allSubItems as $row) {


### PR DESCRIPTION
### Changes description

It fixes !39806

During import, if a question in section A contains a condition that references a question in section B, but section B appears after section A in the JSON array (due to the order of the IDs), the UUID linker cannot resolve the reference. The order of the sections in the array is based on the ID rather than the order of the sections in the form.

<img width="1095" height="238" alt="image" src="https://github.com/user-attachments/assets/d565f019-db72-488a-9a19-b1fe603e0a46" />
