### PR TITLE
fix(target): PluginFormcreatorQuestion excluded from itemtypes when saving associated elements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   GLPI_SOURCE: "https://github.com/glpi-project/glpi"
-  GLPI_PACKAGE_URL_BASE: "https://github.com/glpi-project/glpi-project.github.io/raw/refs/heads/main/glpi"
+  GLPI_PACKAGE_URL_BASE: "https://nightly.glpi-project.org/glpi"
   CS: 7.4
   DB_HOST: 127.0.0.1
   MYSQL_ROOT_USER: root

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   GLPI_SOURCE: "https://github.com/glpi-project/glpi"
-  GLPI_PACKAGE_URL_BASE: "https://nightly.glpi-project.org/glpi"
+  GLPI_PACKAGE_URL_BASE: "https://github.com/glpi-project/glpi-project.github.io/raw/refs/heads/main/glpi"
   CS: 7.4
   DB_HOST: 127.0.0.1
   MYSQL_ROOT_USER: root

--- a/inc/targetticket.class.php
+++ b/inc/targetticket.class.php
@@ -1180,7 +1180,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
       $rows = $itemTargetTicket->find([
          self::getForeignKeyField() => $this->getID(),
          [
-            'NOT' => ['itemtype' => [PluginFormcreatorTargetTicket::class, Ticket::class]],
+            'NOT' => ['itemtype' => [PluginFormcreatorTargetTicket::class, PluginFormcreatorQuestion::class, Ticket::class]],
          ],
       ]);
       foreach ($rows as $row) {
@@ -1251,7 +1251,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
             $rows = $itemTargetTicket->find([
                self::getForeignKeyField() => $this->getID(),
                [
-                  'NOT' => ['itemtype' => [PluginFormcreatorTargetTicket::class, Ticket::class]],
+                  'NOT' => ['itemtype' => [PluginFormcreatorTargetTicket::class, PluginFormcreatorQuestion::class, Ticket::class]],
                ],
             ]);
             $data['items_id'] = [];
@@ -1551,6 +1551,7 @@ class PluginFormcreatorTargetTicket extends PluginFormcreatorAbstractItilTarget
             $itemTargetTicket->deleteByCriteria([
                'NOT' => ['itemtype' => [
                   PluginFormcreatorTargetTicket::class,
+                  PluginFormcreatorQuestion::class,
                   Ticket::class,
                ]],
                self::getForeignKeyField() => $this->getID(),


### PR DESCRIPTION
### Changes description

- It fixes: !44204
- In a target's properties, it was not possible to link the “**Link to another ticke**t” option to a question in the form. When the target's configuration was saved, the link to the PluginFormCreatorQuestion item type was removed.

This bug only occurred if assets were entered in the “Associated elements” field.

<img width="1580" height="851" alt="image" src="https://github.com/user-attachments/assets/0b042dcd-354a-4956-916c-d85b45680734" />

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A