### PR TITLE
Fix (Uninstall) - Class Install not found while uninstall

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -67,6 +67,8 @@ function plugin_formcreator_install() {
  * @return boolean
  */
 function plugin_formcreator_uninstall() {
+   spl_autoload_register('plugin_formcreator_autoload');
+
    $migration = new Migration(PLUGIN_FORMCREATOR_SCHEMA_VERSION);
 
    // Display EOL uninstall message


### PR DESCRIPTION
An error occurred during uninstallation : 
```php
glpi.CRITICAL:   *** Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\ClassNotFoundError: "Attempted to load class "Install" from namespace "Glpi\Plugin\Formcreator".
Did you forget a "use" statement for another namespace?" at hook.php line 78
  Backtrace :
  ./plugins/formcreator/hook.php:78                  
  ./src/Plugin.php:1095                              plugin_formcreator_uninstall()
  :                                                  Plugin->uninstall()
  ./src/Glpi/Marketplace/Controller.php:670          call_user_func()
  ./src/Glpi/Marketplace/Controller.php:577          Glpi\Marketplace\Controller->setPluginState()
  ./ajax/marketplace.php:66                          Glpi\Marketplace\Controller->uninstallPlugin()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```