### PR TITLE
fix(target_actor): use 'name' instead of 'completename' for user and supplier actor types

### DIFF
--- a/inc/target_actor.class.php
+++ b/inc/target_actor.class.php
@@ -294,7 +294,7 @@ class PluginFormcreatorTarget_Actor extends CommonDBChild implements PluginFormc
             break;
          case self::ACTOR_TYPE_PERSON:
             $user = new User;
-            $field = $idToRemove == 'uuid' ? 'id' : 'completename';
+            $field = $idToRemove == 'uuid' ? 'id' : 'name';
             if ($user->getFromDB($target_actor['actor_value'])) {
                $target_actor['actor_value'] = $user->fields[$field];
             }
@@ -308,7 +308,7 @@ class PluginFormcreatorTarget_Actor extends CommonDBChild implements PluginFormc
             break;
          case self::ACTOR_TYPE_SUPPLIER:
             $supplier = new Supplier;
-            $field = $idToRemove == 'uuid' ? 'id' : 'completename';
+            $field = $idToRemove == 'uuid' ? 'id' : 'name';
             if ($supplier->getFromDB($target_actor['actor_value'])) {
                $target_actor['actor_value'] = $supplier->fields[$field];
             }


### PR DESCRIPTION
### Changes description

When exporting a form, if a target is predefined with an actor of type “Specific Person,” the actor_value in the JSON is set to null.

This problem arises because the plugin attempts to retrieve the completename field for actors of type user or provider, even though this field does not exist in these cases.
The name of the user (or supplier) is actually stored in the name field.

Actor:
<img width="996" height="271" alt="image" src="https://github.com/user-attachments/assets/f900c36c-4472-417b-bffb-92891eb3e190" />

JSON before fix:
<img width="491" height="158" alt="image" src="https://github.com/user-attachments/assets/4b51e250-7a1e-4b14-b96e-345300040450" />

JSON after fix:
<img width="491" height="158" alt="image" src="https://github.com/user-attachments/assets/81837945-3ad6-4d0c-8b61-597920129cae" />


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

Closes !39806