### PR TITLE
Fix(abstractitiltarget): Restore predefined field computation from category (with template)

### DIFF
--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -2326,11 +2326,6 @@ SCRIPT;
          unset($predefined_fields['_groups_id_assign']);
       }
 
-      if (isset($predefined_fields['_groups_id_assign'])) {
-         $this->addGroupActor(PluginFormcreatorTarget_Actor::ACTOR_ROLE_ASSIGNED, $predefined_fields['_groups_id_assign']);
-         unset($predefined_fields['_groups_id_assign']);
-      }
-
       if (isset($predefined_fields['itilcategories_id'])) {
          $data['itilcategories_id'] = $predefined_fields['itilcategories_id'];
          unset($predefined_fields['itilcategories_id']);

--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -2290,7 +2290,6 @@ SCRIPT;
 
       $data = $targetItemtype::getDefaultValues();
 
-
       $data = $this->setTargetCategory($data, $formanswer);
 
       $this->fields[$targetTemplateFk] = $this->getTargetTemplate($data);
@@ -2338,11 +2337,9 @@ SCRIPT;
 
       $data = array_merge($data, $predefined_fields);
 
-
       if (($data['requesttypes_id'] ?? 0) == 0) {
          unset($data['requesttypes_id']);
       }
-
 
       return $data;
    }

--- a/inc/abstractitiltarget.class.php
+++ b/inc/abstractitiltarget.class.php
@@ -2290,6 +2290,9 @@ SCRIPT;
 
       $data = $targetItemtype::getDefaultValues();
 
+
+      $data = $this->setTargetCategory($data, $formanswer);
+
       $this->fields[$targetTemplateFk] = $this->getTargetTemplate($data);
 
       // Get predefined Fields
@@ -2323,6 +2326,16 @@ SCRIPT;
          unset($predefined_fields['_groups_id_assign']);
       }
 
+      if (isset($predefined_fields['_groups_id_assign'])) {
+         $this->addGroupActor(PluginFormcreatorTarget_Actor::ACTOR_ROLE_ASSIGNED, $predefined_fields['_groups_id_assign']);
+         unset($predefined_fields['_groups_id_assign']);
+      }
+
+      if (isset($predefined_fields['itilcategories_id'])) {
+         $data['itilcategories_id'] = $predefined_fields['itilcategories_id'];
+         unset($predefined_fields['itilcategories_id']);
+      }
+
       // Manage special values
       if (!isset($predefined_fields['date']) || isset($predefined_fields['date']) && $predefined_fields['date'] == 'NOW') {
          $predefined_fields['date'] = $_SESSION['glpi_currenttime'];
@@ -2330,11 +2343,11 @@ SCRIPT;
 
       $data = array_merge($data, $predefined_fields);
 
-      $data = $this->setTargetCategory($data, $formanswer);
 
       if (($data['requesttypes_id'] ?? 0) == 0) {
          unset($data['requesttypes_id']);
       }
+
 
       return $data;
    }


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

Fix regression introduced by

https://github.com/pluginsGLPI/formcreator/pull/3380

When actor are predefined by template, set by category (set by question), is not working anymore since #3380


### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A